### PR TITLE
Used evaluation values for move ordering

### DIFF
--- a/Halogen/src/Evaluate.cpp
+++ b/Halogen/src/Evaluate.cpp
@@ -1,7 +1,5 @@
 #include "Evaluate.h"
 
-const unsigned int PieceValues[N_PIECES] = { 100, 320, 330, 500, 900, 5000, 100, 320, 330, 500, 900, 5000 };
-
 const int knightAdj[9] = { -20, -16, -12, -8, -4,  0,  4,  8, 12 };	//adjustment of piece value based on the number of own pawns
 const int rookAdj[9] = { 15,  12,   9,  6,  3,  0, -3, -6, -9 };
 

--- a/Halogen/src/Evaluate.h
+++ b/Halogen/src/Evaluate.h
@@ -4,6 +4,8 @@
 #include "PawnHashTable.h"
 #include "PieceSquareTables.h"
 
+const unsigned int PieceValues[N_PIECES] = { 100, 320, 330, 500, 900, 5000, 100, 320, 330, 500, 900, 5000 };
+
 extern PawnHashTable pawnHashTable;
 
 int EvaluatePosition(const Position& position);

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -34,19 +34,6 @@ void UpdatePV(Move move, int distanceFromRoot);
 SearchResult NegaScout(Position& position, int depth, int alpha, int beta, int colour, int distanceFromRoot, bool allowedNull, bool printMoves = false);
 SearchResult Quiescence(Position& position, int alpha, int beta, int colour, int distanceFromRoot, int depth);
 
-/*
-TODO list:
-1. Adjust the criteria for how killer moves are stored
-2. Consider putting underpromotions ahead of killer moves?
-
-
-*/
-
-std::vector<int> RelativePieceValues = { 100, 300, 300, 500, 900, 10000, 100, 300, 300, 500, 900, 10000 };	//technically, there is no way we can be capturing a king as the game would already be over.
-
-int hits = 0;
-int misses = 0;
-
 void OrderMoves(std::vector<Move>& moves, Position& position, int searchDepth, int distanceFromRoot, int alpha, int beta, int colour)
 {
 	/*
@@ -89,15 +76,15 @@ void OrderMoves(std::vector<Move>& moves, Position& position, int searchDepth, i
 
 		if (moves[i].IsCapture())
 		{
-			int PieceValue = RelativePieceValues.at(position.GetSquare(moves[i].GetFrom()));
+			int PieceValue = PieceValues[(position.GetSquare(moves[i].GetFrom()))];
 			int CaptureValue = 0;
 
 			if (moves[i].GetFlag() == EN_PASSANT)
-				CaptureValue = RelativePieceValues[WHITE_PAWN];	
+				CaptureValue = PieceValues[WHITE_PAWN];
 
 			if (moves[i].IsCapture() && moves[i].GetFlag() != EN_PASSANT)
 			{
-				CaptureValue = RelativePieceValues.at(position.GetSquare(moves[i].GetTo()));	//if enpassant then the .GetTo() square is empty
+				CaptureValue = PieceValues[position.GetSquare(moves[i].GetTo())];	//if enpassant then the .GetTo() square is empty
 			}
 
 			moves[i].SEE += CaptureValue;
@@ -115,7 +102,7 @@ void OrderMoves(std::vector<Move>& moves, Position& position, int searchDepth, i
 			if (moves[i].GetFlag() == BISHOP_PROMOTION || moves[i].GetFlag() == BISHOP_PROMOTION_CAPTURE)
 				moves[i].SEE = 1;
 			if (moves[i].GetFlag() == QUEEN_PROMOTION || moves[i].GetFlag() == QUEEN_PROMOTION_CAPTURE)
-				moves[i].SEE += RelativePieceValues[WHITE_QUEEN];
+				moves[i].SEE += PieceValues[WHITE_QUEEN];
 		}
 	}
 


### PR DESCRIPTION
Bench 26774098

```
move_order_piece_values vs master DIFF
ELO   | 3.59 +- 7.26 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 0.44 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6096 W: 2147 L: 2084 D: 1865
```