### PR TITLE
Use a better transposition replacement scheme

### DIFF
--- a/Halogen/src/TTEntry.cpp
+++ b/Halogen/src/TTEntry.cpp
@@ -30,9 +30,9 @@ TTEntry::~TTEntry()
 
 void TTEntry::MateScoreAdjustment(int distanceFromRoot)
 {
-	if (GetScore() > 9000)	//checkmate node
+	if (score > 9000)	//checkmate node
 		score -= static_cast<short>(distanceFromRoot);
-	if (GetScore() < -9000)
+	if (score < -9000)
 		score += static_cast<short>(distanceFromRoot);
 }
 
@@ -44,4 +44,12 @@ void TTEntry::Reset()
 	depth = -1;
 	cutoff = EntryType::EMPTY_ENTRY;
 	halfmove = -1;
+}
+
+void TTBucket::Reset()
+{
+	entry[0].Reset();
+	entry[1].Reset();
+	entry[2].Reset();
+	entry[3].Reset();
 }

--- a/Halogen/src/TTEntry.h
+++ b/Halogen/src/TTEntry.h
@@ -13,34 +13,41 @@ enum class EntryType : char {
 };
 
 //16 bytes
-class TTEntry
+struct TTEntry
 {
 public:
 	TTEntry();
 	TTEntry(Move best, uint64_t ZobristKey, int Score, int Depth, int currentTurnCount, int distanceFromRoot, EntryType Cutoff);
 	~TTEntry();
 
-	uint64_t GetKey() const { return key; }
-	int GetScore() const { return score; } 	
-	int GetDepth() const { return depth; }
 	bool IsAncient(unsigned int currenthalfmove, unsigned int distanceFromRoot) const { return halfmove != static_cast<char>((currenthalfmove - distanceFromRoot) % (HALF_MOVE_MODULO)); }
-	EntryType GetCutoff() const { return cutoff; }
-	Move GetMove() const { return Move(bestMove.data); }
-	char GetHalfMove() const { return halfmove; }
 
-	void SetHalfMove(int currenthalfmove, int distanceFromRoot) { halfmove = (currenthalfmove - distanceFromRoot) % (HALF_MOVE_MODULO); }	//halfmove is from current position, distanceFromRoot adjusts this to get what the halfmove was at the root of the search
+	void SetHalfMove(int currenthalfmove, int distanceFromRoot) { halfmove = CalculateHalfMove(currenthalfmove, distanceFromRoot); }	//halfmove is from current position, distanceFromRoot adjusts this to get what the halfmove was at the root of the search
 	void MateScoreAdjustment(int distanceFromRoot);
-
 	void Reset();
+
+	static uint8_t CalculateHalfMove(int currenthalfmove, int distanceFromRoot) { return (currenthalfmove - distanceFromRoot) % (HALF_MOVE_MODULO); }
+
+	uint64_t GetKey() const { return key; }
+	int GetScore() const { return score; }
+	int GetDepth() const { return depth; }
+	EntryType GetCutoff() const { return cutoff; }
+	char GetHalfMove() const { return halfmove; }
+	Move GetMove() const { return Move(bestMove.data); }
 
 private:
 	/*Arranged to minimize padding*/
-
 	uint64_t key;			//8 bytes
 	MoveBits bestMove;		//2 bytes 
 	short int score;		//2 bytes
 	char depth;				//1 bytes
 	EntryType cutoff;		//1 bytes
 	char halfmove;			//1 bytes		(is stored as the halfmove at the ROOT of this current search, modulo 16)
+};
+
+struct TTBucket
+{
+	void Reset();
+	TTEntry entry[4];
 };
 

--- a/Halogen/src/TranspositionTable.cpp
+++ b/Halogen/src/TranspositionTable.cpp
@@ -2,7 +2,7 @@
 
 TranspositionTable::TranspositionTable()
 {
-	table.push_back(TTEntry());
+	table.push_back(TTBucket());
 }
 
 TranspositionTable::~TranspositionTable()
@@ -11,22 +11,17 @@ TranspositionTable::~TranspositionTable()
 
 bool CheckEntry(const TTEntry& entry, uint64_t key, int depth)
 {
-	if (entry.GetKey() == key && (entry.GetDepth() >= depth) && entry.GetCutoff() != EntryType::EMPTY_ENTRY)
-		return true;
-	return false;
+	return (entry.GetKey() == key && entry.GetDepth() >= depth);
 }
 
 uint64_t TranspositionTable::HashFunction(const uint64_t& key) const
 {
 	return key % table.size();
-	//return key & 0x3FFFFF;
 }
 
 bool CheckEntry(const TTEntry& entry, uint64_t key)
 {
-	if (entry.GetKey() == key && entry.GetCutoff() != EntryType::EMPTY_ENTRY)
-		return true;
-	return false;
+	return (entry.GetKey() == key);
 }
 
 void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, int Score, int Depth, int Turncount, int distanceFromRoot, EntryType Cutoff)
@@ -41,21 +36,56 @@ void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, int Sco
 	if (Score < -9000)
 		Score -= distanceFromRoot;
 
-
-	if ((table.at(hash).GetKey() == EMPTY) || (table.at(hash).GetDepth() <= Depth) || (table.at(hash).IsAncient(Turncount, distanceFromRoot)) || table.at(hash).GetCutoff() == EntryType::EMPTY_ENTRY)
+	for (int i = 0; i < 4; i++)
 	{
-		table.at(hash) = TTEntry(best, ZobristKey, Score, Depth, Turncount, distanceFromRoot, Cutoff);
+		if (table[hash].entry[i].GetKey() == EMPTY || table[hash].entry[i].GetKey() == ZobristKey)
+		{
+			table[hash].entry[i] = TTEntry(best, ZobristKey, Score, Depth, Turncount, distanceFromRoot, Cutoff);
+			return;
+		}
 	}
+
+	int8_t currentAge = TTEntry::CalculateHalfMove(Turncount, distanceFromRoot);	//Keep in mind age from each generation goes up so lower (generally) means older
+	int8_t age;
+
+	age = currentAge - table[hash].entry[0].GetHalfMove();
+	int8_t score1 = table[hash].entry[0].GetDepth() - 4 * (age >= 0 ? age : age + 16);
+	age = currentAge - table[hash].entry[1].GetHalfMove();
+	int8_t score2 = table[hash].entry[1].GetDepth() - 4 * (age >= 0 ? age : age + 16);
+	age = currentAge - table[hash].entry[2].GetHalfMove();
+	int8_t score3 = table[hash].entry[2].GetDepth() - 4 * (age >= 0 ? age : age + 16);
+	age = currentAge - table[hash].entry[3].GetHalfMove();
+	int8_t score4 = table[hash].entry[3].GetDepth() - 4 * (age >= 0 ? age : age + 16);
+
+	int8_t lowest = score1;
+	lowest = std::min(lowest, score2);
+	lowest = std::min(lowest, score3);
+	lowest = std::min(lowest, score4);
+
+	if (lowest == score1)		table[hash].entry[0] = TTEntry(best, ZobristKey, Score, Depth, Turncount, distanceFromRoot, Cutoff);
+	else if (lowest == score2)	table[hash].entry[1] = TTEntry(best, ZobristKey, Score, Depth, Turncount, distanceFromRoot, Cutoff);
+	else if (lowest == score3)	table[hash].entry[2] = TTEntry(best, ZobristKey, Score, Depth, Turncount, distanceFromRoot, Cutoff);
+	else						table[hash].entry[3] = TTEntry(best, ZobristKey, Score, Depth, Turncount, distanceFromRoot, Cutoff);
 }
 
 TTEntry TranspositionTable::GetEntry(uint64_t key)
 {
-	return table.at(HashFunction(key));
+	size_t index = HashFunction(key);
+
+	for (int i = 0; i < 4; i++)
+		if (table[index].entry[i].GetKey() == key)
+			return table[index].entry[i];
+
+	return {};
 }
 
 void TranspositionTable::SetNonAncient(uint64_t key, int halfmove, int distanceFromRoot)
 {
-	table.at(HashFunction(key)).SetHalfMove(halfmove, distanceFromRoot);
+	size_t index = HashFunction(key);
+
+	for (int i = 0; i < 4; i++)
+		if (table[index].entry[i].GetKey() == key)
+			table[index].entry[i].SetHalfMove(halfmove, distanceFromRoot);
 }
 
 int TranspositionTable::GetCapacity(int halfmove) const
@@ -64,7 +94,7 @@ int TranspositionTable::GetCapacity(int halfmove) const
 
 	for (int i = 0; i < 1000; i++)	//1000 chosen specifically, because result needs to be 'per mill'
 	{
-		if (table.at(i).GetHalfMove() == static_cast<char>(halfmove % HALF_MOVE_MODULO))
+		if (table.at(i / 4).entry[i % 4].GetHalfMove() == static_cast<char>(halfmove % HALF_MOVE_MODULO))
 			count++;
 	}
 
@@ -81,7 +111,7 @@ void TranspositionTable::ResetTable()
 
 void TranspositionTable::SetSize(uint64_t MB)
 {
-	table.resize(MB * 1024 * 1024 / sizeof(TTEntry));
+	table.resize(MB * 1024 * 1024 / sizeof(TTBucket));
 }
 
 void TranspositionTable::PreFetch(uint64_t key) const

--- a/Halogen/src/TranspositionTable.h
+++ b/Halogen/src/TranspositionTable.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <mutex>
 #include <memory>		//required to compile with g++
+#include <algorithm>
 #include "TTEntry.h"
 
 const unsigned int mutex_frequency = 1024;					//how many entries per mutex
@@ -26,7 +27,7 @@ public:
 	void PreFetch(uint64_t key) const;
 
 private:
-	std::vector<TTEntry> table;
+	std::vector<TTBucket> table;
 };
 
 bool CheckEntry(const TTEntry& entry, uint64_t key, int depth);


### PR DESCRIPTION
```
ELO   | 2.04 +- 4.25 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 12256 W: 2972 L: 2900 D: 6384
```
```
ELO   | 10.15 +- 6.17 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5476 W: 1313 L: 1153 D: 3010
```