### PR TITLE
Use log transformation for SMP aspiration widths 

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -351,8 +351,8 @@ Move SearchPosition(Position position, int allowedTimeMs, uint64_t& totalNodes, 
 		sharedData.ReportResult(depth, searchTime.ElapsedMs(), score, alpha, beta, position, move, locals);
 
 		depth++;
-		alpha = score - 25 - ((threadID % 2 == 0) ? 1 : -1) * threadID * 2;
-		beta = score + 25 + ((threadID % 2 == 0) ? 1 : -1) * threadID * 2;
+		alpha = score - 25 - 4 * ((threadID % 2 == 0) ? 1 : -1) * int(log2(threadID + 1));
+		beta  = score + 25 + 4 * ((threadID % 2 == 0) ? 1 : -1) * int(log2(threadID + 1));
 		prevScore = score;
 	}
 


### PR DESCRIPTION
```
ELO   | 5.26 +- 7.33 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 0.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6738 W: 2684 L: 2582 D: 1472
```