### PR TITLE
Remove SMP aspiration scheme for an elo loss

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -148,8 +148,8 @@ SearchResult AspirationWindowSearch(Position& position, int depth, int prevScore
 {
 	int delta = Aspiration_window;
 
-	int alpha = prevScore - std::max(1, delta + ((threadID % 2 == 0) ? 1 : -1) * int(4.0 * log2(threadID + 1)));
-	int beta  = prevScore + std::max(1, delta + ((threadID % 2 == 0) ? 1 : -1) * int(4.0 * log2(threadID + 1)));
+	int alpha = prevScore - delta;
+	int beta  = prevScore + delta;
 	SearchResult search = 0;
 
 	while (true)


### PR DESCRIPTION
```
ELO   | -9.43 +- 7.04 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | -2.99 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 3428 W: 582 L: 675 D: 2171
```
It's potentially unsound, I have no way of testing at very high core counts, and removing this will allow for elo gains elsewhere, for example early abort when a thread fails low or high. 