### PR TITLE
Fix MoveGenerator to allow killer moves when in check

### DIFF
--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -27,19 +27,10 @@ bool MoveGenerator::Next(Move& move)
 
 	if (stage == Stage::GEN_LOUD)
 	{
-		if (!quiescence && IsInCheck(position))
-		{
-			LegalMoves(position, moveList);	//contains a special function for generating moves when in check which is quicker
-			stage = Stage::GIVE_QUIET;
-		}
-		else
-		{
-			QuiescenceMoves(position, moveList);
-			stage = Stage::GIVE_GOOD_LOUD;
-		}
-
+		QuiescenceMoves(position, moveList);
 		OrderMoves(moveList);
 		current = moveList.begin();
+		stage = Stage::GIVE_GOOD_LOUD;
 	}
 
 	if (stage == Stage::GIVE_GOOD_LOUD)


### PR DESCRIPTION
```
ELO   | 3.14 +- 2.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 17584 W: 2675 L: 2516 D: 12393
```
```
ELO   | 2.47 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 48920 W: 9633 L: 9285 D: 30002
```