### PR TITLE
Scale the network during initialization

### DIFF
--- a/Halogen/src/BitBoardDefine.h
+++ b/Halogen/src/BitBoardDefine.h
@@ -13,9 +13,6 @@
 #define NOMINMAX
 #endif
 
-#define UNIT_TEST_BEGIN(name) namespace name {
-#define UNIT_TEST_END(name) }
-
 enum Square
 {
 	SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1,

--- a/Halogen/src/EvalNet.cpp
+++ b/Halogen/src/EvalNet.cpp
@@ -10,7 +10,6 @@ int EvaluatePositionNet(const Position& position, EvalCacheTable& evalTable)
     {
         eval = position.GetEvaluation();
 
-        NetworkScaleAdjustment(eval);
         NoPawnAdjustment(eval, position);
         TempoAdjustment(eval, position);
 
@@ -53,7 +52,8 @@ bool DeadPosition(const Position& position)
     return false;
 }
 
-UNIT_TEST_BEGIN(UnitTestEvalNet)
+namespace UnitTestEvalNet
+{
 
 void TempoAdjustment(int& eval, const Position& position)
 {
@@ -69,12 +69,7 @@ void NoPawnAdjustment(int& eval, const Position& position)
         eval /= 2;
 }
 
-void NetworkScaleAdjustment(int& eval)
-{
-    eval = eval * 94 / 100;
 }
-
-UNIT_TEST_END(UnitTestEvalNet);
 
 
 

--- a/Halogen/src/EvalNet.h
+++ b/Halogen/src/EvalNet.h
@@ -11,7 +11,6 @@ int EvaluatePositionNet(const Position& position, EvalCacheTable& evalTable);
 namespace UnitTestEvalNet
 {
 	void NoPawnAdjustment(int& eval, const Position& position);
-	void NetworkScaleAdjustment(int& eval);
 	void TempoAdjustment(int& eval, const Position& position);
 }
 

--- a/Halogen/src/Network.cpp
+++ b/Halogen/src/Network.cpp
@@ -6,6 +6,11 @@ std::array<int16_t, HIDDEN_NEURONS> Network::hiddenBias = {};
 std::array<int16_t, HIDDEN_NEURONS> Network::outputWeights = {};
 int16_t Network::outputBias = {};
 
+constexpr int16_t MAX_VALUE = 128;
+constexpr int16_t PRECISION = ((size_t)std::numeric_limits<int16_t>::max() + 1) / MAX_VALUE;
+constexpr int32_t SQUARE_PRECISION = (int32_t)PRECISION * PRECISION;
+constexpr double SCALE_FACTOR = 0.94;   //Found empirically to maximize elo
+
 template<typename T, size_t SIZE>
 [[nodiscard]] std::array<T, SIZE> ReLU(const std::array<T, SIZE>& source)
 {
@@ -35,10 +40,10 @@ void Network::Init()
         for (size_t j = 0; j < HIDDEN_NEURONS; j++)
             hiddenWeights[i][j] = (int16_t)round(*Data++ * PRECISION);
 
-    outputBias = (int16_t)round(*Data++ * PRECISION);
+    outputBias = (int16_t)round(*Data++ * SCALE_FACTOR * PRECISION);
 
     for (size_t i = 0; i < HIDDEN_NEURONS; i++)
-        outputWeights[i] = (int16_t)round(*Data++ * PRECISION);
+        outputWeights[i] = (int16_t)round(*Data++ * SCALE_FACTOR * PRECISION);
 
     //Swap the first half with last half to swap white and black inputs
     //Because Andrew's trainer goes WHITE, BLACK but Halogen goes BLACK, WHITE

--- a/Halogen/src/Network.h
+++ b/Halogen/src/Network.h
@@ -16,12 +16,6 @@
 constexpr size_t INPUT_NEURONS = 12 * 64;
 constexpr size_t HIDDEN_NEURONS = 512;
 
-constexpr int16_t MAX_VALUE = 128;
-constexpr int16_t PRECISION = ((size_t)std::numeric_limits<int16_t>::max() + 1) / MAX_VALUE;
-constexpr int32_t SQUARE_PRECISION = (int32_t)PRECISION * PRECISION;
-constexpr int32_t HALF_SQUARE_PRECISION = SQUARE_PRECISION / 2;
-constexpr int16_t HALF_PRECISION = PRECISION / 2;
-
 struct deltaArray
 {
     struct deltaPoint

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.3.3";
+string version = "10.3.4";
 
 int main(int argc, char* argv[])
 {

--- a/HalogenTests/TestEvalNet.cpp
+++ b/HalogenTests/TestEvalNet.cpp
@@ -55,24 +55,6 @@ namespace EvalNet
 		}
 	};
 
-	TEST_CLASS(networkScaleAdjustment)
-	{
-	public:
-		TEST_METHOD(SmallValue)
-		{
-			int value = 20;
-			NetworkScaleAdjustment(value);
-			Assert::AreEqual(18, value);
-		}
-
-		TEST_METHOD(LargeValue)
-		{
-			int value = 2000;
-			NetworkScaleAdjustment(value);
-			Assert::AreEqual(1880, value);
-		}
-	};
-
 	TEST_CLASS(tempoAdjustment)
 	{
 	public:


### PR DESCRIPTION
```
ELO   | 0.08 +- 2.59 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.03 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 27354 W: 5446 L: 5440 D: 16468
```