### PR TITLE
Implement IID reduction by Rebel

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -115,10 +115,6 @@ void OrderMoves(std::vector<Move>& moves, Position& position, unsigned int initi
 	*/
 
 	Move TTmove = GetHashMove(position, distanceFromRoot);
-
-	//basically, if we have no hash move, do a shallow search and make that the hash move
-	InternalIterativeDeepening(TTmove, initialDepth, depthRemaining, position, alpha, beta, colour, distanceFromRoot, locals, sharedData);
-
 	std::vector<int> orderScores(moves.size(), 0);
 
 	for (size_t i = 0; i < moves.size(); i++)
@@ -519,6 +515,9 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	OrderMoves(moves, position, initialDepth, depthRemaining, distanceFromRoot, alpha, beta, colour, locals, sharedData);
 	bool InCheck = IsInCheck(position);
 	int staticScore = colour * EvaluatePosition(position);
+
+	if (hashMove.IsUninitialized() && depthRemaining > 3)
+		depthRemaining--;
 
 	bool FutileNode = (depthRemaining < static_cast<int>(FutilityMargins.size()) && staticScore + FutilityMargins.at(std::max<int>(0, depthRemaining)) < a);
 


### PR DESCRIPTION
```
rebel_IID vs master DIFF
ELO   | 1.67 +- 5.05 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | -2.99 (-2.94, 2.94) [0.00, 10.00]
Games | N: 10424 W: 3022 L: 2972 D: 4430
```