### PR TITLE
Fix best move selection in multiPV mode

### DIFF
--- a/Halogen/src/SearchData.cpp
+++ b/Halogen/src/SearchData.cpp
@@ -50,10 +50,14 @@ void ThreadSharedData::ReportResult(unsigned int depth, double Time, int score, 
 		if (!noOutput)
 			PrintSearchInfo(depth, Time, abs(score) > 9000, score, alpha, beta, position, move, locals);
 
-		currentBestMove = move;
-		prevScore = score;
-		lowestAlpha = score;
-		highestBeta = score;
+		if (GetMultiPVCount() == 0)
+		{
+			currentBestMove = move;
+			prevScore = score;
+			lowestAlpha = score;
+			highestBeta = score;
+		}
+
 		MultiPVExclusion.push_back(move);
 
 		if (GetMultiPVCount() >= GetMultiPVSetting())


### PR DESCRIPTION
```
ELO   | -1.85 +- 1.97 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | -0.54 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 51184 W: 10831 L: 11103 D: 29250
```