### PR TITLE
Use emplace_back

### DIFF
--- a/Halogen/src/MoveGeneration.cpp
+++ b/Halogen/src/MoveGeneration.cpp
@@ -153,7 +153,7 @@ void AppendLegalMoves(Square from, uint64_t to, Position& position, MoveFlag fla
 		Square target = static_cast<Square>(LSBpop(to));
 		Move move(from, target, flag);
 		if (!(pinned & SquareBB[from]) || !MovePutsSelfInCheck(position, move))
-			moves.push_back(move);
+			moves.emplace_back(move);
 	}
 }
 
@@ -165,7 +165,7 @@ void AppendLegalMoves(uint64_t from, Square to, Position& position, MoveFlag fla
 		Square source = static_cast<Square>(LSBpop(from));
 		Move move(source, to, flag);
 		if (!(pinned & SquareBB[source]) || !MovePutsSelfInCheck(position, move))
-			moves.push_back(move);
+			moves.emplace_back(move);
 	}
 }
 
@@ -258,7 +258,7 @@ void PawnPushes(Position& position, std::vector<Move>& moves, uint64_t pinned)
 		Move move(start, end, QUIET);
 
 		if (!(pinned & SquareBB[start]) || !MovePutsSelfInCheck(position, move))
-			moves.push_back(move);
+			moves.emplace_back(move);
 	}
 }
 
@@ -290,10 +290,10 @@ void PawnPromotions(Position& position, std::vector<Move>& moves, uint64_t pinne
 		if ((pinned & SquareBB[start]) && MovePutsSelfInCheck(position, move))
 			continue;
 
-		moves.push_back(move);
-		moves.emplace_back(Move(start, end, ROOK_PROMOTION));
-		moves.emplace_back(Move(start, end, BISHOP_PROMOTION));
-		moves.emplace_back(Move(start, end, QUEEN_PROMOTION));
+		moves.emplace_back(move);
+		moves.emplace_back(start, end, ROOK_PROMOTION);
+		moves.emplace_back(start, end, BISHOP_PROMOTION);
+		moves.emplace_back(start, end, QUEEN_PROMOTION);
 	}
 }
 
@@ -326,7 +326,7 @@ void PawnDoublePushes(Position& position, std::vector<Move>& moves, uint64_t pin
 		Move move(start, end, PAWN_DOUBLE_MOVE);
 
 		if (!(pinned & SquareBB[start]) || !MovePutsSelfInCheck(position, move))
-			moves.push_back(move);
+			moves.emplace_back(move);
 	}
 }
 
@@ -373,13 +373,13 @@ void PawnCaptures(Position& position, std::vector<Move>& moves, uint64_t pinned)
 
 		if (GetRank(end) == RANK_1 || GetRank(end) == RANK_8)
 		{
-			moves.emplace_back(Move(start, end, KNIGHT_PROMOTION_CAPTURE));
-			moves.emplace_back(Move(start, end, ROOK_PROMOTION_CAPTURE));
-			moves.emplace_back(Move(start, end, BISHOP_PROMOTION_CAPTURE));
-			moves.emplace_back(Move(start, end, QUEEN_PROMOTION_CAPTURE));
+			moves.emplace_back(start, end, KNIGHT_PROMOTION_CAPTURE);
+			moves.emplace_back(start, end, ROOK_PROMOTION_CAPTURE);
+			moves.emplace_back(start, end, BISHOP_PROMOTION_CAPTURE);
+			moves.emplace_back(start, end, QUEEN_PROMOTION_CAPTURE);
 		}
 		else
-			moves.push_back(move);
+			moves.emplace_back(move);
 	}
 
 	while (rightAttack != 0)
@@ -393,13 +393,13 @@ void PawnCaptures(Position& position, std::vector<Move>& moves, uint64_t pinned)
 
 		if (GetRank(end) == RANK_1 || GetRank(end) == RANK_8)
 		{
-			moves.emplace_back(Move(start, end, KNIGHT_PROMOTION_CAPTURE));
-			moves.emplace_back(Move(start, end, ROOK_PROMOTION_CAPTURE));
-			moves.emplace_back(Move(start, end, BISHOP_PROMOTION_CAPTURE));
-			moves.emplace_back(Move(start, end, QUEEN_PROMOTION_CAPTURE));
+			moves.emplace_back(start, end, KNIGHT_PROMOTION_CAPTURE);
+			moves.emplace_back(start, end, ROOK_PROMOTION_CAPTURE);
+			moves.emplace_back(start, end, BISHOP_PROMOTION_CAPTURE);
+			moves.emplace_back(start, end, QUEEN_PROMOTION_CAPTURE);
 		}
 		else
-			moves.push_back(move);
+			moves.emplace_back(move);
 	}
 }
 
@@ -413,7 +413,7 @@ void CastleMoves(const Position& position, std::vector<Move>& moves)
 		{
 			if (!IsSquareThreatened(position, SQ_E1, position.GetTurn()) && !IsSquareThreatened(position, SQ_F1, position.GetTurn()) && !IsSquareThreatened(position, SQ_G1, position.GetTurn()))
 			{
-				moves.emplace_back(Move(SQ_E1, SQ_G1, KING_CASTLE));
+				moves.emplace_back(SQ_E1, SQ_G1, KING_CASTLE);
 			}
 		}
 	}
@@ -424,7 +424,7 @@ void CastleMoves(const Position& position, std::vector<Move>& moves)
 		{
 			if (!IsSquareThreatened(position, SQ_E1, position.GetTurn()) && !IsSquareThreatened(position, SQ_D1, position.GetTurn()) && !IsSquareThreatened(position, SQ_C1, position.GetTurn()))
 			{
-				moves.emplace_back(Move(SQ_E1, SQ_C1, QUEEN_CASTLE));
+				moves.emplace_back(SQ_E1, SQ_C1, QUEEN_CASTLE);
 			}
 		}
 	}
@@ -435,7 +435,7 @@ void CastleMoves(const Position& position, std::vector<Move>& moves)
 		{
 			if (!IsSquareThreatened(position, SQ_E8, position.GetTurn()) && !IsSquareThreatened(position, SQ_F8, position.GetTurn()) && !IsSquareThreatened(position, SQ_G8, position.GetTurn()))
 			{
-				moves.emplace_back(Move(SQ_E8, SQ_G8, KING_CASTLE));
+				moves.emplace_back(SQ_E8, SQ_G8, KING_CASTLE);
 			}
 		}
 	}
@@ -446,7 +446,7 @@ void CastleMoves(const Position& position, std::vector<Move>& moves)
 		{
 			if (!IsSquareThreatened(position, SQ_E8, position.GetTurn()) && !IsSquareThreatened(position, SQ_D8, position.GetTurn()) && !IsSquareThreatened(position, SQ_C8, position.GetTurn()))
 			{
-				moves.emplace_back(Move(SQ_E8, SQ_C8, QUEEN_CASTLE));
+				moves.emplace_back(SQ_E8, SQ_C8, QUEEN_CASTLE);
 			}
 		}
 	}


### PR DESCRIPTION
```
ELO   | 3.40 +- 2.70 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 26096 W: 5504 L: 5249 D: 15343
```
This patch previously failed, but after https://github.com/KierenP/Halogen/pull/269 the Move class now can use move semantics which likely helps? 