### PR TITLE
Do not save results to TT in quiescence search

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -919,9 +919,6 @@ SearchResult Quiescence(Position& position, unsigned int initialDepth, int alpha
 			break;
 	}
 
-	if (!locals.AbortSearch(position.GetNodes()) && !(sharedData.ThreadAbort(initialDepth)))
-		AddScoreToTable(Score, alpha, position, depthRemaining, distanceFromRoot, beta, bestmove);
-
 	return SearchResult(Score, bestmove);
 }
 


### PR DESCRIPTION
Bench: 4988928
```
ELO   | 1.01 +- 3.45 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | -1.45 (-2.94, 2.94) [0.00, 5.00]
Games | N: 23056 W: 6891 L: 6824 D: 9341
```
```
ELO   | -1.26 +- 3.56 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 0.61 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 17376 W: 4115 L: 4178 D: 9083
```