### PR TITLE
Keep threads searching if at least one other thread is still searching

### DIFF
--- a/Halogen/src/Search.h
+++ b/Halogen/src/Search.h
@@ -61,6 +61,7 @@ public:
 	bool ThreadAbort(unsigned int initialDepth) const;
 	void ReportResult(unsigned int depth, double Time, int score, int alpha, int beta, const Position& position, Move move, const SearchData& locals);
 	void ReportDepth(unsigned int depth, unsigned int threadID);
+	void ReportWantsToStop(unsigned int threadID);
 	bool ShouldSkipDepth(unsigned int depth);
 	int GetAspirationScore();
 	void AddTBHit() { tbHits++; }
@@ -85,7 +86,8 @@ private:
 	std::atomic<uint64_t> tbHits;
 	std::atomic<uint64_t> nodes;
 
-	std::vector<unsigned int> searchDepth;					//what depth is each thread currently searching?
+	std::vector<unsigned int> searchDepth;			//what depth is each thread currently searching?
+	std::vector<bool> ThreadWantsToStop;			//Threads signal here that they want to stop searching, but will keep going until all threads want to stop
 };
 
 extern TranspositionTable tTable;


### PR DESCRIPTION
```
ELO   | 8.18 +- 5.97 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9646 W: 3689 L: 3462 D: 2495
```
Also tested for non regression in single threaded games
```
ELO   | 6.60 +- 6.98 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 6000 W: 1952 L: 1838 D: 2210
```