### PR TITLE
Bench: 7209513

### DIFF
--- a/Halogen/src/Position.cpp
+++ b/Halogen/src/Position.cpp
@@ -1,6 +1,6 @@
 #include "Position.h"
 
-Position::Position() : net(InitNetwork("C:\\HalogenWeights\\JAe1bBpt3r.network"))
+Position::Position() : net(InitNetwork("C:\\HalogenWeights\\nxtc9owQ2i.network"))
 {
 	key = EMPTY;
 	NodeCount = 0;


### PR DESCRIPTION
```
net_nxtc9owQ2i vs master DIFF
ELO   | 11.88 +- 9.22 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 3540 W: 1209 L: 1088 D: 1243
```