### PR TITLE
Separate loud moves from quiet moves in MoveGenerator

### DIFF
--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -27,15 +27,15 @@ bool MoveGenerator::Next(Move& move)
 
 	if (stage == Stage::GEN_LOUD)
 	{
-		QuiescenceMoves(position, moveList);
-		OrderMoves(moveList);
-		current = moveList.begin();
+		QuiescenceMoves(position, loudMoves);
+		OrderMoves(loudMoves);
+		current = loudMoves.begin();
 		stage = Stage::GIVE_GOOD_LOUD;
 	}
 
 	if (stage == Stage::GIVE_GOOD_LOUD)
 	{
-		if (current != moveList.end() && current->SEE >= 0)
+		if (current != loudMoves.end() && current->SEE >= 0)
 		{
 			move = current->move;
 			moveSEE = current->SEE;
@@ -75,7 +75,7 @@ bool MoveGenerator::Next(Move& move)
 
 	if (stage == Stage::GIVE_BAD_LOUD)
 	{
-		if (current != moveList.end())
+		if (current != loudMoves.end())
 		{
 			move = current->move;
 			moveSEE = current->SEE;
@@ -93,16 +93,15 @@ bool MoveGenerator::Next(Move& move)
 
 	if (stage == Stage::GEN_QUIET)
 	{
-		moveList.clear();
-		QuietMoves(position, moveList);
-		OrderMoves(moveList);
-		current = moveList.begin();
+		QuietMoves(position, quietMoves);
+		OrderMoves(quietMoves);
+		current = quietMoves.begin();
 		stage = Stage::GIVE_QUIET;
 	}
 
 	if (stage == Stage::GIVE_QUIET)
 	{
-		if (current != moveList.end())
+		if (current != quietMoves.end())
 		{
 			move = current->move;
 			moveSEE = current->SEE;
@@ -118,7 +117,7 @@ void MoveGenerator::AdjustHistory(const Move& move, SearchData& Locals, int dept
 {
 	Locals.AddHistory(position.GetTurn(), move.GetFrom(), move.GetTo(), depthRemaining * depthRemaining);
 
-	for (auto const& m : moveList)
+	for (auto const& m : quietMoves)
 	{
 		if (m.move == move) break;
 		Locals.AddHistory(position.GetTurn(), m.move.GetFrom(), m.move.GetTo(), -depthRemaining * depthRemaining);

--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -53,7 +53,8 @@ private:
 	int distanceFromRoot;
 	const SearchData& locals;
 	bool quiescence;
-	ExtendedMoveList moveList;
+	ExtendedMoveList loudMoves;
+	ExtendedMoveList quietMoves;
 
 	// Data uses for keeping track of internal values
 	Stage stage;


### PR DESCRIPTION
```
ELO   | 0.05 +- 2.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 27680 W: 5298 L: 5294 D: 17088
```