### PR TITLE
Expand the maximum range for evaluation scores

### DIFF
--- a/Halogen/src/BitBoardDefine.h
+++ b/Halogen/src/BitBoardDefine.h
@@ -151,12 +151,15 @@ enum Score
 	LowINF = -30000,
 
 	MATED = -10000,
-	TB_LOSS_SCORE = -5000,
-	EVAL_MIN = -4000,
+	MATE = 10000,
+
+	TB_LOSS_SCORE = -9900,
+	TB_WIN_SCORE = 9900,
+
+	EVAL_MIN = -9800,
+	EVAL_MAX = 9800,
+
 	DRAW = 0,
-	EVAL_MAX = 4000,
-	TB_WIN_SCORE = 5000,
-	MATE = 10000
 };
 
 void BBInit();

--- a/Halogen/src/SearchData.cpp
+++ b/Halogen/src/SearchData.cpp
@@ -39,7 +39,7 @@ void ThreadSharedData::ReportResult(unsigned int depth, double Time, int score, 
 	if (alpha < score && score < beta && depth > threadDepthCompleted && !MultiPVExcludeMoveUnlocked(move))
 	{
 		if (!noOutput)
-			PrintSearchInfo(depth, Time, abs(score) > 9000, score, alpha, beta, position, move, locals);
+			PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, move, locals);
 
 		if (GetMultiPVCount() == 0)
 		{
@@ -60,13 +60,13 @@ void ThreadSharedData::ReportResult(unsigned int depth, double Time, int score, 
 
 	if (score < lowestAlpha && score <= alpha && !noOutput && Time > 5000 && depth == threadDepthCompleted + 1)
 	{
-		PrintSearchInfo(depth, Time, abs(score) > 9000, score, alpha, beta, position, move, locals);
+		PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, move, locals);
 		lowestAlpha = alpha;
 	}
 
 	if (score > highestBeta && score >= beta && !noOutput && Time > 5000 && depth == threadDepthCompleted + 1)
 	{
-		PrintSearchInfo(depth, Time, abs(score) > 9000, score, alpha, beta, position, move, locals);
+		PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, move, locals);
 		highestBeta = beta;
 	}
 }


### PR DESCRIPTION
```
ELO   | 1.55 +- 3.66 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 14088 W: 2909 L: 2846 D: 8333
```