### PR TITLE
Allow futility pruning at all depths

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -1,6 +1,6 @@
 #include "Search.h"
 
-const std::vector<int> FutilityMargins = { 100, 150, 250, 400, 600 };
+int FutilityMargins[MAX_DEPTH];
 const unsigned int R = 3;					//Null-move reduction depth
 const unsigned int VariableNullDepth = 7;	//Beyond this depth R = 4
 
@@ -89,6 +89,11 @@ void DepthSearch(const Position& position, int maxSearchDepth)
 void InitSearch()
 {
 	KeepSearching = true;
+
+	for (int i = 0; i < MAX_DEPTH; i++)
+	{
+		FutilityMargins[i] = 25 * i * i + 25 * i + 100;
+	}
 }
 
 void OrderMoves(std::vector<Move>& moves, Position& position, int distanceFromRoot, SearchData& locals)
@@ -485,7 +490,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	if (hashMove.IsUninitialized() && depthRemaining > 3)
 		depthRemaining--;
 
-	bool FutileNode = (depthRemaining < static_cast<int>(FutilityMargins.size()) && staticScore + FutilityMargins.at(std::max<int>(0, depthRemaining)) < a);
+	bool FutileNode = staticScore + FutilityMargins[std::max<int>(0, depthRemaining)] < a;
 
 	for (size_t i = 0; i < moves.size(); i++)	
 	{


### PR DESCRIPTION
```
ELO   | 5.83 +- 4.42 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12400 W: 3348 L: 3140 D: 5912
```
```
ELO   | 4.51 +- 3.49 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15872 W: 3420 L: 3214 D: 9238
```