### PR TITLE
Correctly overload 'greater than' operator for ExtendedMove objects

### DIFF
--- a/Halogen/src/MoveGenerator.h
+++ b/Halogen/src/MoveGenerator.h
@@ -18,7 +18,7 @@ struct ExtendedMove
 	ExtendedMove(const Move _move, const int _score = 0, const short int _SEE = 0) : move(_move), score(_score), SEE(_SEE) {}
 
 	bool operator<(const ExtendedMove& rhs) const { return score < rhs.score; };
-	bool operator>(const ExtendedMove& rhs) const { return score < rhs.score; };
+	bool operator>(const ExtendedMove& rhs) const { return score > rhs.score; };
 
 	Move move;
 	int16_t score;


### PR DESCRIPTION
The greater than overload was never actually used, but this error should definitely be fixed. Thanks to @thehlopster for pointing this out to me.