### PR TITLE
Only update history if the move is quiet

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -840,6 +840,7 @@ void AddKiller(Move move, int distanceFromRoot, std::vector<Killer>& KillerMoves
 
 void AddHistory(Move& move, int depthRemaining, unsigned int(&HistoryMatrix)[N_SQUARES][N_SQUARES])
 {
+	if (move.IsCapture() || move.IsPromotion()) return;
 	HistoryMatrix[move.GetFrom()][move.GetTo()] += depthRemaining * depthRemaining;
 }
 


### PR DESCRIPTION
```
quiet_history vs master DIFF
ELO   | 13.11 +- 7.96 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4984 W: 1792 L: 1604 D: 1588
```