### PR TITLE
Added prefetch intrinsic for gcc complies

### DIFF
--- a/Halogen/src/TranspositionTable.cpp
+++ b/Halogen/src/TranspositionTable.cpp
@@ -117,6 +117,10 @@ void TranspositionTable::PreFetch(uint64_t key) const
 #ifdef _MSC_VER
 	_mm_prefetch((char*)(&table[HashFunction(key)]), _MM_HINT_T0);
 #endif
+
+#ifndef _MSC_VER
+	__builtin_prefetch(&table[HashFunction(key)]);
+#endif 
 }
 
 void TranspositionTable::RunAsserts() const


### PR DESCRIPTION
Bench: 12140859

```
prefetch_gcc vs master DIFF
ELO   | 10.03 +- 8.01 (95%)
SPRT  | 5.0+0.05s Threads=6 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 4711 W: 1603 L: 1467 D: 1641
```