### PR TITLE
Disallow LMR in KPvKP endgames

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -676,6 +676,7 @@ bool LMR(Move move, bool InCheck, Position& position, int depthRemaining)
 	return !move.IsCapture()
 		&& !move.IsPromotion()
 		&& !InCheck 
+		&& !IsEndGame(position)
 		&& !IsInCheck(position)
 		&& depthRemaining > 3;
 }


### PR DESCRIPTION
```
Bench: 3502525

lmr_endgame vs master DIFF
ELO   | 0.87 +- 5.66 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | -2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 7944 W: 2197 L: 2177 D: 3570
```