### PR TITLE
Limit futility pruning to a max depth of 10

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -1,6 +1,6 @@
 #include "Search.h"
 
-constexpr int FutilityMaxDepth = 15;
+constexpr int FutilityMaxDepth = 10;
 int FutilityMargins[FutilityMaxDepth];
 const unsigned int R = 3;					//Null-move reduction depth
 const unsigned int VariableNullDepth = 7;	//Beyond this depth R = 4


### PR DESCRIPTION
```
ELO   | 12.77 +- 6.64 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3920 W: 804 L: 660 D: 2456
```
```
ELO   | 2.69 +- 2.07 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 47136 W: 10501 L: 10136 D: 26499
```