### PR TITLE
Fix bug in MoveIsLegal function

### DIFF
--- a/Halogen/src/MoveGeneration.cpp
+++ b/Halogen/src/MoveGeneration.cpp
@@ -808,15 +808,12 @@ bool MoveIsLegal(Position& position, const Move& move)
 		std::vector<Move> moves;
 		CastleMoves(position, moves);
 
-		bool present = false;
 		for (size_t i = 0; i < moves.size(); i++)
 		{
 			if (moves[i] == move)
-				present = true;
+				return true;
 		}
-
-		if (!present)
-			return false;
+		return false;
 	}
 
 	/*Move puts me in check*/


### PR DESCRIPTION
```
ELO   | 7.69 +- 6.54 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 4928 W: 1176 L: 1067 D: 2685
```
```
ELO   | -1.50 +- 3.78 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | -2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14352 W: 3153 L: 3215 D: 7984
```
This patch fixes a bug where legal castling moves might incorrectly be flagged as illegal. This would cause a hash move which is a castling move. Patch doesn't gain elo, but does pass simplification bounds.