### PR TITLE
Restrict the depth that futility pruning is applied to

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -1,6 +1,7 @@
 #include "Search.h"
 
-int FutilityMargins[MAX_DEPTH];
+constexpr unsigned int FutilityMaxDepth = 15;
+int FutilityMargins[FutilityMaxDepth];
 const unsigned int R = 3;					//Null-move reduction depth
 const unsigned int VariableNullDepth = 7;	//Beyond this depth R = 4
 
@@ -105,7 +106,7 @@ void InitSearch()
 	int Futility_linear = 25;
 	int Futility_constant = 100;
 
-	for (int i = 0; i < MAX_DEPTH; i++)
+	for (int i = 0; i < FutilityMaxDepth; i++)
 	{
 		FutilityMargins[i] = Futility_linear * i + Futility_constant;
 	}
@@ -507,7 +508,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	if (hashMove.IsUninitialized() && depthRemaining > 3)
 		depthRemaining--;
 
-	bool FutileNode = staticScore + FutilityMargins[std::max<int>(0, depthRemaining)] < a;
+	bool FutileNode = (depthRemaining < FutilityMaxDepth) && (staticScore + FutilityMargins[std::max<int>(0, depthRemaining)] < a);
 
 	for (size_t i = 0; i < moves.size(); i++)	
 	{


### PR DESCRIPTION
```
ELO   | 4.80 +- 5.81 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7168 W: 1925 L: 1826 D: 3417
```
```
ELO   | 4.68 +- 3.55 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14848 W: 3099 L: 2899 D: 8850
```