### PR TITLE
Correct interaction between 3 fold rep and ep passant squares

### DIFF
--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.11.3";
+string version = "10.12";
 
 int main(int argc, char* argv[])
 {

--- a/HalogenTests/TestMoveGeneration.cpp
+++ b/HalogenTests/TestMoveGeneration.cpp
@@ -2,6 +2,8 @@
 
 #include "..\Halogen\src\Search.h"
 
+#include "..\Halogen\src\MoveList.cpp"
+
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace MoveGeneration
@@ -12,7 +14,8 @@ namespace MoveGeneration
 			return 1;	//if perftdivide is called with 1 this is necesary
 
 		uint64_t nodeCount = 0;
-		std::vector<ExtendedMove> moves;
+		ExtendedMoveList moves;
+		moves.clear();
 		LegalMoves(position, moves);
 
 		if (depth == 1)


### PR DESCRIPTION
```
ELO   | 3.25 +- 3.81 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 9312 W: 1407 L: 1320 D: 6585
```
```
ELO   | 5.66 +- 5.47 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 6136 W: 1266 L: 1166 D: 3704
```
```
ELO   | 4.77 +- 3.61 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13992 W: 2861 L: 2669 D: 8462
```