### PR TITLE
Simplify SMP depth skiping

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -290,8 +290,6 @@ void SearchPosition(Position position, ThreadSharedData& sharedData, unsigned in
 		if (!locals.ContinueSearch())
 			sharedData.ReportWantsToStop(threadID);
 
-		if (sharedData.ShouldSkipDepth(depth)) continue;
-
 		sharedData.ReportDepth(depth, threadID);
 
 		SearchResult search = AspirationWindowSearch(position, depth, prevScore, locals, sharedData, threadID);
@@ -1048,20 +1046,6 @@ void ThreadSharedData::ReportWantsToStop(unsigned int threadID)
 	}
 
 	KeepSearching = false;
-}
-
-bool ThreadSharedData::ShouldSkipDepth(unsigned int depth)
-{
-	std::lock_guard<std::mutex> lg(ioMutex);
-	int count = 0;
-
-	for (size_t i = 0; i < searchDepth.size(); i++)
-	{
-		if (searchDepth[i] >= depth)
-			count++;
-	}
-
-	return (count > static_cast<int>(searchDepth.size()) / 2);
 }
 
 int ThreadSharedData::GetAspirationScore()

--- a/Halogen/src/Search.h
+++ b/Halogen/src/Search.h
@@ -64,7 +64,6 @@ public:
 	void ReportResult(unsigned int depth, double Time, int score, int alpha, int beta, const Position& position, Move move, const SearchData& locals);
 	void ReportDepth(unsigned int depth, unsigned int threadID);
 	void ReportWantsToStop(unsigned int threadID);
-	bool ShouldSkipDepth(unsigned int depth);
 	int GetAspirationScore();
 	
 	uint64_t getTBHits() const { return tbHits; }


### PR DESCRIPTION
Bench: 6258688

```
ELO   | 2.99 +- 5.30 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 10122 W: 3156 L: 3069 D: 3897
```
```
ELO   | -4.35 +- 3.46 (95%)
SPRT  | 20.0+0.2s Threads=8 Hash=256MB
LLR   | -2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 18610 W: 4363 L: 4596 D: 9651
```
Small regression acceptable.