### PR TITLE
Limit history depth to 20

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -675,7 +675,7 @@ void AddKiller(Move move, int distanceFromRoot, std::vector<std::array<Move, 2>>
 
 void AddHistory(const MoveGenerator& gen, const Move& move, SearchData& locals, int depthRemaining)
 {
-	if (move.IsCapture() || move.IsPromotion()) return;
+	if (depthRemaining > 20 || move.IsCapture() || move.IsPromotion()) return;
 	gen.AdjustHistory(move, locals, depthRemaining);
 }
 


### PR DESCRIPTION
```
ELO   | -0.84 +- 1.93 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 53664 W: 11538 L: 11667 D: 30459
```
```
ELO   | 3.06 +- 4.57 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 9536 W: 2092 L: 2008 D: 5436
```