### PR TITLE
Remove search extension from pawns reaching 7th rank

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -733,11 +733,11 @@ int extension(Position& position, const Move& move, int alpha, int beta)
 			extension += 1;
 	}
 
-	if (position.GetSquare(move.GetTo()) == WHITE_PAWN && GetRank(move.GetTo()) == RANK_7)	//note the move has already been applied
-		extension += 1;
+	//if (position.GetSquare(move.GetTo()) == WHITE_PAWN && GetRank(move.GetTo()) == RANK_7)	//note the move has already been applied
+	//	extension += 1;
 
-	if (position.GetSquare(move.GetTo()) == BLACK_PAWN && GetRank(move.GetTo()) == RANK_2)
-		extension += 1;
+	//if (position.GetSquare(move.GetTo()) == BLACK_PAWN && GetRank(move.GetTo()) == RANK_2)
+	//	extension += 1;
 
 	return extension;
 }


### PR DESCRIPTION
```
ELO   | 3.12 +- 5.25 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.06 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 10128 W: 3107 L: 3016 D: 4005
```
```
ELO   | 3.42 +- 4.93 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.08 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 9344 W: 2342 L: 2250 D: 4752
```