### PR TITLE
Bench: 25784886

### DIFF
--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -151,7 +151,8 @@ int main(int argc, char* argv[])
 				if (movestogo != 0)
 					AllocatedTime = myTime / (movestogo + 1) * 3 / 2;	//repeating time control
 				else if (myInc != 0)
-					AllocatedTime = myTime / 16 + myInc;				//increment time control
+					// use a greater proportion of remaining time as the game continues, so that we use it all up and get to just increment
+					AllocatedTime = myTime * (1 + position.GetTurnCount() / 40.0) / 16 + myInc;	//increment time control
 				else
 					AllocatedTime = myTime / 20;						//sudden death time control
 


### PR DESCRIPTION
```
ELO   | 15.42 +- 7.05 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.03 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 2976 W: 542 L: 410 D: 2024
```
```
ELO   | 4.61 +- 3.97 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 12880 W: 2914 L: 2743 D: 7223
```
As the number of moves increases, use a higher proportion of remaining time so that it actually gets used up at some point during the game.