### PR TITLE
Add null move verification for high depth searches

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -458,7 +458,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 
 		if (score >= beta)
 		{
-			if (beta < matedIn(MAX_DEPTH))
+			if (beta < matedIn(MAX_DEPTH) || depthRemaining >= 10)
 			{
 				SearchResult result = NegaScout(position, initialDepth, depthRemaining - reduction - 1, beta - 1, beta, colour, distanceFromRoot, false, locals, sharedData);
 				if (result.GetScore() >= beta)


### PR DESCRIPTION
When the depth remaining is at least 10, verify the null move pruning in order to fix zugzwang blindness.

```
ELO   | 1.94 +- 4.03 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 12736 W: 2890 L: 2819 D: 7027
```
```
ELO   | -0.49 +- 2.64 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | -2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22672 W: 3850 L: 3882 D: 14940
```
Testing shows no strength change, but Halogen will analyse much better in zugzwang positions.