### PR TITLE
Bench: 12103680

### DIFF
--- a/Halogen/src/Network.cpp
+++ b/Halogen/src/Network.cpp
@@ -51,14 +51,11 @@ void RecalculateIncremental(std::array<int16_t, INPUT_NEURONS> inputs, std::arra
     std::array<int32_t, HIDDEN_NEURONS> Zeta32;    //calculate into a int32 but save to a int16 once the quantisation has compressed the values at the end
 
     for (size_t i = 0; i < HIDDEN_NEURONS; i++)
-        Zeta32[i] = (*hiddenBias)[i] * PRECISION;
+        Zeta32[i] = (*hiddenBias)[i];
 
     for (size_t i = 0; i < HIDDEN_NEURONS; i++)
         for (size_t j = 0; j < INPUT_NEURONS; j++)
             Zeta32[i] += inputs[j] * (*hiddenWeights)[j][i];
-
-    for (size_t i = 0; i < HIDDEN_NEURONS; i++)
-        Zeta32[i] = (Zeta32[i] + HALF_PRECISION) / PRECISION;
 
     for (size_t i = 0; i < HIDDEN_NEURONS; i++)
         Zeta[0][i] = Zeta32[i];
@@ -92,9 +89,7 @@ int16_t QuickEval(const std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPT
     for (size_t i = 0; i < HIDDEN_NEURONS; i++)
         output += std::max(int16_t(0), Zeta[incrementalDepth][i]) * (*outputWeights)[i];
 
-    output += HALF_PRECISION;
-    output /= PRECISION;
-    output += HALF_PRECISION;
-    output /= PRECISION;
+    output /= SQUARE_PRECISION;
+
     return output;
 }

--- a/Halogen/src/Position.cpp
+++ b/Halogen/src/Position.cpp
@@ -433,7 +433,7 @@ std::array<int16_t, INPUT_NEURONS> Position::GetInputLayer() const
 
 			for (int sq = 0; sq < N_SQUARES; sq++)
 			{
-				ret[index++] = ((bb & SquareBB[sq]) != 0) * PRECISION;
+				ret[index++] = ((bb & SquareBB[sq]) != 0);
 			}
 		}
 	}


### PR DESCRIPTION
```
ELO   | 4.30 +- 3.41 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 19008 W: 4655 L: 4420 D: 9933
```
Rounding costs time and gives accuracy that we don't need