### PR TITLE
Update best move on fail high

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -173,6 +173,7 @@ SearchResult AspirationWindowSearch(Position position, int depth, int prevScore,
 		if (search.GetScore() >= beta)
 		{
 			sharedData.ReportResult(depth, locals.limits.ElapsedTime(), beta, alpha, beta, position, search.GetMove(), locals);
+            sharedData.UpdateBestMove(search.GetMove());
 			beta = std::min<int>(MATE, beta + delta);
 		}
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -173,7 +173,7 @@ SearchResult AspirationWindowSearch(Position position, int depth, int prevScore,
 		if (search.GetScore() >= beta)
 		{
 			sharedData.ReportResult(depth, locals.limits.ElapsedTime(), beta, alpha, beta, position, search.GetMove(), locals);
-            sharedData.UpdateBestMove(search.GetMove());
+			sharedData.UpdateBestMove(search.GetMove());
 			beta = std::min<int>(MATE, beta + delta);
 		}
 

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -68,6 +68,7 @@ void ThreadSharedData::ReportResult(unsigned int depth, double Time, int score, 
 	{
 		PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, move, locals);
 		highestBeta = beta;
+        currentBestMove = move;
 	}
 }
 

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -103,6 +103,12 @@ bool ThreadSharedData::MultiPVExcludeMove(Move move) const
 	return std::find(MultiPVExclusion.begin(), MultiPVExclusion.end(), move) != MultiPVExclusion.end();
 }
 
+void ThreadSharedData::UpdateBestMove(Move move)
+{
+	std::scoped_lock lock(ioMutex);
+	currentBestMove = move;
+}
+
 bool ThreadSharedData::MultiPVExcludeMoveUnlocked(Move move) const
 {
 	return std::find(MultiPVExclusion.begin(), MultiPVExclusion.end(), move) != MultiPVExclusion.end();

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -68,7 +68,6 @@ void ThreadSharedData::ReportResult(unsigned int depth, double Time, int score, 
 	{
 		PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, move, locals);
 		highestBeta = beta;
-        currentBestMove = move;
 	}
 }
 

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -97,6 +97,7 @@ public:
 	int GetMultiPVSetting() const { return param.multiPV; };
 	int GetMultiPVCount() const;
 	bool MultiPVExcludeMove(Move move) const;
+	void UpdateBestMove(Move move) { currentBestMove = move; }
 
 	uint64_t getTBHits() const;
 	uint64_t getNodes() const;

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -97,7 +97,7 @@ public:
 	int GetMultiPVSetting() const { return param.multiPV; };
 	int GetMultiPVCount() const;
 	bool MultiPVExcludeMove(Move move) const;
-	void UpdateBestMove(Move move) { currentBestMove = move; }
+	void UpdateBestMove(Move move);
 
 	uint64_t getTBHits() const;
 	uint64_t getNodes() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.16";
+string version = "10.17";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Update current best move on fail-high aspiration searches 

LTC 
http://chess.grantnet.us/test/12665/
```
ELO   | 15.78 +- 6.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2864 W: 481 L: 351 D: 2032
```


STC 
http://chess.grantnet.us/test/12663/
```
ELO   | 12.96 +- 6.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3968 W: 826 L: 678 D: 2464
```