### PR TITLE
Randomize draw scores

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -244,7 +244,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	}
 
 	//Query the transpotition table
-	if (true /*!IsPV(beta, alpha)*/) 
+	if (!IsPV(beta, alpha)) 
 	{
 		TTEntry entry = tTable.GetEntry(position.GetZobristKey(), distanceFromRoot);
 		if (CheckEntry(entry, position.GetZobristKey(), depthRemaining))

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -198,9 +198,11 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	//See if we should abort the search
 	if (initialDepth > 1 && locals.limits.CheckTimeLimit()) return -1;	//Am I out of time?
 	if (sharedData.ThreadAbort(initialDepth)) return -1;				//Has this depth been finished by another thread?
-	if (DeadPosition(position)) return 0;								//Is this position a dead draw?
-	if (CheckForRep(position, distanceFromRoot)) return 0;				//Have we had a draw by repitition?
-	if (position.GetFiftyMoveCount() > 100) return 0;					//cannot use >= as it could currently be checkmate which would count as a win
+
+	if (DeadPosition(position)											//Is this position a dead draw?
+		|| CheckForRep(position, distanceFromRoot)						//Have we had a draw by repitition?
+		|| position.GetFiftyMoveCount() > 100)							//cannot use >= as it could currently be checkmate which would count as a win
+		return 8 - locals.GetThreadNodes() & 0b1111;
 	
 	int Score = LowINF;
 	int MaxScore = HighINF;
@@ -242,7 +244,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	}
 
 	//Query the transpotition table
-	if (!IsPV(beta, alpha)) 
+	if (true /*!IsPV(beta, alpha)*/) 
 	{
 		TTEntry entry = tTable.GetEntry(position.GetZobristKey(), distanceFromRoot);
 		if (CheckEntry(entry, position.GetZobristKey(), depthRemaining))

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -202,7 +202,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	if (DeadPosition(position)) return 0;								//Is this position a dead draw?
 	if (CheckForRep(position, distanceFromRoot)							//Have we had a draw by repitition?
 		|| position.GetFiftyMoveCount() > 100)							//cannot use >= as it could currently be checkmate which would count as a win
-		return 8 - locals.GetThreadNodes() & 0b1111;
+		return 8 - (locals.GetThreadNodes() & 0b1111);
 	
 	int Score = LowINF;
 	int MaxScore = HighINF;

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -202,7 +202,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	if (DeadPosition(position)) return 0;								//Is this position a dead draw?
 	if (CheckForRep(position, distanceFromRoot)							//Have we had a draw by repitition?
 		|| position.GetFiftyMoveCount() > 100)							//cannot use >= as it could currently be checkmate which would count as a win
-		return 8 - (locals.GetThreadNodes() & 0b1111);
+		return 8 - (locals.GetThreadNodes() & 0b1111);					//as in https://github.com/Luecx/Koivisto/commit/c8f01211c290a582b69e4299400b667a7731a9f7 with permission from Koivisto authors. 
 	
 	int Score = LowINF;
 	int MaxScore = HighINF;

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -199,8 +199,8 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	if (initialDepth > 1 && locals.limits.CheckTimeLimit()) return -1;	//Am I out of time?
 	if (sharedData.ThreadAbort(initialDepth)) return -1;				//Has this depth been finished by another thread?
 
-	if (DeadPosition(position)											//Is this position a dead draw?
-		|| CheckForRep(position, distanceFromRoot)						//Have we had a draw by repitition?
+	if (DeadPosition(position)) return 0;								//Is this position a dead draw?
+	if (CheckForRep(position, distanceFromRoot)							//Have we had a draw by repitition?
 		|| position.GetFiftyMoveCount() > 100)							//cannot use >= as it could currently be checkmate which would count as a win
 		return 8 - locals.GetThreadNodes() & 0b1111;
 	

--- a/Halogen/src/SearchData.h
+++ b/Halogen/src/SearchData.h
@@ -70,6 +70,8 @@ public:
 
 	void AddHistory(Players side, Square from, Square to, int change);
 
+	uint64_t GetThreadNodes() const { return nodes; }
+
 private:
 	friend class ThreadSharedData;
 	uint64_t tbHits = 0;

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.6";
+string version = "10.7";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Based on https://github.com/Luecx/Koivisto/commit/c8f01211c290a582b69e4299400b667a7731a9f7

The idea of draw randomization originated in Stockfish. The implementation is very similar, but the idea behind this patch is based on a different idea, namely the Beal effect. While the idea is based on The Beal effect, it is important to keep in mind that only limited testing has been done and the real reason behind the elo gain is still open to interpretation. It is also important to note that this is the first version tried in Koivisto, so tuning/tweaks are likely possible.  Variations on the range (currently a range of 16 score grain) need to be tested. 

Elo tests in Halogen:
http://chess.grantnet.us/test/10830/
ELO   | 6.20 +- 4.40 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9920 W: 2144 L: 1967 D: 5809

http://chess.grantnet.us/test/10832/
ELO   | 3.76 +- 2.85 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16552 W: 2490 L: 2311 D: 11751

For more information on the Beal effect, see https://www.chessprogramming.org/Search_with_Random_Leaf_Values