### PR TITLE
Remove score adjustment when winning side has no pawns

### DIFF
--- a/Halogen/src/EvalNet.cpp
+++ b/Halogen/src/EvalNet.cpp
@@ -10,7 +10,6 @@ int EvaluatePositionNet(const Position& position, EvalCacheTable& evalTable)
     {
         eval = position.GetEvaluation();
 
-        //NoPawnAdjustment(eval, position);
         TempoAdjustment(eval, position);
 
         evalTable.AddEntry(position.GetZobristKey(), eval);
@@ -59,14 +58,6 @@ void TempoAdjustment(int& eval, const Position& position)
 {
     constexpr static int TEMPO = 10;
     eval += position.GetTurn() == WHITE ? TEMPO : -TEMPO;
-}
-
-void NoPawnAdjustment(int& eval, const Position& position)
-{
-    if (eval > 0 && position.GetPieceBB(PAWN, WHITE) == 0)
-        eval /= 2;
-    if (eval < 0 && position.GetPieceBB(PAWN, BLACK) == 0)
-        eval /= 2;
 }
 
 }

--- a/Halogen/src/EvalNet.cpp
+++ b/Halogen/src/EvalNet.cpp
@@ -10,7 +10,7 @@ int EvaluatePositionNet(const Position& position, EvalCacheTable& evalTable)
     {
         eval = position.GetEvaluation();
 
-        NoPawnAdjustment(eval, position);
+        //NoPawnAdjustment(eval, position);
         TempoAdjustment(eval, position);
 
         evalTable.AddEntry(position.GetZobristKey(), eval);

--- a/Halogen/src/main.cpp
+++ b/Halogen/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.13";
+string version = "10.14";
 
 int main(int argc, char* argv[])
 {

--- a/HalogenTests/TestEvalNet.cpp
+++ b/HalogenTests/TestEvalNet.cpp
@@ -26,35 +26,6 @@ namespace EvalNet
 {
 	using namespace UnitTestEvalNet;
 
-	TEST_CLASS(noPawnAdjustment)
-	{
-	public:
-		noPawnAdjustment()
-		{
-			ZobristInit();
-		}
-
-		TEST_METHOD(Insufficent)
-		{
-			Position position;
-			position.InitialiseFromFen("k7/8/8/8/8/8/8/K2R4 w - - 0 1");
-
-			int value = 100;
-			NoPawnAdjustment(value, position);
-			Assert::AreEqual(100 / 2, value);
-		}
-
-		TEST_METHOD(Sufficent)
-		{
-			Position position;
-			position.InitialiseFromFen("k7/8/8/8/8/8/4P3/K2B4 w - - 0 1");
-
-			int value = 100;
-			NoPawnAdjustment(value, position);
-			Assert::AreEqual(100, value);
-		}
-	};
-
 	TEST_CLASS(tempoAdjustment)
 	{
 	public:


### PR DESCRIPTION
```
ELO   | 3.42 +- 3.63 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.03 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 9240 W: 1260 L: 1169 D: 6811
```
```
ELO   | 0.61 +- 2.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 20904 W: 3792 L: 3755 D: 13357
```