### PR TITLE
Fix potential crash in history update

### DIFF
--- a/Halogen/src/MoveGenerator.cpp
+++ b/Halogen/src/MoveGenerator.cpp
@@ -131,9 +131,10 @@ void MoveGenerator::AdjustHistory(const Move& move, SearchData& Locals, int dept
 {
 	Locals.History.AddHistory(position.GetTurn(), move.GetFrom(), move.GetTo(), depthRemaining * depthRemaining);
 
-	for (auto it = legalMoves.begin(); it != current - 1 && it != legalMoves.end(); ++it)
+	for (auto const& m : legalMoves)
 	{
-		Locals.History.AddHistory(position.GetTurn(), it->move.GetFrom(), it->move.GetTo(), -depthRemaining * depthRemaining);
+		if (m.move == move) break;
+		Locals.History.AddHistory(position.GetTurn(), m.move.GetFrom(), m.move.GetTo(), -depthRemaining * depthRemaining);
 	}
 }
 


### PR DESCRIPTION
```
ELO   | 4.58 +- 5.38 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7280 W: 1708 L: 1612 D: 3960
```