### PR TITLE
Adjust time usage to be less aggressive

### DIFF
--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -147,7 +147,7 @@ int main(int argc, char* argv[])
 					AllocatedTime = myTime / (movestogo + 1) * 3 / 2;	//repeating time control
 				else if (myInc != 0)
 					// use a greater proportion of remaining time as the game continues, so that we use it all up and get to just increment
-					AllocatedTime = myTime * (1 + position.GetTurnCount() / 40.0) / 16 + myInc;	//increment time control
+					AllocatedTime = myTime * (1 + position.GetTurnCount() / 40.0) / 20 + myInc;	//increment time control
 				else
 					AllocatedTime = myTime / 20;						//sudden death time control
 


### PR DESCRIPTION
```
ELO   | 3.64 +- 2.79 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 17754 W: 2744 L: 2558 D: 12452
```
```
ELO   | 25.30 +- 10.18 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1912 W: 478 L: 339 D: 1095
```