### PR TITLE
Implement a move list pool

### DIFF
--- a/Halogen/src/MoveGenerator.cpp
+++ b/Halogen/src/MoveGenerator.cpp
@@ -1,9 +1,9 @@
 #include "MoveGenerator.h"
 
-MoveGenerator::MoveGenerator(Position& Position, int DistanceFromRoot, const SearchData& Locals, MoveList& MoveList, bool Quiescence) :
-	position(Position), distanceFromRoot(DistanceFromRoot), locals(Locals), moveList(MoveList), quiescence(Quiescence)
+MoveGenerator::MoveGenerator(Position& Position, int DistanceFromRoot, const SearchData& Locals, MoveListPool::MoveListPtr MoveList, bool Quiescence) :
+	position(Position), distanceFromRoot(DistanceFromRoot), locals(Locals), moveList(std::move(MoveList)), quiescence(Quiescence)
 {
-	moveList.clear();
+	moveList->clear();
 
 	if (quiescence)
 		stage = Stage::GEN_LOUD;
@@ -29,22 +29,22 @@ bool MoveGenerator::Next(Move& move)
 	{
 		if (!quiescence && IsInCheck(position))
 		{
-			LegalMoves(position, moveList);	//contains a special function for generating moves when in check which is quicker
+			LegalMoves(position, *moveList);	//contains a special function for generating moves when in check which is quicker
 			stage = Stage::GIVE_QUIET;
 		}
 		else
 		{
-			QuiescenceMoves(position, moveList);
+			QuiescenceMoves(position, *moveList);
 			stage = Stage::GIVE_GOOD_LOUD;
 		}
 
-		OrderMoves(moveList);
-		current = moveList.begin();
+		OrderMoves(*moveList);
+		current = moveList->begin();
 	}
 
 	if (stage == Stage::GIVE_GOOD_LOUD)
 	{
-		if (current != moveList.end() && current->SEE >= 0)
+		if (current != moveList->end() && current->SEE >= 0)
 		{
 			move = current->move;
 			++current;
@@ -83,7 +83,7 @@ bool MoveGenerator::Next(Move& move)
 
 	if (stage == Stage::GIVE_BAD_LOUD)
 	{
-		if (current != moveList.end())
+		if (current != moveList->end())
 		{
 			move = current->move;
 			++current;
@@ -100,16 +100,16 @@ bool MoveGenerator::Next(Move& move)
 
 	if (stage == Stage::GEN_QUIET)
 	{
-		moveList.clear();
-		QuietMoves(position, moveList);
-		OrderMoves(moveList);
-		current = moveList.begin();
+		moveList->clear();
+		QuietMoves(position, *moveList);
+		OrderMoves(*moveList);
+		current = moveList->begin();
 		stage = Stage::GIVE_QUIET;
 	}
 
 	if (stage == Stage::GIVE_QUIET)
 	{
-		if (current != moveList.end())
+		if (current != moveList->end())
 		{
 			move = current->move;
 			++current;
@@ -124,7 +124,7 @@ void MoveGenerator::AdjustHistory(const Move& move, SearchData& Locals, int dept
 {
 	Locals.AddHistory(position.GetTurn(), move.GetFrom(), move.GetTo(), depthRemaining * depthRemaining);
 
-	for (auto const& m : moveList)
+	for (auto const& m : *moveList)
 	{
 		if (m.move == move) break;
 		Locals.AddHistory(position.GetTurn(), m.move.GetFrom(), m.move.GetTo(), -depthRemaining * depthRemaining);

--- a/Halogen/src/MoveGenerator.h
+++ b/Halogen/src/MoveGenerator.h
@@ -16,7 +16,8 @@ enum class Stage
 class MoveGenerator
 {
 public:
-	MoveGenerator(Position& Position, int DistanceFromRoot, const SearchData& Locals, MoveList& MoveList, bool Quiescence);
+	MoveGenerator(Position& Position, int DistanceFromRoot, const SearchData& Locals, MoveListPool::MoveListPtr MoveList, bool Quiescence);
+
 	bool Next(Move& move);	//returns false if no more legal moves
 	int GetSEE() const { return (current - 1)->SEE; }
 
@@ -32,7 +33,7 @@ private:
 	int distanceFromRoot;
 	const SearchData& locals;
 	bool quiescence;
-	MoveList& moveList;
+	MoveListPool::MoveListPtr moveList;
 
 	//Data uses for keeping track of internal values
 	Stage stage;

--- a/Halogen/src/MoveList.h
+++ b/Halogen/src/MoveList.h
@@ -2,6 +2,7 @@
 #include "Move.h"
 #include <array>
 #include <functional>
+#include <memory>
 
 // For move ordering we need to bundle the 'score' and SEE values
 // with the move objects

--- a/Halogen/src/MoveList.h
+++ b/Halogen/src/MoveList.h
@@ -80,9 +80,7 @@ private:
 	std::array<MoveList, MAX_DEPTH * 2> lists;
 	size_t listCount = 0;
 
-	void Free(MoveList*) { listCount--; }
-
 public:
 	using MoveListPtr = std::unique_ptr<MoveList, std::function<void(MoveList*)>>;
-	auto Get() { return MoveListPtr(&lists[listCount++], [this](MoveList*) { Free(nullptr); }); }
+	auto Get() { return MoveListPtr(&lists[listCount++], [this](MoveList*) { listCount--; }); }
 };

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -313,7 +313,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 
 	bool FutileNode = depthRemaining < Futility_depth && staticScore + Futility_constant + Futility_coeff * depthRemaining < a;
 
-	MoveGenerator gen(position, distanceFromRoot, locals, locals.moveList[distanceFromRoot], false);
+	MoveGenerator gen(position, distanceFromRoot, locals, locals.moveListStack.Get(), false);
 	Move move;
 
 	for (searchedMoves = 0; gen.Next(move); searchedMoves++)
@@ -630,7 +630,7 @@ SearchResult Quiescence(Position& position, unsigned int initialDepth, int alpha
 	Move bestmove;
 	int Score = staticScore;
 
-	MoveGenerator gen(position, distanceFromRoot, locals, locals.moveList[distanceFromRoot], true);
+	MoveGenerator gen(position, distanceFromRoot, locals, locals.moveListStack.Get(), true);
 	Move move;
 
 	while (gen.Next(move))

--- a/Halogen/src/SearchData.h
+++ b/Halogen/src/SearchData.h
@@ -53,7 +53,7 @@ public:
 	
 	EvalCacheTable evalTable;
 	SearchLimits limits;
-	std::array<MoveList, MAX_DEPTH> moveList;
+	MoveListPool moveListStack;
 
 	void AddNode() { nodes++; }
 	void AddTbHit() { tbHits++; }


### PR DESCRIPTION
```
ELO   | -2.69 +- 2.11 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | -2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 41232 W: 8058 L: 8377 D: 24797
```
This loses elo but is necessary to allow singular extensions and bugs in the future.