### PR TITLE
Implement reverse futility pruning

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -417,6 +417,9 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	}
 
 	int staticScore = colour * EvaluatePositionNet(position, locals.evalTable);
+	bool InCheck = IsInCheck(position);
+
+	if (depthRemaining == 1 && staticScore - 200 >= beta && !InCheck && !IsPV(beta, alpha)) return beta;
 
 	/*Null move pruning*/
 	if (AllowedNull(allowedNull, position, beta, alpha) && (staticScore > beta))
@@ -501,7 +504,6 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	if (position.GetFiftyMoveCount() >= 100) return 0;	//must make sure its not already checkmate
 	
 	OrderMoves(moves, position, distanceFromRoot, locals);
-	bool InCheck = IsInCheck(position);
 
 	if (hashMove.IsUninitialized() && depthRemaining > 3)
 		depthRemaining--;


### PR DESCRIPTION
```
ELO   | 4.87 +- 3.80 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15488 W: 3847 L: 3630 D: 8011
```
```
ELO   | 6.70 +- 4.51 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8656 W: 1732 L: 1565 D: 5359
```