### PR TITLE
Improved scaling

### DIFF
--- a/Halogen/src/Move.cpp
+++ b/Halogen/src/Move.cpp
@@ -25,6 +25,11 @@ Move::Move(unsigned int from, unsigned int to, unsigned int flag)
 	SetFlag(flag);
 }
 
+Move::Move(unsigned short bits)
+{
+	data = bits;
+}
+
 Move::~Move()
 {
 }

--- a/Halogen/src/Move.h
+++ b/Halogen/src/Move.h
@@ -25,6 +25,7 @@ class Move
 public:
 	Move();
 	Move(unsigned int from, unsigned int to, unsigned int flag);
+	Move(unsigned short bits);
 	~Move();
 
 	unsigned int GetFrom() const;
@@ -44,6 +45,8 @@ public:
 
 	int orderScore;
 
+	unsigned short GetBits() const { return data; }
+
 private:
 
 	void SetFrom(unsigned int from);
@@ -51,6 +54,11 @@ private:
 	void SetFlag(unsigned int flag);
 
 	//6 bits for 'from square', 6 bits for 'to square' and 4 bits for the 'move flag'
+	unsigned short data;
+};
+
+struct MoveBits
+{
 	unsigned short data;
 };
 

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -258,7 +258,6 @@ void PrintSearchInfo(unsigned int depth, double Time, bool isCheckmate, int scor
 #if defined(_MSC_VER) && !defined(NDEBUG)  
 	std::cout	//these lines are for debug and not part of official uci protocol
 		<< " string thread " << std::this_thread::get_id()
-		<< " hashHitRate " << tTable.GetHitCount() * 1000 / std::max(sharedData.getNodes(), uint64_t(1))
 		<< " evalHitRate " << locals.evalTable.hits * 1000 / std::max(locals.evalTable.hits + locals.evalTable.misses, uint64_t(1));
 #endif
 

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -89,7 +89,6 @@ void DepthSearch(const Position& position, int maxSearchDepth)
 void InitSearch()
 {
 	KeepSearching = true;
-	tTable.ResetHitCount();
 }
 
 void OrderMoves(std::vector<Move>& moves, Position& position, int distanceFromRoot, SearchData& locals)
@@ -679,7 +678,6 @@ void UpdatePV(Move move, int distanceFromRoot, std::vector<std::vector<Move>>& P
 
 bool UseTransposition(TTEntry& entry, int distanceFromRoot, int alpha, int beta)
 {
-	tTable.AddHit();
 	entry.MateScoreAdjustment(distanceFromRoot);	//this MUST be done
 
 	if (entry.GetCutoff() == EntryType::EXACT) return true;

--- a/Halogen/src/TTEntry.cpp
+++ b/Halogen/src/TTEntry.cpp
@@ -1,20 +1,22 @@
 #include "TTEntry.h"
 
-TTEntry::TTEntry() : bestMove(0, 0, 0)
+TTEntry::TTEntry()
 {
 	key = EMPTY;
+	bestMove.data = 0;
 	score = -1;
 	depth = -1;
 	cutoff = EntryType::EMPTY_ENTRY;
 	halfmove = -1;
 }
 
-TTEntry::TTEntry(Move best, uint64_t ZobristKey, int Score, int Depth, int currentTurnCount, int distanceFromRoot, EntryType Cutoff) : bestMove(best)
+TTEntry::TTEntry(Move best, uint64_t ZobristKey, int Score, int Depth, int currentTurnCount, int distanceFromRoot, EntryType Cutoff)
 {
 	assert(Score < SHRT_MAX && Score > SHRT_MIN);
 	assert(Depth < CHAR_MAX && Depth > CHAR_MIN);
 
 	key = ZobristKey;
+	bestMove.data = best.GetBits();
 	score = static_cast<short>(Score);
 	depth = static_cast<char>(Depth);
 	cutoff = Cutoff;
@@ -36,7 +38,7 @@ void TTEntry::MateScoreAdjustment(int distanceFromRoot)
 
 void TTEntry::Reset()
 {
-	bestMove.Reset();
+	bestMove.data = 0;
 	key = EMPTY;
 	score = -1;
 	depth = -1;

--- a/Halogen/src/TTEntry.h
+++ b/Halogen/src/TTEntry.h
@@ -24,7 +24,7 @@ public:
 	int GetDepth() const { return depth; }
 	bool IsAncient(unsigned int currenthalfmove, unsigned int distanceFromRoot) const { return halfmove != static_cast<char>((currenthalfmove - distanceFromRoot) % (HALF_MOVE_MODULO)); }
 	EntryType GetCutoff() const { return cutoff; }
-	Move GetMove() const { return bestMove; }
+	Move GetMove() const { return Move(bestMove.data); }
 	char GetHalfMove() const { return halfmove; }
 
 	void SetHalfMove(int currenthalfmove, int distanceFromRoot) { halfmove = (currenthalfmove - distanceFromRoot) % (HALF_MOVE_MODULO); }	//halfmove is from current position, distanceFromRoot adjusts this to get what the halfmove was at the root of the search
@@ -36,12 +36,10 @@ private:
 	/*Arranged to minimize padding*/
 
 	uint64_t key;			//8 bytes
-
-	Move bestMove;			//2 bytes 
-	char halfmove;			//1 bytes		(is stored as the halfmove at the ROOT of this current search, modulo 16)
-
+	MoveBits bestMove;		//2 bytes 
 	short int score;		//2 bytes
 	char depth;				//1 bytes
 	EntryType cutoff;		//1 bytes
+	char halfmove;			//1 bytes		(is stored as the halfmove at the ROOT of this current search, modulo 16)
 };
 

--- a/Halogen/src/TranspositionTable.cpp
+++ b/Halogen/src/TranspositionTable.cpp
@@ -2,7 +2,6 @@
 
 TranspositionTable::TranspositionTable()
 {
-	TTHits = 0;
 	table.push_back(TTEntry());
 }
 
@@ -74,8 +73,6 @@ int TranspositionTable::GetCapacity(int halfmove) const
 
 void TranspositionTable::ResetTable()
 {
-	TTHits = 0;
-
 	for (size_t i = 0; i < table.size(); i++)
 	{
 		table.at(i).Reset();

--- a/Halogen/src/TranspositionTable.h
+++ b/Halogen/src/TranspositionTable.h
@@ -13,10 +13,8 @@ public:
 	~TranspositionTable();
 
 	size_t GetSize() const { return table.size(); }
-	uint64_t GetHitCount() const { return TTHits; }
 	int GetCapacity(int halfmove) const;
 
-	void ResetHitCount() { TTHits = 0; }
 	void ResetTable();
 	void SetSize(uint64_t MB);	//will wipe the table and reconstruct a new empty table with a set size. units in MB!
 	void AddEntry(const Move& best, uint64_t ZobristKey, int Score, int Depth, int Turncount, int distanceFromRoot, EntryType Cutoff);
@@ -24,13 +22,11 @@ public:
 
 	void SetNonAncient(uint64_t key, int halfmove, int distanceFromRoot);
 
-	void AddHit() { TTHits++; }	//this is called every time we get a position from here. We don't count it if we just used it for move ordering
 	uint64_t HashFunction(const uint64_t& key) const;
 	void PreFetch(uint64_t key) const;
 
 private:
 	std::vector<TTEntry> table;
-	uint64_t TTHits;
 };
 
 bool CheckEntry(const TTEntry& entry, uint64_t key, int depth);


### PR DESCRIPTION
```
ELO   | 15.04 +- 8.06 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3652 W: 1013 L: 855 D: 1784
```
```
ELO   | 3.91 +- 3.14 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 24816 W: 6700 L: 6421 D: 11695
```