### PR TITLE
Verify null move pruning when being checkmated

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -440,7 +440,18 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 		position.RevertNullMove();
 
 		if (score >= beta)
-			return beta;
+		{
+			if (beta < matedIn(MAX_DEPTH))	
+			{
+				SearchResult result = NegaScout(position, initialDepth, depthRemaining - reduction - 1, beta - 1, beta, colour, distanceFromRoot, false, locals, sharedData);
+				if (result.GetScore() >= beta)
+					return result;
+			}
+			else
+			{
+				return beta;
+			}
+		}
 	}
 
 	//mate distance pruning


### PR DESCRIPTION
```
ELO   | 1.60 +- 4.19 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 13664 W: 3573 L: 3510 D: 6581
```