### PR TITLE
[fix] decreased performance

### DIFF
--- a/Halogen/src/MoveGeneration.cpp
+++ b/Halogen/src/MoveGeneration.cpp
@@ -292,9 +292,9 @@ void PawnPromotions(Position& position, std::vector<Move>& moves, uint64_t pinne
 			continue;
 
 		moves.push_back(move);
-		moves.push_back(Move(static_cast<Square>(end - foward), end, ROOK_PROMOTION));
-		moves.push_back(Move(static_cast<Square>(end - foward), end, BISHOP_PROMOTION));
-		moves.push_back(Move(static_cast<Square>(end - foward), end, QUEEN_PROMOTION));
+		moves.emplace_back(Move(static_cast<Square>(end - foward), end, ROOK_PROMOTION));
+		moves.emplace_back(Move(static_cast<Square>(end - foward), end, BISHOP_PROMOTION));
+		moves.emplace_back(Move(static_cast<Square>(end - foward), end, QUEEN_PROMOTION));
 	}
 }
 
@@ -379,10 +379,10 @@ void PawnCaptures(Position& position, std::vector<Move>& moves, uint64_t pinned)
 
 		if (GetRank(end) == RANK_1 || GetRank(end) == RANK_8)
 		{
-			moves.push_back(Move(static_cast<Square>(end - fowardleft), end, KNIGHT_PROMOTION_CAPTURE));
-			moves.push_back(Move(static_cast<Square>(end - fowardleft), end, ROOK_PROMOTION_CAPTURE));
-			moves.push_back(Move(static_cast<Square>(end - fowardleft), end, BISHOP_PROMOTION_CAPTURE));
-			moves.push_back(Move(static_cast<Square>(end - fowardleft), end, QUEEN_PROMOTION_CAPTURE));
+			moves.emplace_back(Move(static_cast<Square>(end - fowardleft), end, KNIGHT_PROMOTION_CAPTURE));
+			moves.emplace_back(Move(static_cast<Square>(end - fowardleft), end, ROOK_PROMOTION_CAPTURE));
+			moves.emplace_back(Move(static_cast<Square>(end - fowardleft), end, BISHOP_PROMOTION_CAPTURE));
+			moves.emplace_back(Move(static_cast<Square>(end - fowardleft), end, QUEEN_PROMOTION_CAPTURE));
 		}
 		else
 			moves.push_back(move);
@@ -398,10 +398,10 @@ void PawnCaptures(Position& position, std::vector<Move>& moves, uint64_t pinned)
 
 		if (GetRank(end) == RANK_1 || GetRank(end) == RANK_8)
 		{
-			moves.push_back(Move(static_cast<Square>(end - fowardright), end, KNIGHT_PROMOTION_CAPTURE));
-			moves.push_back(Move(static_cast<Square>(end - fowardright), end, ROOK_PROMOTION_CAPTURE));
-			moves.push_back(Move(static_cast<Square>(end - fowardright), end, BISHOP_PROMOTION_CAPTURE));
-			moves.push_back(Move(static_cast<Square>(end - fowardright), end, QUEEN_PROMOTION_CAPTURE));
+			moves.emplace_back(Move(static_cast<Square>(end - fowardright), end, KNIGHT_PROMOTION_CAPTURE));
+			moves.emplace_back(Move(static_cast<Square>(end - fowardright), end, ROOK_PROMOTION_CAPTURE));
+			moves.emplace_back(Move(static_cast<Square>(end - fowardright), end, BISHOP_PROMOTION_CAPTURE));
+			moves.emplace_back(Move(static_cast<Square>(end - fowardright), end, QUEEN_PROMOTION_CAPTURE));
 		}
 		else
 			moves.push_back(move);
@@ -418,7 +418,7 @@ void CastleMoves(const Position& position, std::vector<Move>& moves)
 		{
 			if (!IsSquareThreatened(position, SQ_E1, position.GetTurn()) && !IsSquareThreatened(position, SQ_F1, position.GetTurn()) && !IsSquareThreatened(position, SQ_G1, position.GetTurn()))
 			{
-				moves.push_back(Move(SQ_E1, SQ_G1, KING_CASTLE));
+				moves.emplace_back(Move(SQ_E1, SQ_G1, KING_CASTLE));
 			}
 		}
 	}
@@ -429,7 +429,7 @@ void CastleMoves(const Position& position, std::vector<Move>& moves)
 		{
 			if (!IsSquareThreatened(position, SQ_E1, position.GetTurn()) && !IsSquareThreatened(position, SQ_D1, position.GetTurn()) && !IsSquareThreatened(position, SQ_C1, position.GetTurn()))
 			{
-				moves.push_back(Move(SQ_E1, SQ_C1, QUEEN_CASTLE));
+				moves.emplace_back(Move(SQ_E1, SQ_C1, QUEEN_CASTLE));
 			}
 		}
 	}
@@ -440,7 +440,7 @@ void CastleMoves(const Position& position, std::vector<Move>& moves)
 		{
 			if (!IsSquareThreatened(position, SQ_E8, position.GetTurn()) && !IsSquareThreatened(position, SQ_F8, position.GetTurn()) && !IsSquareThreatened(position, SQ_G8, position.GetTurn()))
 			{
-				moves.push_back(Move(SQ_E8, SQ_G8, KING_CASTLE));
+				moves.emplace_back(Move(SQ_E8, SQ_G8, KING_CASTLE));
 			}
 		}
 	}
@@ -451,7 +451,7 @@ void CastleMoves(const Position& position, std::vector<Move>& moves)
 		{
 			if (!IsSquareThreatened(position, SQ_E8, position.GetTurn()) && !IsSquareThreatened(position, SQ_D8, position.GetTurn()) && !IsSquareThreatened(position, SQ_C8, position.GetTurn()))
 			{
-				moves.push_back(Move(SQ_E8, SQ_C8, QUEEN_CASTLE));
+				moves.emplace_back(Move(SQ_E8, SQ_C8, QUEEN_CASTLE));
 			}
 		}
 	}


### PR DESCRIPTION
When inserting a temporary object into a container using the methods `push_back`, the object is constructed outside the container and then moved/copied into the container. On the other hand, the `emplace_back` methods allow you to eliminate the extra call of the move/copy constructor and create the object "in place" inside the container instead, perfectly passing the function's parameters to the constructor.