### PR TITLE
Thread safety

### DIFF
--- a/Halogen/src/Makefile
+++ b/Halogen/src/Makefile
@@ -3,7 +3,7 @@ CC = g++
 EXE = Halogen
 SRC = *.cpp
 
-RFLAGS = -O3 -std=c++11 -DNDEBUG -flto -march=native
+RFLAGS = -O3 -std=c++14 -DNDEBUG -flto -march=native
 
 release: 
 	$(CC) $(RFLAGS) $(SRC) -o $(EXE)

--- a/Halogen/src/TranspositionTable.cpp
+++ b/Halogen/src/TranspositionTable.cpp
@@ -88,15 +88,16 @@ void TranspositionTable::ResetTable()
 
 void TranspositionTable::SetSize(uint64_t MB)
 {
+	/*
+	We can't adjust the number of entries based on the size of a mutex because this size is different under msvc (80 bytes) and g++ (8 bytes)
+	*/
+
 	table.clear();
 	locks.clear();
 	size_t EntrySize = sizeof(TTEntry);
-	size_t MutexSize = sizeof(std::mutex);	//80 bytes
 
 	size_t entries = (MB * 1024 * 1024 / EntrySize);
 	size_t mutexCount = (entries / mutex_frequency);
-
-	entries -= mutexCount * MutexSize / EntrySize;
 	
 	for (size_t i = 0; i < entries; i++)
 	{

--- a/Halogen/src/TranspositionTable.h
+++ b/Halogen/src/TranspositionTable.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <mutex>
 #include <deque>
+#include <memory>
 #include "TTEntry.h"
 
 const unsigned int mutex_frequency = 1024;					//how many entries per mutex

--- a/Halogen/src/TranspositionTable.h
+++ b/Halogen/src/TranspositionTable.h
@@ -1,6 +1,10 @@
 #pragma once
 #include <vector>
+#include <mutex>
+#include <deque>
 #include "TTEntry.h"
+
+const unsigned int mutex_frequency = 1024;					//how many entries per mutex
 
 class TranspositionTable
 {
@@ -17,8 +21,8 @@ public:
 	void ResetTable();
 	void SetSize(uint64_t MB);	//will wipe the table and reconstruct a new empty table with a set size. units in MB!
 
-	bool CheckEntry(uint64_t key, int depth) const;
-	bool CheckEntry(uint64_t key) const;
+	bool CheckEntry(uint64_t key, int depth);
+	bool CheckEntry(uint64_t key);
 	void AddEntry(const Move& best, uint64_t ZobristKey, int Score, int Depth, int distanceFromRoot, EntryType Cutoff);
 	TTEntry GetEntry(uint64_t key);	//you MUST do mate score adjustment if you are using this score in the alpha beta search! for move ordering there is no need
 
@@ -30,6 +34,7 @@ public:
 
 private:
 	std::vector<TTEntry> table;
+	std::vector<std::unique_ptr<std::mutex>> locks;
 	uint64_t TTHits;
 };
 


### PR DESCRIPTION
Small regression permitted for confidence in thread safety. 

```
thread_safety vs master DIFF
ELO   | -13.36 +- 11.55 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | -2.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2394 W: 778 L: 870 D: 746
```