### PR TITLE
Fix MultiPV when the number of legal moves is lower

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -58,7 +58,7 @@ SearchResult Quiescence(Position& position, unsigned int initialDepth, int alpha
 
 void InitSearch();
 
-uint64_t SearchThread(const Position& position, const SearchParameters& parameters, const SearchLimits& limits, bool noOutput)
+uint64_t SearchThread(Position position, SearchParameters parameters, const SearchLimits& limits, bool noOutput)
 {
 	//Probe TB at root
 	if (GetBitCount(position.GetAllPieces()) <= TB_LARGEST 
@@ -74,6 +74,11 @@ uint64_t SearchThread(const Position& position, const SearchParameters& paramete
 			return 0;
 		}
 	}
+
+	//Limit the MultiPV setting to be at most the number of legal moves
+	std::vector<ExtendedMove> moves;
+	LegalMoves(position, moves);
+	parameters.multiPV = std::min<int>(parameters.multiPV, moves.size());
 
 	InitSearch();
 

--- a/Halogen/src/Search.h
+++ b/Halogen/src/Search.h
@@ -40,4 +40,4 @@ private:
 	Move m_move;
 };
 
-uint64_t SearchThread(const Position& position, const SearchParameters& parameters, const SearchLimits& limits, bool noOutput = false);
+uint64_t SearchThread(Position position, SearchParameters parameters, const SearchLimits& limits, bool noOutput = false);

--- a/Halogen/src/SearchData.cpp
+++ b/Halogen/src/SearchData.cpp
@@ -36,7 +36,7 @@ void ThreadSharedData::ReportResult(unsigned int depth, double Time, int score, 
 {
 	std::scoped_lock lock(ioMutex);
 
-	if (alpha < score && score < beta && depth > threadDepthCompleted && (!MultiPVExcludeMoveUnlocked(move) || move.IsUninitialized()))	//if uninitialized, MultiPV setting was higher than the number of legal moves
+	if (alpha < score && score < beta && depth > threadDepthCompleted && !MultiPVExcludeMoveUnlocked(move))
 	{
 		if (!noOutput)
 			PrintSearchInfo(depth, Time, abs(score) > 9000, score, alpha, beta, position, move, locals);

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char* argv[])
 			if (searchThread.joinable())
 				searchThread.join();
 
-			searchThread = thread([=, &limits] {SearchThread(position, parameters, limits); });
+			searchThread = thread([=] {SearchThread(position, parameters, limits); });
 		}
 
 		else if (token == "setoption")

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char* argv[])
 			if (searchThread.joinable())
 				searchThread.join();
 
-			searchThread = thread([&position, &parameters, limits] {SearchThread(position, parameters, limits); });
+			searchThread = thread([=, &limits] {SearchThread(position, parameters, limits); });
 		}
 
 		else if (token == "setoption")


### PR DESCRIPTION
```
ELO   | -0.69 +- 1.99 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 48020 W: 9849 L: 9944 D: 28227
```