### PR TITLE
Skip TT move in quiescence search

### DIFF
--- a/Halogen/src/MoveGenerator.cpp
+++ b/Halogen/src/MoveGenerator.cpp
@@ -3,7 +3,10 @@
 MoveGenerator::MoveGenerator(Position& Position, int DistanceFromRoot, const SearchData& Locals, bool Quiescence) :
 	position(Position), distanceFromRoot(DistanceFromRoot), locals(Locals), quiescence(Quiescence)
 {
-	stage = Stage::TT_MOVE;
+	if (quiescence)
+		stage = Stage::GEN_LOUD;
+	else
+		stage = Stage::TT_MOVE;
 }
 
 bool MoveGenerator::Next(Move& move)


### PR DESCRIPTION
```
ELO   | 1.54 +- 1.51 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 89440 W: 19829 L: 19433 D: 50178
```