### PR TITLE
Remove node batches

### DIFF
--- a/Halogen/src/Position.cpp
+++ b/Halogen/src/Position.cpp
@@ -262,9 +262,6 @@ bool Position::InitialiseFromFen(std::vector<std::string> fen)
 	key = GenerateZobristKey();
 	RecalculateIncremental(GetInputLayer(), Zeta, incrementalDepth);
 
-	nodesSearched = 0;
-	tbHits = 0;
-
 	return true;
 }
 
@@ -538,28 +535,6 @@ void Position::RevertMoveQuick()
 int16_t Position::GetEvaluation()
 {
 	return QuickEval(Zeta, incrementalDepth);
-}
-
-bool Position::NodesSearchedAddToThreadTotal()
-{
-	if (nodesSearched > NodeCountChunk)
-	{
-		nodesSearched -= NodeCountChunk;
-		return true;
-	}
-
-	return false;
-}
-
-bool Position::TbHitaddToThreadTotal()
-{
-	if (tbHits > NodeCountChunk)
-	{
-		tbHits -= NodeCountChunk;
-		return true;
-	}
-
-	return false;
 }
 
 bool Position::CheckForRep(int distanceFromRoot, int maxReps)

--- a/Halogen/src/Position.h
+++ b/Halogen/src/Position.h
@@ -49,13 +49,6 @@ public:
 
 	int16_t GetEvaluation();
 
-	void addTbHit() { tbHits++; }
-	void addNode() { nodesSearched++; }
-	bool NodesSearchedAddToThreadTotal();
-	bool TbHitaddToThreadTotal();
-
-	size_t GetNodes() { return nodesSearched; }
-
 	bool CheckForRep(int distanceFromRoot, int maxReps);
 
 	void ResetSeldepth() { selDepth = 0; }
@@ -63,8 +56,7 @@ public:
 	int GetSelDepth() const { return selDepth; }
 
 private:
-	size_t nodesSearched;
-	size_t tbHits;
+	//TODO: move this to be inside of SearchData
 	int selDepth;
 
 	uint64_t key;

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -1026,12 +1026,12 @@ ThreadSharedData::ThreadSharedData(unsigned int threads, bool NoOutput) : curren
 	noOutput = NoOutput;
 	lowestAlpha = 0;
 	highestBeta = 0;
+	threadlocalData.resize(threads);
 
 	for (unsigned int i = 0; i < threads; i++)
 	{
 		searchDepth.push_back(0);
 		ThreadWantsToStop.push_back(false);
-		threadlocalData.push_back({});
 	}
 }
 

--- a/Halogen/src/Search.h
+++ b/Halogen/src/Search.h
@@ -70,7 +70,10 @@ struct SearchData
 	EvalCacheTable evalTable;
 	SearchTimeManage timeManage;
 
-	bool AbortSearch(size_t nodes);
+	uint64_t tbHits = 0;
+	uint64_t nodes = 0;
+
+	bool AbortSearch();
 	bool ContinueSearch();
 };
 
@@ -87,11 +90,10 @@ public:
 	void ReportWantsToStop(unsigned int threadID);
 	int GetAspirationScore();
 	
-	uint64_t getTBHits() const { return tbHits; }
-	uint64_t getNodes() const { return nodes; }
+	uint64_t getTBHits() const;
+	uint64_t getNodes() const;
 
-	void AddNodeChunk() { nodes += NodeCountChunk; }
-	void AddTBHitChunk() { tbHits += NodeCountChunk; }
+	SearchData& GetData(unsigned int threadID);
 
 private:
 	std::mutex ioMutex;
@@ -103,9 +105,9 @@ private:
 	int highestBeta;
 	bool noOutput;									//Do not write anything to the concole
 
-	uint64_t tbHits;
-	uint64_t nodes;
+	std::vector<SearchData> threadlocalData;
 
+	//TODO: probably put this inside of SearchData
 	std::vector<unsigned int> searchDepth;			//what depth is each thread currently searching?
 	std::vector<bool> ThreadWantsToStop;			//Threads signal here that they want to stop searching, but will keep going until all threads want to stop
 };

--- a/Halogen/src/Search.h
+++ b/Halogen/src/Search.h
@@ -64,6 +64,8 @@ struct SearchData
 {
 	SearchData();
 
+	uint64_t padding1[8] = {};	//To avoid false sharing between adjacent SearchData objects
+
 	std::vector<std::vector<Move>> PvTable;
 	std::vector<Killer> KillerMoves;							//2 moves indexed by distanceFromRoot
 	unsigned int HistoryMatrix[N_PLAYERS][N_SQUARES][N_SQUARES];			//first index is from square and 2nd index is to square
@@ -72,6 +74,8 @@ struct SearchData
 
 	uint64_t tbHits = 0;
 	uint64_t nodes = 0;
+
+	uint64_t padding2[8] = {};	//To avoid false sharing between adjacent SearchData objects
 
 	bool AbortSearch();
 	bool ContinueSearch();


### PR DESCRIPTION
```
ELO   | 6.04 +- 5.87 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 5984 W: 1385 L: 1281 D: 3318
```
```
ELO   | -9.11 +- 5.65 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | -2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 6030 W: 1175 L: 1333 D: 3522
```
This patch finally allows Halogen to again count TB hits and nodes correctly, and not in multiplies of 4096. Small regression with SMP but possible elo gain for single threaded so I'm accepting this patch and assuming I'll find SMP improvements in future.