### PR TITLE
Output aspiration fail

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -1042,13 +1042,13 @@ void ThreadSharedData::ReportResult(unsigned int depth, double Time, int score, 
 		highestBeta = score;
 	}
 
-	if (score <= lowestAlpha && score <= alpha && !noOutput && Time > 1000 && threadDepthCompleted == depth - 1)
+	if (score <= lowestAlpha && score <= alpha && !noOutput && Time > 5000 && threadDepthCompleted == depth - 1)
 	{
 		PrintSearchInfo(depth, Time, abs(score) > 9000, score, alpha, beta, position, move, locals, *this);
 		lowestAlpha = alpha;
 	}
 
-	if (score >= highestBeta && score >= beta && !noOutput && Time > 1000 && threadDepthCompleted == depth - 1)
+	if (score >= highestBeta && score >= beta && !noOutput && Time > 5000 && threadDepthCompleted == depth - 1)
 	{
 		PrintSearchInfo(depth, Time, abs(score) > 9000, score, alpha, beta, position, move, locals, *this);
 		highestBeta = alpha;

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -1038,6 +1038,20 @@ void ThreadSharedData::ReportResult(unsigned int depth, double Time, int score, 
 		threadDepthCompleted = depth;
 		currentBestMove = move;
 		prevScore = score;
+		lowestAlpha = score;
+		highestBeta = score;
+	}
+
+	if (score <= lowestAlpha && score <= alpha && !noOutput && Time > 1000 && threadDepthCompleted == depth - 1)
+	{
+		PrintSearchInfo(depth, Time, abs(score) > 9000, score, alpha, beta, position, move, locals, *this);
+		lowestAlpha = alpha;
+	}
+
+	if (score >= highestBeta && score >= beta && !noOutput && Time > 1000 && threadDepthCompleted == depth - 1)
+	{
+		PrintSearchInfo(depth, Time, abs(score) > 9000, score, alpha, beta, position, move, locals, *this);
+		highestBeta = alpha;
 	}
 }
 

--- a/Halogen/src/Search.h
+++ b/Halogen/src/Search.h
@@ -78,6 +78,8 @@ private:
 	unsigned int threadDepthCompleted;				//The depth that has been completed. When the first thread finishes a depth it increments this. All other threads should stop searching that depth
 	Move currentBestMove;							//Whoever finishes first gets to update this as long as they searched deeper than threadDepth
 	int prevScore;									//if threads abandon the search, we need to know what the score was in order to set new alpha/beta bounds
+	int lowestAlpha;
+	int highestBeta;
 	bool noOutput;									//Do not write anything to the concole
 
 	std::atomic<uint64_t> tbHits;


### PR DESCRIPTION
```
ELO   | -1.62 +- 3.97 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 12880 W: 2795 L: 2855 D: 7230
```