### PR TITLE
Scale NN output by 1.3x

### DIFF
--- a/Halogen/src/EvalNet.cpp
+++ b/Halogen/src/EvalNet.cpp
@@ -11,7 +11,7 @@ int EvaluatePositionNet(Position& position, EvalCacheTable& evalTable)
 
     if (!evalTable.GetEntry(position.GetZobristKey(), eval))
     {
-        eval = position.GetEvaluation() + (position.GetTurn() == WHITE ? TEMPO : -TEMPO);
+        eval = position.GetEvaluation() * 13 / 10 + (position.GetTurn() == WHITE ? TEMPO : -TEMPO);
         evalTable.AddEntry(position.GetZobristKey(), eval);
     }
 


### PR DESCRIPTION
Bench: 6189619
```
ELO   | 27.81 +- 11.95 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2016 W: 703 L: 542 D: 771
```
