### PR TITLE
Fix source of rare crashes

### DIFF
--- a/Halogen/src/Network.cpp
+++ b/Halogen/src/Network.cpp
@@ -41,11 +41,11 @@ void NetworkInit()
     delete[] OutputBias;
 }
 
-void RecalculateIncremental(std::array<int16_t, INPUT_NEURONS> inputs, std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH>& Zeta, size_t& incrementalDepth)
+void RecalculateIncremental(std::array<int16_t, INPUT_NEURONS> inputs, std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH + 1>& Zeta, size_t& incrementalDepth)
 {
     incrementalDepth = 0;
 
-    for (size_t i = 0; i < MAX_DEPTH; i++)
+    for (size_t i = 0; i <= MAX_DEPTH; i++)
         Zeta[i] = {};
 
     for (size_t i = 0; i < HIDDEN_NEURONS; i++)
@@ -56,7 +56,7 @@ void RecalculateIncremental(std::array<int16_t, INPUT_NEURONS> inputs, std::arra
             Zeta[0][i] += inputs[j] * (*hiddenWeights)[j][i];
 }
 
-void ApplyDelta(deltaArray& update, std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH>& Zeta, size_t& incrementalDepth)
+void ApplyDelta(deltaArray& update, std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH + 1>& Zeta, size_t& incrementalDepth)
 {
     incrementalDepth++;
     Zeta[incrementalDepth] = Zeta[incrementalDepth - 1];
@@ -77,7 +77,7 @@ void ApplyInverseDelta(size_t& incrementalDepth)
     --incrementalDepth;
 }
 
-int16_t QuickEval(const std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH>& Zeta, const size_t& incrementalDepth)
+int16_t QuickEval(const std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH + 1>& Zeta, const size_t& incrementalDepth)
 {
     int32_t output = (*outputBias) * PRECISION;
 

--- a/Halogen/src/Network.h
+++ b/Halogen/src/Network.h
@@ -39,9 +39,9 @@ extern std::array<int16_t, HIDDEN_NEURONS>* hiddenBias;
 extern std::array<int16_t, HIDDEN_NEURONS>* outputWeights;
 extern int16_t* outputBias;
 
-void RecalculateIncremental(std::array<int16_t, INPUT_NEURONS> inputs, std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH>& Zeta, size_t& incrementalDepth);
-void ApplyDelta(deltaArray& update, std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH>& Zeta, size_t& incrementalDepth);     //incrementally update the connections between input layer and first hidden layer
+void RecalculateIncremental(std::array<int16_t, INPUT_NEURONS> inputs, std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH + 1>& Zeta, size_t& incrementalDepth);
+void ApplyDelta(deltaArray& update, std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH + 1>& Zeta, size_t& incrementalDepth);     //incrementally update the connections between input layer and first hidden layer
 void ApplyInverseDelta(size_t& incrementalDepth);                                                                                   //for un-make moves
-int16_t QuickEval(const std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH>& Zeta, const size_t& incrementalDepth);          //when used with above, this just calculates starting from the alpha of first hidden layer and skips input -> hidden
+int16_t QuickEval(const std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH + 1>& Zeta, const size_t& incrementalDepth);          //when used with above, this just calculates starting from the alpha of first hidden layer and skips input -> hidden
 
 void NetworkInit();

--- a/Halogen/src/Position.h
+++ b/Halogen/src/Position.h
@@ -78,7 +78,7 @@ private:
 	deltaArray delta;										//re recycle this object to save time in CalculateMoveDelta
 
 	//Values for keeping the network updated
-	std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH> Zeta;
+	std::array<std::array<int16_t, HIDDEN_NEURONS>, MAX_DEPTH + 1> Zeta;
 	size_t incrementalDepth = 0;
 };
 


### PR DESCRIPTION
No crashes after 15k LTC games.
```
ELO   | -0.27 +- 3.34 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | -1.86 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15408 W: 2866 L: 2878 D: 9664
```
Tested for regression
```
ELO   | -2.19 +- 3.61 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 16784 W: 3919 L: 4025 D: 8840
```