### PR TITLE
Fix the maximum allocated time to avoid time losses

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -33,7 +33,7 @@ unsigned int ProbeTBSearch(const Position& position);
 SearchResult UseSearchTBScore(unsigned int result, int staticEval);
 SearchResult UseRootTBScore(unsigned int result, int staticEval);
 
-void SearchPosition(Position position, ThreadSharedData& sharedData, unsigned int threadID, int maxTime, int allocatedTimeMs, int threads, int maxSearchDepth = MAX_DEPTH, SearchData locals = SearchData());
+void SearchPosition(Position position, ThreadSharedData& sharedData, unsigned int threadID, int maxTime, int allocatedTimeMs, int maxSearchDepth = MAX_DEPTH, SearchData locals = SearchData());
 SearchResult AspirationWindowSearch(Position& position, int depth, int prevScore, SearchData& locals, ThreadSharedData& sharedData, unsigned int threadID);
 SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthRemaining, int alpha, int beta, int colour, unsigned int distanceFromRoot, bool allowedNull, SearchData& locals, ThreadSharedData& sharedData);
 void UpdateAlpha(int Score, int& a, std::vector<Move>& moves, const size_t& i, unsigned int distanceFromRoot, SearchData& locals);
@@ -54,7 +54,7 @@ Move MultithreadedSearch(const Position& position, unsigned int maxTimeMs, unsig
 
 	for (unsigned int i = 0; i < threadCount; i++)
 	{
-		threads.emplace_back(std::thread([=, &sharedData] {SearchPosition(position, sharedData, i, maxTimeMs, AllocatedTimeMs, threadCount, maxSearchDepth ); }));
+		threads.emplace_back(std::thread([=, &sharedData] {SearchPosition(position, sharedData, i, maxTimeMs, AllocatedTimeMs, maxSearchDepth ); }));
 	}
 
 	for (size_t i = 0; i < threads.size(); i++)
@@ -72,7 +72,7 @@ uint64_t BenchSearch(const Position& position, int maxSearchDepth)
 	tTable.ResetTable();
 	ThreadSharedData sharedData(1, true);
 	
-	SearchPosition(position, sharedData, 0, 2147483647, 2147483647, 1, maxSearchDepth);
+	SearchPosition(position, sharedData, 0, 2147483647, 2147483647, maxSearchDepth);
 
 	return sharedData.getNodes();
 }
@@ -82,7 +82,7 @@ void DepthSearch(const Position& position, int maxSearchDepth)
 	InitSearch();
 	tTable.ResetTable();
 	ThreadSharedData sharedData(1);
-	SearchPosition(position, sharedData, 0, 2147483647, 2147483647, 1, maxSearchDepth);
+	SearchPosition(position, sharedData, 0, 2147483647, 2147483647, maxSearchDepth);
 	PrintBestMove(sharedData.GetBestMove());
 }
 
@@ -274,12 +274,12 @@ void PrintSearchInfo(unsigned int depth, double Time, bool isCheckmate, int scor
 	std::cout << std::endl;
 }
 
-void SearchPosition(Position position, ThreadSharedData& sharedData, unsigned int threadID, int maxTime, int allocatedTimeMs, int threads, int maxSearchDepth, SearchData locals)
+void SearchPosition(Position position, ThreadSharedData& sharedData, unsigned int threadID, int maxTime, int allocatedTimeMs, int maxSearchDepth, SearchData locals)
 {
 	Timer searchTime;
 	searchTime.Start();
 
-	locals.timeManage.StartSearch(maxTime, allocatedTimeMs, threads);
+	locals.timeManage.StartSearch(maxTime, allocatedTimeMs);
 
 	int alpha = -30000;
 	int beta = 30000;

--- a/Halogen/src/TimeManage.cpp
+++ b/Halogen/src/TimeManage.cpp
@@ -54,11 +54,10 @@ bool SearchTimeManage::AbortSearch(uint64_t nodes)
 	return (!KeepSearching || CacheShouldStop);
 }
 
-void SearchTimeManage::StartSearch(int maxTime, int allocatedTime, int threads)
+void SearchTimeManage::StartSearch(int maxTime, int allocatedTime)
 {
 	timer.Restart();
 	timer.Start();
 	AllocatedSearchTimeMS = allocatedTime;
 	MaxTimeMS = maxTime;
-	BufferTime *= threads;
 }

--- a/Halogen/src/TimeManage.h
+++ b/Halogen/src/TimeManage.h
@@ -52,7 +52,7 @@ public:
 	bool ContinueSearch();	//Should I search to another depth, or stop with what ive got?
 	bool AbortSearch(uint64_t nodes);		//should I attempt to stop searching right now? Nodes is passed because we only want to check the exact time every 1000 nodes or so
 
-	void StartSearch(int maxTime, int allocatedTime, int threads = 1);	//pass the allowed search time maximum in milliseconds
+	void StartSearch(int maxTime, int allocatedTime);	//pass the allowed search time maximum in milliseconds
 
 private:
 	Timer timer;

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
 				}
 			}
 
-			thread searchThread([=] {MultithreadedSearch(position, std::max(position.GetTurn() ? wtime + winc : btime + binc, movetime), movetime, ThreadCount); });
+			thread searchThread([=] {MultithreadedSearch(position, std::max(position.GetTurn() ? wtime : btime, movetime), movetime, ThreadCount); });
 			searchThread.detach();
 			
 		}


### PR DESCRIPTION
Bench: 6144000
```
ELO   | 20.94 +- 11.04 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 2176 W: 686 L: 555 D: 935
```
```
ELO   | 2.93 +- 5.27 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 10208 W: 3166 L: 3080 D: 3962
```