### PR TITLE
Ignore negative depth for futility pruning and late move pruning

### DIFF
--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -311,7 +311,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 	if (GetHashMove(position, distanceFromRoot).IsUninitialized() && depthRemaining > 3)
 		depthRemaining--;
 
-	bool FutileNode = depthRemaining < Futility_depth && staticScore + Futility_constant + Futility_coeff * std::max(0, depthRemaining) < a;
+	bool FutileNode = depthRemaining < Futility_depth && staticScore + Futility_constant + Futility_coeff * depthRemaining < a;
 
 	MoveGenerator gen(position, distanceFromRoot, locals, false);
 	Move move;
@@ -325,7 +325,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 		locals.AddNode();
 
 		// late move pruning
-		if (depthRemaining < LMP_depth && searchedMoves >= LMP_constant + LMP_coeff * std::max(0, depthRemaining) && Score > TBLossIn(MAX_DEPTH))
+		if (depthRemaining < LMP_depth && searchedMoves >= LMP_constant + LMP_coeff * depthRemaining && Score > TBLossIn(MAX_DEPTH))
 			gen.SkipQuiets();
 
 		//futility pruning

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.9.1";
+string version = "10.9.2";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 5.41 +- 5.38 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 6488 W: 1369 L: 1268 D: 3851
```