### PR TITLE
Time check fix

### DIFF
--- a/Halogen/src/TimeManage.cpp
+++ b/Halogen/src/TimeManage.cpp
@@ -48,7 +48,7 @@ bool SearchTimeManage::ContinueSearch()
 
 bool SearchTimeManage::AbortSearch(uint64_t nodes)
 {
-	if ((nodes & 0x3FF) == 0 || nodes <= 0x3FFF)	//will hit once every 1024, but every time its called initially to help with very fast time controls
+	if (nodes <= 0x3FFF)	
 		CacheShouldStop = (timer.ElapsedMs() > (AllocatedSearchTimeMS)) || (timer.ElapsedMs() > (MaxTimeMS - BufferTime));
 
 	return (!KeepSearching || CacheShouldStop);

--- a/Halogen/src/TimeManage.cpp
+++ b/Halogen/src/TimeManage.cpp
@@ -48,7 +48,7 @@ bool SearchTimeManage::ContinueSearch()
 
 bool SearchTimeManage::AbortSearch(uint64_t nodes)
 {
-	if (nodes <= 0x3FFF)	
+	if ((nodes & 0x3FF) == 0)
 		CacheShouldStop = (timer.ElapsedMs() > (AllocatedSearchTimeMS)) || (timer.ElapsedMs() > (MaxTimeMS - BufferTime));
 
 	return (!KeepSearching || CacheShouldStop);


### PR DESCRIPTION
This patch fixes a oversight that the nodes value passed to the function from `position.GetNodes()` does not count upward, but counts chunks up to a maximum of 4096 before resetting at zero. As such, the condition to check every node in the first 1024 causes the engine to check the remaining time for 1/4 of nodes rather than 1/1024 nodes as intended. 
```
ELO   | 33.81 +- 12.37 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1536 W: 462 L: 313 D: 761
```
Bench: 13438976