### PR TITLE
Tweak output

### DIFF
--- a/Halogen/src/Position.h
+++ b/Halogen/src/Position.h
@@ -58,9 +58,14 @@ public:
 
 	bool CheckForRep(int distanceFromRoot, int maxReps);
 
+	void ResetSeldepth() { selDepth = 0; }
+	void ReportDepth(int distanceFromRoot) { selDepth = std::max(distanceFromRoot, selDepth); }
+	int GetSelDepth() const { return selDepth; }
+
 private:
 	size_t nodesSearched;
 	size_t tbHits;
+	int selDepth;
 
 	uint64_t key;
 	std::vector<uint64_t> PreviousKeys;

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -332,6 +332,7 @@ SearchResult AspirationWindowSearch(Position& position, int depth, int prevScore
 
 	while (!locals.AbortSearch(0) || depth == 1)
 	{
+		position.ResetSeldepth();
 		search = NegaScout(position, depth, depth, alpha, beta, position.GetTurn() ? 1 : -1, 0, false, locals, sharedData);
 		if (alpha < search.GetScore() && search.GetScore() < beta) break;
 		if (sharedData.ThreadAbort(depth)) break;
@@ -364,7 +365,6 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 
 	locals.PvTable[distanceFromRoot].clear();
 	if (position.NodesSearchedAddToThreadTotal()) sharedData.AddNodeChunk();
-	if (distanceFromRoot == 0) position.ResetSeldepth();
 	position.ReportDepth(distanceFromRoot);
 
 	if (initialDepth > 1 && locals.AbortSearch(position.GetNodes())) return -1;										//we must check later that we don't let this score pollute the transposition table


### PR DESCRIPTION
```
ELO   | -3.01 +- 2.36 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | -2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 39872 W: 9421 L: 9766 D: 20685
```