### PR TITLE
Allow null pruning at all depths

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -752,7 +752,6 @@ bool AllowedNull(bool allowedNull, const Position& position, int beta, int alpha
 		&& !IsSquareThreatened(position, position.GetKing(position.GetTurn()), position.GetTurn())
 		&& !IsPV(beta, alpha)
 		&& !IsEndGame(position)
-		&& depthRemaining > R + 1								//don't drop directly into quiessence search. particularly important in mate searches as quiessence search has no mate detection currently. See 5rk1/2p4p/2p4r/3P4/4p1b1/1Q2NqPp/PP3P1K/R4R2 b - - 0 1
 		&& GetBitCount(position.GetAllPieces()) >= 5;	//avoid null move pruning in very late game positions due to zanauag issues. Even with verification search e.g 8/6k1/8/8/8/8/1K6/Q7 w - - 0 1 
 }
 


### PR DESCRIPTION
```
ELO   | 116.64 +- 26.16 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 448 W: 209 L: 64 D: 175
```
```
ELO   | 95.09 +- 20.99 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.12 (-2.94, 2.94) [0.00, 5.00]
Games | N: 528 W: 200 L: 59 D: 269
```