### PR TITLE
Tune static null move pruning

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -2,8 +2,8 @@
 
 /*Tuneable search constants*/
 
-double LMR_constant = -0.23;
-double LMR_coeff    =  0.71;
+double LMR_constant = -1.26;
+double LMR_coeff = 0.84;
 
 int Null_constant = 4;
 int Null_depth_quotent = 6;
@@ -132,6 +132,7 @@ void OrderMoves(std::vector<Move>& moves, Position& position, int distanceFromRo
 
 	Note that typically the maximum value of the history matrix does not exceed 1,000,000 after a minute
 	and as such we choose 1m to be the maximum allowed value
+
 	*/
 
 	Move TTmove = GetHashMove(position, distanceFromRoot);

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -132,7 +132,6 @@ void OrderMoves(std::vector<Move>& moves, Position& position, int distanceFromRo
 
 	Note that typically the maximum value of the history matrix does not exceed 1,000,000 after a minute
 	and as such we choose 1m to be the maximum allowed value
-
 	*/
 
 	Move TTmove = GetHashMove(position, distanceFromRoot);

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -2,8 +2,8 @@
 
 /*Tuneable search constants*/
 
-double LMR_constant = -1.26;
-double LMR_coeff    =  0.84;
+double LMR_constant = -0.23;
+double LMR_coeff    =  0.71;
 
 int Null_constant = 4;
 int Null_depth_quotent = 6;
@@ -15,6 +15,9 @@ int Futility_constant = 100;
 int Aspiration_window = 15;
 
 int Delta_margin = 200;
+
+int SNMP_depth = 7;
+int SNMP_coeff = 119;
 
 /*----------------*/
 
@@ -377,7 +380,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	int staticScore = colour * EvaluatePositionNet(position, locals.evalTable); 
 
 	//Static null move pruning
-	if (depthRemaining <= 2 && staticScore - 150 * depthRemaining >= beta && !InCheck && !IsPV(beta, alpha)) return beta;
+	if (depthRemaining <= SNMP_depth && staticScore - SNMP_coeff * depthRemaining >= beta && !InCheck && !IsPV(beta, alpha)) return beta;
 
 	//Null move pruning
 	if (AllowedNull(allowedNull, position, beta, alpha, InCheck) && (staticScore > beta))

--- a/Halogen/src/Search.h
+++ b/Halogen/src/Search.h
@@ -24,6 +24,9 @@ extern int Aspiration_window;
 
 extern int Delta_margin;
 
+extern int SNMP_depth;
+extern int SNMP_coeff;
+
 /*----------------*/
 
 struct SearchResult

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -263,6 +263,20 @@ int main(int argc, char* argv[])
 				iss >> token;
 				Delta_margin = stoi(token);
 			}
+
+			else if (token == "SNMP_depth")
+			{
+				iss >> token; //'value'
+				iss >> token;
+				SNMP_depth = stoi(token);
+			}
+
+			else if (token == "SNMP_coeff")
+			{
+				iss >> token; //'value'
+				iss >> token;
+				SNMP_coeff = stoi(token);
+			}
 		}
 
 		else if (token == "perft")


### PR DESCRIPTION
```
ELO   | 8.13 +- 5.19 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 5984 W: 1112 L: 972 D: 3900
```
```
ELO   | 6.11 +- 4.73 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 9104 W: 2082 L: 1922 D: 5100
```