### PR TITLE
Extend SNMP

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -415,47 +415,6 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	int a = alpha;
 	int b = beta;
 
-	/*
-	TODO: This needs to be replaced with a staged move generation and is way overdue.
-	*/
-
-	//If a hash move exists, search with that move first and hope we can get a cutoff
-	Move hashMove = GetHashMove(position, distanceFromRoot);
-	if (!hashMove.IsUninitialized() && position.GetFiftyMoveCount() < 100 && MoveIsLegal(position, hashMove))	//if its 50 move rule we need to skip this and figure out if its checkmate or draw below
-	{
-		locals.AddNode();
-		position.ApplyMove(hashMove);
-		tTable.PreFetch(position.GetZobristKey());							//load the transposition into l1 cache. ~5% speedup
-		int extendedDepth = depthRemaining + extension(position, alpha, beta);
-		int newScore = -NegaScout(position, initialDepth, extendedDepth - 1, -b, -a, -colour, distanceFromRoot + 1, true, locals, sharedData).GetScore();
-		position.RevertMove();
-
-		if (newScore > Score)
-		{
-			Score = newScore;
-			bestMove = hashMove;
-		}
-
-		if (Score > a)
-		{
-			a = Score;
-			UpdatePV(hashMove, distanceFromRoot, locals.PvTable);
-		}
-
-		if (a >= beta) //Fail high cutoff
-		{
-			AddKiller(hashMove, distanceFromRoot, locals.KillerMoves);
-			AddHistory(hashMove, depthRemaining, locals.HistoryMatrix, position.GetTurn());
-
-			if (!locals.limits.CheckTimeLimit() && !(sharedData.ThreadAbort(initialDepth)))
-				AddScoreToTable(Score, alpha, position, depthRemaining, distanceFromRoot, beta, bestMove);
-
-			return SearchResult(Score, bestMove);
-		}
-
-		b = a + 1;				//Set a new zero width window
-	}
-
 	//Generate the legal moves
 	std::vector<Move> moves;
 	LegalMoves(position, moves);
@@ -472,16 +431,13 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	OrderMoves(moves, position, distanceFromRoot, locals);
 
 	//Rebel style IID. Don't ask why this helps but it does.
-	if (hashMove.IsUninitialized() && depthRemaining > 3)
+	if (GetHashMove(position, distanceFromRoot).IsUninitialized() && depthRemaining > 3)
 		depthRemaining--;
 
 	bool FutileNode = (depthRemaining < FutilityMaxDepth) && (staticScore + FutilityMargins[std::max<int>(0, depthRemaining)] < a);
 
 	for (size_t i = 0; i < moves.size(); i++)	
 	{
-		if (moves[i] == hashMove)
-			continue;
-
 		locals.AddNode();
 
 		//futility pruning


### PR DESCRIPTION
```
ELO   | 5.24 +- 4.03 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 9888 W: 1787 L: 1638 D: 6463
```
```
ELO   | 6.05 +- 4.64 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.07 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 9472 W: 2171 L: 2006 D: 5295
```
Extend static null move pruning to depth <= 2