### PR TITLE
Use all available time when given the command go movetime

### DIFF
--- a/Halogen/src/TimeManage.cpp
+++ b/Halogen/src/TimeManage.cpp
@@ -43,7 +43,7 @@ SearchTimeManage::~SearchTimeManage()
 
 bool SearchTimeManage::ContinueSearch()
 {
-	return (timer.ElapsedMs() < AllocatedSearchTimeMS / 2);
+	return (AllocatedSearchTimeMS == MaxTimeMS || timer.ElapsedMs() < AllocatedSearchTimeMS / 2);	//if AllocatedSearchTimeMS == MaxTimeMS then we have recieved a 'go movetime X' command and we should not abort search early
 }
 
 bool SearchTimeManage::AbortSearch(uint64_t nodes)


### PR DESCRIPTION
```
ELO   | -0.71 +- 2.42 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 40384 W: 10299 L: 10382 D: 19703
```