### PR TITLE
Tune the null move pruning reduction scheme

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -5,8 +5,9 @@
 double LMR_constant = -1.26;
 double LMR_coeff    =  0.84;
 
-int Null_constant = 3;					//Null-move reduction depth
-int VariableNullDepth = 7;				//Beyond this depth R = 4
+int Null_constant = 3;
+int Null_depth_quotent = 6;
+int Null_beta_quotent = 256;
 
 int Futility_linear = 25;
 int Futility_constant = 100;
@@ -449,7 +450,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	/*Null move pruning*/
 	if (AllowedNull(allowedNull, position, beta, alpha, InCheck) && (staticScore > beta))
 	{
-		unsigned int reduction = Null_constant + (depthRemaining >= static_cast<int>(VariableNullDepth));
+		unsigned int reduction = Null_constant + depthRemaining / Null_depth_quotent + std::min(3, (staticScore - beta) / Null_beta_quotent);
 
 		position.ApplyNullMove();
 		int score = -NegaScout(position, initialDepth, depthRemaining - reduction - 1, -beta, -beta + 1, -colour, distanceFromRoot + 1, false, locals, sharedData).GetScore();

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -5,9 +5,9 @@
 double LMR_constant = -1.26;
 double LMR_coeff    =  0.84;
 
-int Null_constant = 3;
+int Null_constant = 4;
 int Null_depth_quotent = 6;
-int Null_beta_quotent = 256;
+int Null_beta_quotent = 250;
 
 int Futility_linear = 25;
 int Futility_constant = 100;

--- a/Halogen/src/Search.h
+++ b/Halogen/src/Search.h
@@ -17,8 +17,9 @@
 extern double LMR_constant;
 extern double LMR_coeff;
 
-extern int Null_constant;					//Null-move reduction depth
-extern int VariableNullDepth;				//Beyond this depth R = 4
+extern int Null_constant;				
+extern int Null_depth_quotent;				
+extern int Null_beta_quotent;
 
 extern int Futility_linear;
 extern int Futility_constant;

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -198,11 +198,18 @@ int main(int argc, char* argv[])
 				Null_constant = stoi(token);
 			}
 
-			else if (token == "VariableNullDepth")
+			else if (token == "Null_depth_quotent")
 			{
 				iss >> token; //'value'
 				iss >> token;
-				VariableNullDepth = stoi(token);
+				Null_depth_quotent = stoi(token);
+			}
+
+			else if (token == "Null_beta_quotent")
+			{
+				iss >> token; //'value'
+				iss >> token;
+				Null_beta_quotent = stoi(token);
 			}
 
 			else if (token == "Futility_linear")


### PR DESCRIPTION
The reduction formula for null move pruning has been adjusted and tuned with chess tuning tools. The new formula is  
`reduction = 4 + depth / 6 + min(3, (staticScore - beta) / 250);`

```
ELO   | 7.34 +- 5.02 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8288 W: 1957 L: 1782 D: 4549
```
```
ELO   | 10.90 +- 5.90 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4688 W: 900 L: 753 D: 3035
```