### PR TITLE
Extend all checks

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -509,11 +509,8 @@ int extension(const Position& position, int alpha, int beta)
 {
 	int extension = 0;
 
-	if (IsPV(beta, alpha))
-	{
-		if (IsSquareThreatened(position, position.GetKing(position.GetTurn()), position.GetTurn()))	
-			extension += 1;
-	}
+	if (IsSquareThreatened(position, position.GetKing(position.GetTurn()), position.GetTurn()))	
+		extension += 1;
 
 	return extension;
 }

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.5";
+string version = "10.6";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 6.37 +- 4.12 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8232 W: 1318 L: 1167 D: 5747
```
```
ELO   | 3.80 +- 3.02 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20304 W: 4178 L: 3956 D: 12170
```