### PR TITLE
Extend SNMP to depth 2

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -377,7 +377,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	int staticScore = colour * EvaluatePositionNet(position, locals.evalTable); 
 
 	//Static null move pruning
-	if (depthRemaining == 1 && staticScore - 200 >= beta && !InCheck && !IsPV(beta, alpha)) return beta;
+	if (depthRemaining <= 2 && staticScore - 150 * depthRemaining >= beta && !InCheck && !IsPV(beta, alpha)) return beta;
 
 	//Null move pruning
 	if (AllowedNull(allowedNull, position, beta, alpha, InCheck) && (staticScore > beta))


### PR DESCRIPTION
```
ELO   | 5.24 +- 4.03 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 9888 W: 1787 L: 1638 D: 6463
```
```
ELO   | 6.05 +- 4.64 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.07 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 9472 W: 2171 L: 2006 D: 5295
```