### PR TITLE
Bench: 7072296

### DIFF
--- a/Halogen/src/Network.h
+++ b/Halogen/src/Network.h
@@ -23,7 +23,7 @@ struct trainingPoint
 struct deltaPoint
 {
     size_t index;
-    float delta;
+    int delta;
 };
 
 struct Neuron

--- a/Halogen/src/Position.cpp
+++ b/Halogen/src/Position.cpp
@@ -479,7 +479,7 @@ std::vector<deltaPoint> Position::CalculateMoveDelta(Move move)
 	ret.reserve(4);	//1 for turn change, 2 for to and from square and then 1 extra if there is a capture. Promotions or castle moves use more but thats ok
 
 	//Change of turn
-	ret.push_back({ modifier(12 * 64), static_cast<float>(GetTurn() * 2 - 1) });	//+1 if its now whites turn and -1 if its now blacks turn
+	ret.push_back({ modifier(12 * 64), (GetTurn() * 2 - 1) });	//+1 if its now whites turn and -1 if its now blacks turn
 
 	if (move.IsUninitialized()) return ret;		//null move
 


### PR DESCRIPTION
```
ELO   | -1.67 +- 7.91 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | -2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 4356 W: 1273 L: 1294 D: 1789
```
Even though it suggests that it may be a tiny regression, testing shows that the bench is in fact faster and I doubt it has drastic side effects. Int makes more intuitive sense and I think in this case is more correct. Possibly revisit in future.