### PR TITLE
Faster sort

### DIFF
--- a/Halogen/src/Move.cpp
+++ b/Halogen/src/Move.cpp
@@ -9,6 +9,7 @@ const unsigned int FLAG_MASK = 0b1111 << 12;	// 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0
 Move::Move()
 {
 	data = 0;
+	orderScore = 0;
 }
 
 Move::Move(unsigned int from, unsigned int to, unsigned int flag)

--- a/Halogen/src/Move.h
+++ b/Halogen/src/Move.h
@@ -42,6 +42,8 @@ public:
 
 	void Reset();
 
+	int orderScore;	//used by the move picker to order the moves
+
 private:
 
 	void SetFrom(unsigned int from);

--- a/Halogen/src/MoveOrder.cpp
+++ b/Halogen/src/MoveOrder.cpp
@@ -103,16 +103,16 @@ void OrderMoves(std::vector<Move>& moves, Position& position, int distanceFromRo
 		{
 			if (moves[i].GetFlag() == QUEEN_PROMOTION || moves[i].GetFlag() == QUEEN_PROMOTION_CAPTURE)
 			{
-				moves[i].orderScore = 9000000;
+				moves[i].orderScore = static_cast<int>(MoveScore::PROMOTION);
 			}
 			else
 			{
-				moves[i].orderScore = -1;
+				moves[i].orderScore = static_cast<int>(MoveScore::UNDERPROMOTION);
 			}
 		}
 
 		//Captures
-		if (moves[i].IsCapture())
+		else if (moves[i].IsCapture())
 		{
 			int SEE = 0;
 
@@ -123,24 +123,24 @@ void OrderMoves(std::vector<Move>& moves, Position& position, int distanceFromRo
 
 			if (SEE >= 0)
 			{
-				moves[i].orderScore = 8000000 + SEE;
+				moves[i].orderScore = static_cast<int>(MoveScore::GOOD_CAPTURE) + SEE;
 			}
 
 			if (SEE < 0)
 			{
-				moves[i].orderScore = 6000000 + SEE;
+				moves[i].orderScore = static_cast<int>(MoveScore::BAD_CAPTURE) + SEE;
 			}
 		}
 
 		//Killers
 		else if (moves[i] == KillerMoves.at(distanceFromRoot).move[0])
 		{
-			moves[i].orderScore = 7500000;
+			moves[i].orderScore = static_cast<int>(MoveScore::KILLER_1);
 		}
 
 		else if (moves[i] == KillerMoves.at(distanceFromRoot).move[1])
 		{
-			moves[i].orderScore = 6500000;
+			moves[i].orderScore = static_cast<int>(MoveScore::KILLER_2);
 		}
 
 		else 
@@ -148,9 +148,9 @@ void OrderMoves(std::vector<Move>& moves, Position& position, int distanceFromRo
 			//Quiet
 			moves[i].orderScore = HistoryMatrix[position.GetTurn()][moves[i].GetFrom()][moves[i].GetTo()];
 
-			if (moves[i].orderScore > 1000000)
+			if (moves[i].orderScore > static_cast<int>(MoveScore::QUIET_MAXIMUM))
 			{
-				moves[i].orderScore = 1000000;
+				moves[i].orderScore = static_cast<int>(MoveScore::QUIET_MAXIMUM);
 			}
 		}
 	}

--- a/Halogen/src/MoveOrder.cpp
+++ b/Halogen/src/MoveOrder.cpp
@@ -89,32 +89,26 @@ void OrderMoves(std::vector<Move>& moves, Position& position, int distanceFromRo
 	Previously this function would order all the moves at once. Now it only orderes the section we are generating (for example just the loud moves).
 	*/
 
-	std::vector<int> orderScores(moves.size(), 0);
-
 	for (size_t i = 0; i < moves.size(); i++)
 	{
 		//Hash move
 		if (moves[i] == TTmove)
 		{
-			orderScores.erase(orderScores.begin() + i);
 			moves.erase(moves.begin() + i);
 			i--;
-			continue;
 		}
 
 		//Promotions
-		if (moves[i].IsPromotion())
+		else if (moves[i].IsPromotion())
 		{
 			if (moves[i].GetFlag() == QUEEN_PROMOTION || moves[i].GetFlag() == QUEEN_PROMOTION_CAPTURE)
 			{
-				orderScores[i] = 9000000;
+				moves[i].orderScore = 9000000;
 			}
 			else
 			{
-				orderScores[i] = -1;
+				moves[i].orderScore = -1;
 			}
-
-			continue;
 		}
 
 		//Captures
@@ -129,40 +123,42 @@ void OrderMoves(std::vector<Move>& moves, Position& position, int distanceFromRo
 
 			if (SEE >= 0)
 			{
-				orderScores[i] = 8000000 + SEE;
+				moves[i].orderScore = 8000000 + SEE;
 			}
 
 			if (SEE < 0)
 			{
-				orderScores[i] = 6000000 + SEE;
+				moves[i].orderScore = 6000000 + SEE;
 			}
-
-			continue;
 		}
 
 		//Killers
-		if (moves[i] == KillerMoves.at(distanceFromRoot).move[0])
+		else if (moves[i] == KillerMoves.at(distanceFromRoot).move[0])
 		{
-			orderScores[i] = 7500000;
-			continue;
+			moves[i].orderScore = 7500000;
 		}
 
-		if (moves[i] == KillerMoves.at(distanceFromRoot).move[1])
+		else if (moves[i] == KillerMoves.at(distanceFromRoot).move[1])
 		{
-			orderScores[i] = 6500000;
-			continue;
+			moves[i].orderScore = 6500000;
 		}
 
-		//Quiet
-		orderScores[i] = HistoryMatrix[position.GetTurn()][moves[i].GetFrom()][moves[i].GetTo()];
-
-		if (orderScores[i] > 1000000)
+		else 
 		{
-			orderScores[i] = 1000000;
+			//Quiet
+			moves[i].orderScore = HistoryMatrix[position.GetTurn()][moves[i].GetFrom()][moves[i].GetTo()];
+
+			if (moves[i].orderScore > 1000000)
+			{
+				moves[i].orderScore = 1000000;
+			}
 		}
 	}
 
-	SortMovesByScore(moves, orderScores);
+	std::sort(moves.begin(), moves.end(), [](const Move& lhs, const Move& rhs)
+		{
+			return lhs.orderScore > rhs.orderScore;
+		});
 }
 
 void SortMovesByScore(std::vector<Move>& moves, std::vector<int>& orderScores)

--- a/Halogen/src/MoveOrder.h
+++ b/Halogen/src/MoveOrder.h
@@ -11,6 +11,18 @@ enum class Stage
 	QUIET_MOVES
 };
 
+enum class MoveScore
+{
+	TT_MOVE = 10000000,
+	PROMOTION = 9000000,
+	GOOD_CAPTURE = 8000000,
+	KILLER_1 = 7500000,
+	KILLER_2 = 6500000,
+	BAD_CAPTURE = 6000000,
+	QUIET_MAXIMUM = 1000000,
+	UNDERPROMOTION = -1
+};
+
 struct Killer
 {
 	Move move[2];

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -671,9 +671,17 @@ SearchResult Quiescence(Position& position, unsigned int initialDepth, int alpha
 	while (gen.GetNext(move, position, distanceFromRoot, locals.KillerMoves, locals.HistoryMatrix))
 	{
 		int SEE = 0;
+		
 		if (move.GetFlag() == CAPTURE) //seeCapture doesn't work for ep or promotions
 		{
-			SEE = seeCapture(position, move);
+			if (move.orderScore >= static_cast<int>(MoveScore::GOOD_CAPTURE))
+			{
+				SEE = move.orderScore - static_cast<int>(MoveScore::GOOD_CAPTURE);
+			}
+			else 
+			{
+				SEE = move.orderScore - static_cast<int>(MoveScore::BAD_CAPTURE);
+			}
 		}
 
 		if (move.IsPromotion())


### PR DESCRIPTION
```
ELO   | 7.68 +- 5.56 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9456 W: 3090 L: 2881 D: 3485
```