### PR TITLE
Small non-functional speedup

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -520,6 +520,8 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	bool InCheck = IsInCheck(position);
 	int staticScore = colour * EvaluatePosition(position);
 
+	bool FutileNode = (depthRemaining < FutilityMargins.size() && staticScore + FutilityMargins.at(std::max<int>(0, depthRemaining)) < a);
+
 	for (int i = 0; i < moves.size(); i++)	
 	{
 		if (moves[i] == hashMove)
@@ -529,13 +531,10 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 		tTable.PreFetch(position.GetZobristKey());							//load the transposition into l1 cache. ~5% speedup
 
 		//futility pruning
-		if (IsFutile(moves[i], beta, alpha, InCheck, position) && i > 0)	//Possibly stop futility pruning if alpha or beta are close to mate scores
+		if (IsFutile(moves[i], beta, alpha, InCheck, position) && i > 0 && FutileNode)	//Possibly stop futility pruning if alpha or beta are close to mate scores
 		{
-			if (depthRemaining < FutilityMargins.size() && staticScore + FutilityMargins.at(std::max<int>(0, depthRemaining)) < a)
-			{
-				position.RevertMove();
-				continue;
-			}
+			position.RevertMove();
+			continue;
 		}
 
 		int extendedDepth = depthRemaining + extension(position, moves[i], alpha, beta);


### PR DESCRIPTION
```
Bench: 3635209
futility_prune_enhance vs master DIFF
ELO   | 1.31 +- 7.32 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.04 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 4768 W: 1324 L: 1306 D: 2138
```