### PR TITLE
Allow LMR when score equals alpha

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -260,8 +260,6 @@ void PrintBestMove(Move Best)
 
 void PrintSearchInfo(unsigned int depth, double Time, bool isCheckmate, int score, int alpha, int beta, unsigned int threadCount, Position& position, Move move, SearchData& locals)
 {
-	//const std::lock_guard<std::mutex> lock(ioMutex);
-
 	uint64_t actualNodeCount = position.GetNodeCount() * threadCount;
 	std::vector<Move> pv = locals.PvTable[0];
 
@@ -546,7 +544,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 			int reduction = Reduction(depthRemaining, i, alpha, beta);
 			int score = -NegaScout(position, initialDepth, extendedDepth - 1 - reduction, -a - 1, -a, -colour, distanceFromRoot + 1, true, locals, sharedData).GetScore();
 
-			if (score < a)
+			if (score <= a)
 			{
 				position.RevertMove();
 				continue;


### PR DESCRIPTION

```
Bench: 3635209
LMR_equal_alpha vs master DIFF
ELO   | 11.46 +- 8.90 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 10.00]
Games | N: 3456 W: 1077 L: 963 D: 1416

```