### PR TITLE
Add late move pruning

### DIFF
--- a/Halogen/src/MoveGenerator.cpp
+++ b/Halogen/src/MoveGenerator.cpp
@@ -93,6 +93,9 @@ bool MoveGenerator::Next(Move& move)
 		}
 	}
 
+	if (skipQuiets)
+		return false;
+
 	if (stage == Stage::GEN_QUIET)
 	{
 		legalMoves.clear();
@@ -124,6 +127,11 @@ void MoveGenerator::AdjustHistory(const Move& move, SearchData& Locals, int dept
 		if (m.move == move) break;
 		Locals.AddHistory(position.GetTurn(), m.move.GetFrom(), m.move.GetTo(), -depthRemaining * depthRemaining);
 	}
+}
+
+void MoveGenerator::SkipQuiets()
+{
+	skipQuiets = true;
 }
 
 void selection_sort(std::vector<ExtendedMove>& v)

--- a/Halogen/src/MoveGenerator.h
+++ b/Halogen/src/MoveGenerator.h
@@ -22,6 +22,8 @@ public:
 
 	void AdjustHistory(const Move& move, SearchData& Locals, int depthRemaining) const;
 
+	void SkipQuiets();
+
 private:
 	void OrderMoves(std::vector<ExtendedMove>& moves);
 
@@ -39,6 +41,8 @@ private:
 	Move TTmove;
 	Move Killer1;
 	Move Killer2;
+
+	bool skipQuiets = false;
 };
 
 Move GetHashMove(const Position& position, int depthRemaining, int distanceFromRoot);

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -25,6 +25,13 @@ constexpr int FutilityMaxDepth = 10;
 int FutilityMargins[FutilityMaxDepth];		//[depth]
 int LMR_reduction[64][64] = {};				//[depth][move number]
 
+constexpr int LMPLimit[] = { 1, 3, 6, 10, 15, 21 };
+
+//intentionally uses signed rather than unsigned
+//as size() will be compared to signed types
+template<class T, int N>
+constexpr int size(T(&)[N]) { return N; }
+
 void PrintBestMove(Move Best);
 bool UseTransposition(const TTEntry& entry, int alpha, int beta);
 bool CheckForRep(const Position& position, int distanceFromRoot);
@@ -344,6 +351,10 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 
 		noLegalMoves = false;
 		locals.AddNode();
+
+		// late move pruning
+		if (depthRemaining < size(LMPLimit) && searchedMoves >= LMPLimit[std::max(0, depthRemaining)] && Score > TBLossIn(MAX_DEPTH))
+			gen.SkipQuiets();
 
 		//futility pruning
 		if (IsFutile(move, beta, alpha, position, InCheck) && searchedMoves > 0 && FutileNode)	//Possibly stop futility pruning if alpha or beta are close to mate scores

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -25,7 +25,7 @@ constexpr int FutilityMaxDepth = 10;
 int FutilityMargins[FutilityMaxDepth];		//[depth]
 int LMR_reduction[64][64] = {};				//[depth][move number]
 
-constexpr int LMPLimit[] = { 1, 3, 6, 10, 15, 21 };
+constexpr int LMPLimit[] = { 10, 17, 24, 31, 38, 45 };
 
 //intentionally uses signed rather than unsigned
 //as size() will be compared to signed types

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.8.1";
+string version = "10.9";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 13.87 +- 6.49 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3384 W: 590 L: 455 D: 2339
```
```
ELO   | 5.47 +- 4.01 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11696 W: 2471 L: 2287 D: 6938
```