### PR TITLE
Remove check extensions for non PV branches

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -725,13 +725,6 @@ int extension(Position& position, const Move& move, int alpha, int beta)
 		if (IsSquareThreatened(position, position.GetKing(position.GetTurn()), position.GetTurn()))	
 			extension += 1;
 	}
-	else
-	{
-		int SEE = see(position, move.GetTo(), position.GetTurn());
-
-		if (IsSquareThreatened(position, position.GetKing(position.GetTurn()), position.GetTurn()) && SEE == 0)	//move already applied so positive SEE bad
-			extension += 1;
-	}
 
 	if (position.GetSquare(move.GetTo()) == WHITE_PAWN && GetRank(move.GetTo()) == RANK_7)	//note the move has already been applied
 		extension += 1;


### PR DESCRIPTION
```
ELO   | 0.63 +- 3.88 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 18624 W: 5653 L: 5619 D: 7352
```
```
ELO   | 5.31 +- 4.75 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.19 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10208 W: 2618 L: 2462 D: 5128
```