### PR TITLE
Apply LMR when when in check, giving check, or the end game

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -493,7 +493,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 		int extendedDepth = depthRemaining + extension(position, alpha, beta);
 
 		//late move reductions
-		if (LMR(InCheck, position) && i > 3)
+		if (i > 3)
 		{
 			int reduction = Reduction(depthRemaining, static_cast<int>(i));
 			int score = -NegaScout(position, initialDepth, extendedDepth - 1 - reduction, -a - 1, -a, -colour, distanceFromRoot + 1, true, locals, sharedData).GetScore();


### PR DESCRIPTION
```
ELO   | 2.89 +- 2.75 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 21418 W: 3834 L: 3656 D: 13928
```
```
ELO   | 4.96 +- 4.18 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 12112 W: 2863 L: 2690 D: 6559
```