### PR TITLE
Allow LMR for extended plys

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -541,7 +541,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 		int extendedDepth = depthRemaining + extension(position, moves[i], alpha, beta);
 
 		//late move reductions
-		if (extendedDepth == depthRemaining && LMR(moves, i, InCheck, position, depthRemaining) && i > 3)
+		if (LMR(moves, i, InCheck, position, depthRemaining) && i > 3)
 		{
 			int reduction = Reduction(depthRemaining, i, alpha, beta);
 			int score = -NegaScout(position, initialDepth, extendedDepth - 1 - reduction, -a - 1, -a, -colour, distanceFromRoot + 1, true, locals, sharedData).GetScore();


### PR DESCRIPTION
```
Bench: 4354534
extension_LMR vs master DIFF
ELO   | 13.50 +- 10.05 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 10.00]
Games | N: 2704 W: 848 L: 743 D: 1113
```