### PR TITLE
Make the Move class trivial

### DIFF
--- a/Halogen/src/Move.cpp
+++ b/Halogen/src/Move.cpp
@@ -69,11 +69,6 @@ void Move::Print() const
 	std::cout << str.str();
 }
 
-bool Move::operator==(const Move& rhs) const
-{
-	return (data == rhs.data);
-}
-
 void Move::SetFrom(Square from)
 {
 	data &= ~FROM_MASK;

--- a/Halogen/src/Move.cpp
+++ b/Halogen/src/Move.cpp
@@ -1,16 +1,12 @@
 #include "Move.h"
 
-const unsigned int CAPTURE_MASK = 1 << 14;		// 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-const unsigned int PROMOTION_MASK = 1 << 15;	// 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-const unsigned int FROM_MASK = 0b111111;		// 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1
-const unsigned int TO_MASK = 0b111111 << 6;		// 0 0 0 0 1 1 1 1 1 1 0 0 0 0 0 0
-const unsigned int FLAG_MASK = 0b1111 << 12;	// 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 
+constexpr int CAPTURE_MASK = 1 << 14;	// 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+constexpr int PROMOTION_MASK = 1 << 15;	// 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+constexpr int FROM_MASK = 0b111111;		// 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1
+constexpr int TO_MASK = 0b111111 << 6;	// 0 0 0 0 1 1 1 1 1 1 0 0 0 0 0 0
+constexpr int FLAG_MASK = 0b1111 << 12;	// 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 
 
-Move::Move()
-{
-}
-
-Move::Move(Square from, Square to, MoveFlag flag)
+Move::Move(Square from, Square to, MoveFlag flag) : data(0)
 {
 	assert(from < 64);
 	assert(to < 64);
@@ -20,8 +16,6 @@ Move::Move(Square from, Square to, MoveFlag flag)
 	SetTo(to);
 	SetFlag(flag);
 }
-
-
 
 Square Move::GetFrom() const
 {
@@ -78,11 +72,6 @@ void Move::Print() const
 bool Move::operator==(const Move& rhs) const
 {
 	return (data == rhs.data);
-}
-
-bool Move::IsUninitialized() const
-{
-	return (data == 0);
 }
 
 void Move::SetFrom(Square from)

--- a/Halogen/src/Move.h
+++ b/Halogen/src/Move.h
@@ -47,7 +47,7 @@ public:
 		return (data == rhs.data);
 	}
 
-	static Move Uninitialized;
+	static const Move Uninitialized;
 
 private:
 	void SetFrom(Square from);
@@ -66,5 +66,5 @@ private:
 
 static_assert(std::is_trivial_v<Move>);
 
-inline Move Move::Uninitialized = Move(static_cast<Square>(0), static_cast<Square>(0), static_cast<MoveFlag>(0));
+inline const Move Move::Uninitialized = Move(static_cast<Square>(0), static_cast<Square>(0), static_cast<MoveFlag>(0));
 

--- a/Halogen/src/Move.h
+++ b/Halogen/src/Move.h
@@ -29,7 +29,7 @@ enum MoveFlag
 class Move
 {
 public:
-	Move();
+	Move() = default;
 	Move(Square from, Square to, MoveFlag flag);
 
 	Square GetFrom() const;
@@ -44,7 +44,7 @@ public:
 
 	bool operator==(const Move& rhs) const;
 
-	bool IsUninitialized() const;
+	static Move Uninitialized;
 
 private:
 	void SetFrom(Square from);
@@ -52,7 +52,16 @@ private:
 	void SetFlag(MoveFlag flag);
 
 	//6 bits for 'from square', 6 bits for 'to square' and 4 bits for the 'move flag'
-	uint16_t data = 0;
+	uint16_t data;
 };
 
+// Why do we mandate that Move is trivial and allow the default
+// constructor to have member 'data' be uninitialized? Because
+// we need to allocate arrays of Move objects on the stack
+// millions of times per second and making Move trivial makes
+// the allocation virtually free.
+
+static_assert(std::is_trivial_v<Move>);
+
+inline Move Move::Uninitialized = Move(static_cast<Square>(0), static_cast<Square>(0), static_cast<MoveFlag>(0));
 

--- a/Halogen/src/Move.h
+++ b/Halogen/src/Move.h
@@ -42,7 +42,10 @@ public:
 	void Print(std::stringstream& ss) const;
 	void Print() const;
 
-	bool operator==(const Move& rhs) const;
+	constexpr bool operator==(const Move& rhs) const
+	{
+		return (data == rhs.data);
+	}
 
 	static Move Uninitialized;
 

--- a/Halogen/src/MoveGeneration.cpp
+++ b/Halogen/src/MoveGeneration.cpp
@@ -598,13 +598,13 @@ Move GetSmallestAttackerMove(const Position& position, Square square, Players co
 		return Move(static_cast<Square>(LSBpop(kingmask)), square, CAPTURE);
 	}
 
-	return {};
+	return Move::Uninitialized;
 }
 
 bool MoveIsLegal(Position& position, const Move& move)
 {
 	/*Obvious check first*/
-	if (move.IsUninitialized())
+	if (move == Move::Uninitialized)
 		return false;
 
 	Pieces piece = position.GetSquare(move.GetFrom());

--- a/Halogen/src/MoveGenerator.cpp
+++ b/Halogen/src/MoveGenerator.cpp
@@ -295,7 +295,7 @@ Move GetHashMove(const Position& position, int depthRemaining, int distanceFromR
 		return hash.GetMove();
 	}
 
-	return {};
+	return Move::Uninitialized;
 }
 
 Move GetHashMove(const Position& position, int distanceFromRoot)
@@ -308,5 +308,5 @@ Move GetHashMove(const Position& position, int distanceFromRoot)
 		return hash.GetMove();
 	}
 
-	return {};
+	return Move::Uninitialized;
 }

--- a/Halogen/src/MoveGenerator.h
+++ b/Halogen/src/MoveGenerator.h
@@ -39,9 +39,9 @@ private:
 	Stage stage;
 	MoveList::iterator current;
 
-	Move TTmove;
-	Move Killer1;
-	Move Killer2;
+	Move TTmove = Move::Uninitialized;
+	Move Killer1 = Move::Uninitialized;
+	Move Killer2 = Move::Uninitialized;
 
 	bool skipQuiets = false;
 };

--- a/Halogen/src/MoveGenerator.h
+++ b/Halogen/src/MoveGenerator.h
@@ -16,7 +16,7 @@ enum class Stage
 class MoveGenerator
 {
 public:
-	MoveGenerator(Position& Position, int DistanceFromRoot, const SearchData& Locals, MoveListPool::MoveListPtr MoveList, bool Quiescence);
+	MoveGenerator(Position& Position, int DistanceFromRoot, const SearchData& Locals, bool Quiescence);
 
 	bool Next(Move& move);	//returns false if no more legal moves
 	int GetSEE() const { return (current - 1)->SEE; }
@@ -33,7 +33,7 @@ private:
 	int distanceFromRoot;
 	const SearchData& locals;
 	bool quiescence;
-	MoveListPool::MoveListPtr moveList;
+	MoveList moveList;
 
 	//Data uses for keeping track of internal values
 	Stage stage;

--- a/Halogen/src/MoveList.cpp
+++ b/Halogen/src/MoveList.cpp
@@ -10,6 +10,16 @@ MoveList::iterator MoveList::end()
     return list.begin() + moveCount;
 }
 
+MoveList::const_iterator MoveList::begin() const
+{
+    return list.begin();
+}
+
+MoveList::const_iterator MoveList::end() const
+{
+    return list.begin() + moveCount;
+}
+
 size_t MoveList::size() const
 {
     return moveCount;

--- a/Halogen/src/MoveList.h
+++ b/Halogen/src/MoveList.h
@@ -9,8 +9,10 @@
 struct ExtendedMove
 {
 	ExtendedMove() = default;
-	ExtendedMove(const Move _move, const int _score = 0, const short int _SEE = 0) : move(_move), score(_score), SEE(_SEE) {}
-	ExtendedMove(Square from, Square to, MoveFlag flag) : move(from, to, flag) {}
+	ExtendedMove(const Move _move) : move(_move), score(0), SEE(0) {}
+	ExtendedMove(Square from, Square to, MoveFlag flag) : move(from, to, flag), score(0), SEE(0) {}
+
+	//If you need a constructor that sets score or SEE then feel free to add one.
 
 	bool operator<(const ExtendedMove& rhs) const { return score < rhs.score; };
 	bool operator>(const ExtendedMove& rhs) const { return score > rhs.score; };

--- a/Halogen/src/MoveList.h
+++ b/Halogen/src/MoveList.h
@@ -16,8 +16,8 @@ struct ExtendedMove
 	bool operator>(const ExtendedMove& rhs) const { return score > rhs.score; };
 
 	Move move;
-	int16_t score = 0;
-	int16_t SEE = 0;
+	int16_t score;
+	int16_t SEE;
 };
 
 // Internally, a MoveList is an array
@@ -47,8 +47,10 @@ public:
 	      ExtendedMove& operator[](size_t index)       { return list[index]; }
 
 private:
-	size_t moveCount = 0;
+	size_t moveCount;
 };
+
+static_assert(std::is_trivial_v<MoveList>);
 
 template <typename ...Args>
 inline void MoveList::Append(Args&& ...args)

--- a/Halogen/src/MoveList.h
+++ b/Halogen/src/MoveList.h
@@ -34,9 +34,13 @@ public:
 	void Append(Args&&... args);
 
 	using iterator = decltype(list)::iterator;
+	using const_iterator = decltype(list)::const_iterator;
 
 	iterator begin();
 	iterator end();
+
+	const_iterator begin() const;
+	const_iterator end() const;
 
 	size_t size() const;
 
@@ -57,32 +61,3 @@ inline void MoveList::Append(Args&& ...args)
 {
 	list[moveCount++] = { args... };
 }
-
-// Assumption: We want to use MoveList objects in a LIFO fashion, always throwing away
-// the one that was most recently allocated. Because the search algorithm is recursive, 
-// this is a reasonable assumption.
-
-// Assumption: We won't ever call Get() to get more than MAX_DEPTH * 2 'MoveList's. This is 
-// justified as Get() is only called on each recursion of NegaScout or Quiessence and we
-// should never have more than MAX_DEPTH * 2 recursions. We double MAX_DEPTH because 
-// the assumption is not a strong one and in cases like a null move verification search, we 
-// may recurse without incrementing distanceFromRoot allowing more than MAX_DEPTH recursions
-
-// MoveListStack acts as an object pool of MoveList objects. It is ~300KB in size. It is
-// reasonable to assume this will allow the use of enough MoveList objects simultaneously
-// without running out of space.
-
-// Get() returns a MoveListPtr (unique_ptr). When the unique_ptr is destroyed, it signals
-// the MoveListPool that this MoveList can now be resused automatically. Take care to manage
-// ownership of the unique_ptr to last as long as you need to use the MoveList and no longer.
-
-class MoveListPool
-{
-private:
-	std::array<MoveList, MAX_DEPTH * 2> lists;
-	size_t listCount = 0;
-
-public:
-	using MoveListPtr = std::unique_ptr<MoveList, std::function<void(MoveList*)>>;
-	auto Get() { return MoveListPtr(&lists[listCount++], [this](MoveList*) { listCount--; }); }
-};

--- a/Halogen/src/Position.cpp
+++ b/Halogen/src/Position.cpp
@@ -176,7 +176,7 @@ void Position::ApplyNullMove()
 	Increment50Move();
 
 	NextTurn();
-	IncrementZobristKey(Move());
+	IncrementZobristKey(Move::Uninitialized);
 
 	/*if (GenerateZobristKey() != key)
 	{
@@ -341,7 +341,7 @@ uint64_t Position::IncrementZobristKey(Move move)
 	if (PrevGetEnPassant() <= SQ_H8)
 		key ^= ZobristTable[(12 * 64 + 5 + GetFile(PrevGetEnPassant()))];		//undo the previous ep square
 
-	if (move.IsUninitialized()) return key;	//null move
+	if (move == Move::Uninitialized) return key;	//null move
 
 	if (!move.IsPromotion())
 	{
@@ -420,7 +420,7 @@ std::array<int16_t, INPUT_NEURONS> Position::GetInputLayer() const
 deltaArray& Position::CalculateMoveDelta(Move move)
 {
 	delta.size = 0;
-	if (move.IsUninitialized()) return delta;		//null move
+	if (move == Move::Uninitialized) return delta;		//null move
 
 	if (!move.IsPromotion())
 	{

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -61,6 +61,7 @@ uint64_t SearchThread(Position position, SearchParameters parameters, const Sear
 
 	//Limit the MultiPV setting to be at most the number of legal moves
 	MoveList moves;
+	moves.clear();
 	LegalMoves(position, moves);
 	parameters.multiPV = std::min<int>(parameters.multiPV, moves.size());
 

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -2,13 +2,6 @@
 
 int LMR_reduction[64][64];				//[depth][move number]
 
-constexpr int LMPLimit[] = { 10, 17, 24, 31, 38, 45 };
-
-//intentionally uses signed rather than unsigned
-//as size() will be compared to signed types
-template<class T, int N>
-constexpr int size(T(&)[N]) { return N; }
-
 void PrintBestMove(Move Best);
 bool UseTransposition(const TTEntry& entry, int alpha, int beta);
 bool CheckForRep(const Position& position, int distanceFromRoot);

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -301,14 +301,14 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 		return alpha;
 
 	//Set up search variables
-	Move bestMove = Move();	
+	Move bestMove = Move::Uninitialized;	
 	int a = alpha;
 	int b = beta;
 	int searchedMoves;
 	bool noLegalMoves = true;
 
 	//Rebel style IID. Don't ask why this helps but it does.
-	if (GetHashMove(position, distanceFromRoot).IsUninitialized() && depthRemaining > 3)
+	if (GetHashMove(position, distanceFromRoot) == Move::Uninitialized && depthRemaining > 3)
 		depthRemaining--;
 
 	bool FutileNode = depthRemaining < Futility_depth && staticScore + Futility_constant + Futility_coeff * depthRemaining < a;
@@ -627,7 +627,7 @@ SearchResult Quiescence(Position& position, unsigned int initialDepth, int alpha
 	if (staticScore >= beta) return staticScore;
 	if (staticScore > alpha) alpha = staticScore;
 	
-	Move bestmove;
+	Move bestmove = Move::Uninitialized;
 	int Score = staticScore;
 
 	MoveGenerator gen(position, distanceFromRoot, locals, locals.moveListStack.Get(), true);

--- a/Halogen/src/Search.cpp
+++ b/Halogen/src/Search.cpp
@@ -313,7 +313,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
 
 	bool FutileNode = depthRemaining < Futility_depth && staticScore + Futility_constant + Futility_coeff * depthRemaining < a;
 
-	MoveGenerator gen(position, distanceFromRoot, locals, locals.moveListStack.Get(), false);
+	MoveGenerator gen(position, distanceFromRoot, locals, false);
 	Move move;
 
 	for (searchedMoves = 0; gen.Next(move); searchedMoves++)
@@ -630,7 +630,7 @@ SearchResult Quiescence(Position& position, unsigned int initialDepth, int alpha
 	Move bestmove = Move::Uninitialized;
 	int Score = staticScore;
 
-	MoveGenerator gen(position, distanceFromRoot, locals, locals.moveListStack.Get(), true);
+	MoveGenerator gen(position, distanceFromRoot, locals, true);
 	Move move;
 
 	while (gen.Next(move))

--- a/Halogen/src/Search.h
+++ b/Halogen/src/Search.h
@@ -35,7 +35,7 @@ inline int LMP_depth = 6;
 
 struct SearchResult
 {
-	SearchResult(short score, Move move = Move()) : m_score(score), m_move(move) {}
+	SearchResult(short score, Move move = Move::Uninitialized) : m_score(score), m_move(move) {}
 
 	int GetScore() const { return m_score; }
 	Move GetMove() const { return m_move; }

--- a/Halogen/src/SearchData.h
+++ b/Halogen/src/SearchData.h
@@ -105,7 +105,7 @@ private:
 
 	mutable std::mutex ioMutex;
 	unsigned int threadDepthCompleted = 0;			//The depth that has been completed. When the first thread finishes a depth it increments this. All other threads should stop searching that depth
-	Move currentBestMove;							//Whoever finishes first gets to update this as long as they searched deeper than threadDepth
+	Move currentBestMove = Move::Uninitialized;		//Whoever finishes first gets to update this as long as they searched deeper than threadDepth
 	int prevScore = 0;								//if threads abandon the search, we need to know what the score was in order to set new alpha/beta bounds
 	int lowestAlpha = 0;
 	int highestBeta = 0;

--- a/Halogen/src/SearchData.h
+++ b/Halogen/src/SearchData.h
@@ -53,7 +53,6 @@ public:
 	
 	EvalCacheTable evalTable;
 	SearchLimits limits;
-	MoveListPool moveListStack;
 
 	void AddNode() { nodes++; }
 	void AddTbHit() { tbHits++; }

--- a/Halogen/src/TTEntry.cpp
+++ b/Halogen/src/TTEntry.cpp
@@ -1,6 +1,6 @@
 #include "TTEntry.h"
 
-TTEntry::TTEntry()
+TTEntry::TTEntry() : bestMove(Move::Uninitialized)
 {
 	key = EMPTY;
 	score = -1;
@@ -9,7 +9,7 @@ TTEntry::TTEntry()
 	halfmove = -1;
 }
 
-TTEntry::TTEntry(Move best, uint64_t ZobristKey, int Score, int Depth, int currentTurnCount, int distanceFromRoot, EntryType Cutoff)
+TTEntry::TTEntry(Move best, uint64_t ZobristKey, int Score, int Depth, int currentTurnCount, int distanceFromRoot, EntryType Cutoff) : bestMove(best)
 {
 	assert(Score < SHRT_MAX && Score > SHRT_MIN);
 	assert(Depth < CHAR_MAX && Depth > CHAR_MIN);
@@ -33,7 +33,7 @@ void TTEntry::MateScoreAdjustment(int distanceFromRoot)
 
 void TTEntry::Reset()
 {
-	bestMove = Move();
+	bestMove = Move::Uninitialized;
 	key = EMPTY;
 	score = -1;
 	depth = -1;

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.11.1";
+string version = "10.11.2";
 
 int main(int argc, char* argv[])
 {

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -455,6 +455,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position)
 
 	uint64_t nodeCount = 0;
 	MoveList moves;
+	moves.clear();
 	LegalMoves(position, moves);
 
 	for (size_t i = 0; i < moves.size(); i++)
@@ -483,6 +484,7 @@ uint64_t Perft(unsigned int depth, Position& position)
 
 	uint64_t nodeCount = 0;
 	MoveList moves;
+	moves.clear();
 	LegalMoves(position, moves);
 
 	/*for (int i = 0; i < UINT16_MAX; i++)


### PR DESCRIPTION
```
ELO   | 1.10 +- 3.37 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 16488 W: 3355 L: 3303 D: 9830
```
Doing this makes allocating a MoveList very cheap and means we can remove constructs like the MoveListPool as recycling the objects is no longer necessary. Watch out for UB though as MoveList needs .reset() to be called before it can be used! 