### PR TITLE
Fix NMP late game condition to be more restrictive

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -764,7 +764,7 @@ bool AllowedNull(bool allowedNull, const Position& position, int beta, int alpha
 
 bool IsEndGame(const Position& position)
 {
-	return (position.GetAllPieces() == (position.GetPieceBB(WHITE_KING) | position.GetPieceBB(BLACK_KING) | position.GetPieceBB(WHITE_PAWN) | position.GetPieceBB(BLACK_PAWN)));
+	return (position.GetPiecesColour(position.GetTurn()) == (position.GetPieceBB(KING, position.GetTurn()) | position.GetPieceBB(PAWN, position.GetTurn())));
 }
 
 bool IsPV(int beta, int alpha)


### PR DESCRIPTION
This patch fixes the blunder that Halogen played in this TCEC game (https://tcec-chess.com/#div=ql&game=5&season=20) which took a game which should have been drawn and caused Halogen to lose. When in a position with only king moves and pawn moves, it is too risky to allow null move pruning. The previous condition allowed null move pruning if at least one side had non king/pawn material.

```
ELO   | -0.06 +- 2.43 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 30080 W: 5760 L: 5765 D: 18555
```