### PR TITLE
Adjust EGTB scores when storing in transposition table

### DIFF
--- a/Halogen/src/BitBoardDefine.h
+++ b/Halogen/src/BitBoardDefine.h
@@ -145,6 +145,20 @@ enum GameStages
 	N_STAGES
 };
 
+enum Score
+{
+	HighINF = 30000,
+	LowINF = -30000,
+
+	MATED = -10000,
+	TB_LOSS_SCORE = -5000,
+	EVAL_MIN = -4000,
+	DRAW = 0,
+	EVAL_MAX = 4000,
+	TB_WIN_SCORE = 5000,
+	MATE = 10000
+};
+
 void BBInit();
 int GetBitCount(uint64_t bb);
 

--- a/Halogen/src/EvalNet.cpp
+++ b/Halogen/src/EvalNet.cpp
@@ -16,7 +16,7 @@ int EvaluatePositionNet(const Position& position, EvalCacheTable& evalTable)
         evalTable.AddEntry(position.GetZobristKey(), eval);
     }
 
-    return std::min(4000, std::max(-4000, eval));
+    return std::min<int>(EVAL_MAX, std::max<int>(EVAL_MIN, eval));
 }
 
 bool DeadPosition(const Position& position)

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -230,6 +230,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 			if (result == TB_WIN)
 			{
 				MinScore = probe.GetScore();
+				alpha = std::max(alpha, MinScore);
 			}
 
 			if (result == TB_LOSS)

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -230,7 +230,6 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 			if (result == TB_WIN)
 			{
 				MinScore = probe.GetScore();
-				alpha = std::max(alpha, MinScore);
 			}
 
 			if (result == TB_LOSS)

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -40,10 +40,10 @@ void AddKiller(Move move, int distanceFromRoot, std::vector<std::array<Move, 2>>
 void AddHistory(const MoveGenerator& gen, const Move& move, SearchData& locals, int depthRemaining);
 void UpdatePV(Move move, int distanceFromRoot, std::vector<std::vector<Move>>& PvTable);
 int Reduction(int depth, int i);
-int matedIn(int distanceFromRoot);
-int mateIn(int distanceFromRoot);
-int TBLossIn(int distanceFromRoot);
-int TBWinIn(int distanceFromRoot);
+constexpr int matedIn(int distanceFromRoot);
+constexpr int mateIn(int distanceFromRoot);
+constexpr int TBLossIn(int distanceFromRoot);
+constexpr int TBWinIn(int distanceFromRoot);
 unsigned int ProbeTBRoot(const Position& position);
 unsigned int ProbeTBSearch(const Position& position);
 SearchResult UseSearchTBScore(unsigned int result, int distanceFromRoot);
@@ -420,15 +420,15 @@ SearchResult UseSearchTBScore(unsigned int result, int distanceFromRoot)
 	int score = -1;
 
 	if (result == TB_LOSS)
-		score = -5000 + distanceFromRoot;
+		score = TBLossIn(distanceFromRoot);
 	else if (result == TB_BLESSED_LOSS)
-		score = 0;
+		score = -1;
 	else if (result == TB_DRAW)
 		score = 0;
 	else if (result == TB_CURSED_WIN)
-		score = 0;
+		score = 1;
 	else if (result == TB_WIN)
-		score = 5000 - distanceFromRoot;
+		score = TBWinIn(distanceFromRoot);
 	else
 		assert(0);
 
@@ -588,22 +588,22 @@ int TerminalScore(const Position& position, int distanceFromRoot)
 	}
 }
 
-int matedIn(int distanceFromRoot)
+constexpr int matedIn(int distanceFromRoot)
 {
 	return MATED + distanceFromRoot;
 }
 
-int mateIn(int distanceFromRoot)
+constexpr int mateIn(int distanceFromRoot)
 {
 	return MATE - distanceFromRoot;
 }
 
-int TBLossIn(int distanceFromRoot)
+constexpr int TBLossIn(int distanceFromRoot)
 {
 	return TB_LOSS_SCORE + distanceFromRoot;
 }
 
-int TBWinIn(int distanceFromRoot)
+constexpr int TBWinIn(int distanceFromRoot)
 {
 	return TB_WIN_SCORE - distanceFromRoot;
 }

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -228,6 +228,26 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 			if (probe.GetScore() <= TBLossIn(MAX_DEPTH) && probe.GetScore() <= alpha)
 				return probe;
 
+			// Why update score ?
+			// Because in a PV node we want the returned score to be accurate and reflect the TB score.
+			// As such, we either set a cap for the score or raise the score to a minimum which can be further improved.
+			// Remember, static evals will never reach these impossible tb-win/loss scores
+
+			// Why don't we update score in non-PV nodes?
+			// Because if we are in a non-pv node and didn't get a cutoff then we had one of two situations:
+			// 1. We found a tb - win which is further from root than a tb - win from another line
+			// 2. We found a tb - loss which is closer to root than a tb - loss from another line
+			// Either way this node won't become part of the PV and so getting the correct score doesn't matter
+
+			// Why do we update alpha?
+			// Because we are spending effort exploring a subtree when we already know the result. All we actually
+			// care about is whether there exists a forced mate or not from this node, and hence we raise alpha
+			// to an impossible goal that prunes away all non-mate scores.
+
+			// Why don't we raise alpha in non-pv nodes?
+			// Because if we had a tb-win and the score < beta, then it must also be <= alpha remembering we are in a
+			// zero width search and beta = alpha + 1.
+
 			if (IsPV(beta, alpha))
 			{
 				if (probe.GetScore() >= TBWinIn(MAX_DEPTH))

--- a/Halogen/src/SearchData.h
+++ b/Halogen/src/SearchData.h
@@ -6,18 +6,6 @@
 
 extern TranspositionTable tTable;
 
-enum Score
-{
-	HighINF = 30000,
-	LowINF = -30000,
-
-	MATED = -10000,
-	TB_LOSS_SCORE = -5000,
-	DRAW = 0,
-	TB_WIN_SCORE = 5000,
-	MATE = 10000
-};
-
 class SearchLimits
 {
 public:

--- a/Halogen/src/TTEntry.cpp
+++ b/Halogen/src/TTEntry.cpp
@@ -24,7 +24,8 @@ TTEntry::TTEntry(Move best, uint64_t ZobristKey, int Score, int Depth, int curre
 
 void TTEntry::MateScoreAdjustment(int distanceFromRoot)
 {
-	if (score > EVAL_MAX)	//checkmate node
+	//checkmate node or TB win/loss
+	if (score > EVAL_MAX)	
 		score -= static_cast<short>(distanceFromRoot);
 	if (score < EVAL_MIN)
 		score += static_cast<short>(distanceFromRoot);

--- a/Halogen/src/TTEntry.cpp
+++ b/Halogen/src/TTEntry.cpp
@@ -24,9 +24,9 @@ TTEntry::TTEntry(Move best, uint64_t ZobristKey, int Score, int Depth, int curre
 
 void TTEntry::MateScoreAdjustment(int distanceFromRoot)
 {
-	if (score > 9000)	//checkmate node
+	if (score > EVAL_MAX)	//checkmate node
 		score -= static_cast<short>(distanceFromRoot);
-	if (score < -9000)
+	if (score < EVAL_MIN)
 		score += static_cast<short>(distanceFromRoot);
 }
 

--- a/Halogen/src/TranspositionTable.cpp
+++ b/Halogen/src/TranspositionTable.cpp
@@ -19,7 +19,8 @@ void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, int Sco
 {
 	size_t hash = HashFunction(ZobristKey);
 
-	if (Score > EVAL_MAX)	//checkmate node or TB win/loss
+	//checkmate node or TB win/loss
+	if (Score > EVAL_MAX)	
 		Score += distanceFromRoot;
 	if (Score < EVAL_MIN)
 		Score -= distanceFromRoot;

--- a/Halogen/src/TranspositionTable.cpp
+++ b/Halogen/src/TranspositionTable.cpp
@@ -19,9 +19,9 @@ void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, int Sco
 {
 	size_t hash = HashFunction(ZobristKey);
 
-	if (Score > 9000)	//checkmate node
+	if (Score > EVAL_MAX)	//checkmate node or TB win/loss
 		Score += distanceFromRoot;
-	if (Score < -9000)
+	if (Score < EVAL_MIN)
 		Score -= distanceFromRoot;
 
 	for (auto& entry : table[hash].entry)

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.7";
+string version = "10.8";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Without Syzygy:
```
ELO   | 0.21 +- 2.77 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 24520 W: 4987 L: 4972 D: 14561
```
With Syzygy:
```
ELO   | 1.78 +- 3.74 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 13272 W: 2693 L: 2625 D: 7954
```