### PR TITLE
Lower LMR reduction in PV nodes

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -317,6 +317,12 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 		if (searchedMoves > 3)
 		{
 			int reduction = Reduction(depthRemaining, searchedMoves);
+
+			if (IsPV(beta, alpha))
+				reduction--;
+
+			reduction = std::max(0, reduction);
+
 			int score = -NegaScout(position, initialDepth, extendedDepth - 1 - reduction, -a - 1, -a, -colour, distanceFromRoot + 1, true, locals, sharedData).GetScore();
 
 			if (score <= a)


### PR DESCRIPTION
```
ELO   | 5.22 +- 4.00 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 9792 W: 1733 L: 1586 D: 6473
```
```
ELO   | 3.44 +- 3.28 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 19184 W: 4372 L: 4182 D: 10630
```