### PR TITLE
Blitz time allocation

### DIFF
--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -126,9 +126,9 @@ int main(int argc, char* argv[])
 				{
 
 					if (position.GetTurn() == WHITE)
-						movetime = wtime / 20 + winc;
+						movetime = wtime / 18 + winc;
 					else
-						movetime = btime / 20 + binc;
+						movetime = btime / 18 + binc;
 				}
 				else
 				{

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -126,9 +126,9 @@ int main(int argc, char* argv[])
 				{
 
 					if (position.GetTurn() == WHITE)
-						movetime = wtime / 18 + winc;
+						movetime = wtime / 16 + winc;
 					else
-						movetime = btime / 18 + binc;
+						movetime = btime / 16 + binc;
 				}
 				else
 				{


### PR DESCRIPTION
```
ELO   | 5.18 +- 4.10 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 17168 W: 5475 L: 5219 D: 6474
```