### PR TITLE
Add tempo parameter to the evaluation function

### DIFF
--- a/Halogen/src/EvalNet.cpp
+++ b/Halogen/src/EvalNet.cpp
@@ -3,13 +3,15 @@
 int pieceValueVector[N_STAGES][N_PIECE_TYPES] = { {91, 532, 568, 715, 1279, 5000},
                                                   {111, 339, 372, 638, 1301, 5000} };
 
+constexpr int TEMPO = 10;
+
 int EvaluatePositionNet(Position& position, EvalCacheTable& evalTable)
 {
     int eval;
 
     if (!evalTable.GetEntry(position.GetZobristKey(), eval))
     {
-        eval = position.GetEvaluation();
+        eval = position.GetEvaluation() + (position.GetTurn() == WHITE ? TEMPO : -TEMPO);
         evalTable.AddEntry(position.GetZobristKey(), eval);
     }
 


### PR DESCRIPTION
Bench: 6612922
```
ELO   | 23.74 +- 11.06 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2448 W: 870 L: 703 D: 875
```