### PR TITLE
Revert "Use more aggressive LMR"

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -663,9 +663,9 @@ int Reduction(int depth, int i, int alpha, int beta)
 {
 	/*Formula adapted from Fruit Reloaded, sourced from chess programming wiki*/
 	if (IsPV(beta, alpha))
-		return int((sqrt(static_cast<double>(depth - 1)) + sqrt(static_cast<double>(i - 1))) * 2 / 3);
+		return int((sqrt(static_cast<double>(depth - 1)) + sqrt(static_cast<double>(i - 1))) / 3);
 	else
-		return int((sqrt(static_cast<double>(depth - 1)) + sqrt(static_cast<double>(i - 1))));
+		return int((sqrt(static_cast<double>(depth - 1)) + sqrt(static_cast<double>(i - 1))) / 2);
 }
 
 void UpdatePV(Move move, int distanceFromRoot, std::vector<std::vector<Move>>& PvTable)


### PR DESCRIPTION
Reverts KierenP/Halogen#139

```
ELO   | -5.75 +- 14.76 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | -0.51 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1088 W: 269 L: 287 D: 532
```

Demonstrated to be a regression at LTC