### PR TITLE
Implement new futility pruning scheme

### DIFF
--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -25,6 +25,8 @@ public:
 
 	void SkipQuiets();
 
+	Stage GetStage() { return stage; }
+
 private:
 	void OrderMoves(ExtendedMoveList& moves);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.14.4";
+string version = "10.15";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 3.70 +- 2.80 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16792 W: 2476 L: 2297 D: 12019
```
```
ELO   | 4.88 +- 3.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13088 W: 2536 L: 2352 D: 8200
```