### PR TITLE
No checkmate detection in quiescence search

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -602,21 +602,6 @@ SearchResult Quiescence(Position& position, unsigned int initialDepth, int alpha
 	if (sharedData.ThreadAbort(initialDepth)) return -1;				//Has this depth been finished by another thread?
 	if (DeadPosition(position)) return 0;								//Is this position a dead draw?
 
-	std::vector<Move> moves;
-
-	/*Check for checkmate*/
-	if (IsInCheck(position))
-	{
-		LegalMoves(position, moves);
-
-		if (moves.size() == 0)
-		{
-			return TerminalScore(position, distanceFromRoot);
-		}
-
-		moves.clear();
-	}
-
 	int staticScore = colour * EvaluatePositionNet(position, locals.evalTable);
 	if (staticScore >= beta) return staticScore;
 	if (staticScore > alpha) alpha = staticScore;


### PR DESCRIPTION
```
ELO   | 4.61 +- 3.98 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 12736 W: 2862 L: 2693 D: 7181
```