### PR TITLE
Further adjust history table code to allow for CMH

### DIFF
--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -115,12 +115,14 @@ bool MoveGenerator::Next(Move& move)
 
 void MoveGenerator::AdjustHistory(const Move& move, SearchData& Locals, int depthRemaining) const
 {
-	Locals.AddHistory(Locals.Butterfly(position, move), depthRemaining * depthRemaining);
+	Locals.history.AddButterfly(position, move, depthRemaining * depthRemaining);
+	Locals.history.AddCounterMove(position, move, depthRemaining * depthRemaining);
 
 	for (auto const& m : quietMoves)
 	{
 		if (m.move == move) break;
-		Locals.AddHistory(Locals.Butterfly(position, m.move), -depthRemaining * depthRemaining);
+		Locals.history.AddButterfly(position, m.move, -depthRemaining * depthRemaining);
+		Locals.history.AddCounterMove(position, m.move, depthRemaining * depthRemaining);
 	}
 }
 
@@ -279,8 +281,8 @@ void MoveGenerator::OrderMoves(ExtendedMoveList& moves)
 		//Quiet
 		else
 		{
-			int history = locals.Butterfly(position, moves[i].move);
-			moves[i].score = history;
+			int history = locals.history.GetButterfly(position, moves[i].move) + locals.history.GetCounterMove(position, moves[i].move);
+			moves[i].score = std::clamp<int>(history, std::numeric_limits<decltype(moves[i].score)>::min(), std::numeric_limits<decltype(moves[i].score)>::max());
 		}
 	}
 

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -116,13 +116,11 @@ bool MoveGenerator::Next(Move& move)
 void MoveGenerator::AdjustHistory(const Move& move, SearchData& Locals, int depthRemaining) const
 {
 	Locals.history.AddButterfly(position, move, depthRemaining * depthRemaining);
-	Locals.history.AddCounterMove(position, move, depthRemaining * depthRemaining);
 
 	for (auto const& m : quietMoves)
 	{
 		if (m.move == move) break;
 		Locals.history.AddButterfly(position, m.move, -depthRemaining * depthRemaining);
-		Locals.history.AddCounterMove(position, m.move, depthRemaining * depthRemaining);
 	}
 }
 
@@ -281,7 +279,7 @@ void MoveGenerator::OrderMoves(ExtendedMoveList& moves)
 		//Quiet
 		else
 		{
-			int history = locals.history.GetButterfly(position, moves[i].move) + locals.history.GetCounterMove(position, moves[i].move);
+			int history = locals.history.GetButterfly(position, moves[i].move);
 			moves[i].score = std::clamp<int>(history, std::numeric_limits<decltype(moves[i].score)>::min(), std::numeric_limits<decltype(moves[i].score)>::max());
 		}
 	}

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -278,15 +278,13 @@ void History::AddHistory(int16_t& val, int change)
 }
 
 History::History(const History& other) :
-	butterfly(std::make_unique<History::ButterflyType>(*other.butterfly)),
-	counterMove(std::make_unique<History::CounterMoveType>(*other.counterMove))
+	butterfly(std::make_unique<History::ButterflyType>(*other.butterfly))
 {
 }
 
 History& History::operator=(const History& other)
 {
 	butterfly = std::make_unique<History::ButterflyType>(*other.butterfly);
-	counterMove = std::make_unique<History::CounterMoveType>(*other.counterMove);
 	return *this;
 }
 
@@ -313,40 +311,3 @@ int16_t History::GetButterfly(const Position& position, Move move) const
 
 	return (*butterfly)[position.GetTurn()][move.GetFrom()][move.GetTo()];
 }
-
-void History::AddCounterMove(const Position& position, Move move, int change)
-{
-	Move prevMove = position.GetPreviousMove();
-	if (prevMove == Move::Uninitialized) return;
-
-	assert(move != Move::Uninitialized);
-
-	Pieces prevPiece = position.GetSquare(prevMove.GetTo());
-	Pieces currentPiece = position.GetSquare(move.GetFrom());
-
-	assert(prevPiece != N_PIECES);
-	assert(currentPiece != N_PIECES);
-	assert(prevMove.GetTo() != N_SQUARES);
-	assert(move.GetTo() != N_SQUARES);
-
-	AddHistory((*counterMove)[prevPiece][prevMove.GetTo()][currentPiece][move.GetTo()], change);
-}
-
-int16_t History::GetCounterMove(const Position& position, Move move) const
-{
-	Move prevMove = position.GetPreviousMove();
-	if (prevMove == Move::Uninitialized) return 0;
-
-	assert(move != Move::Uninitialized);
-	
-	Pieces prevPiece = position.GetSquare(prevMove.GetTo());
-	Pieces currentPiece = position.GetSquare(move.GetFrom());
-
-	assert(prevPiece != N_PIECES);
-	assert(currentPiece != N_PIECES);
-	assert(prevMove.GetTo() != N_SQUARES);
-	assert(move.GetTo() != N_SQUARES);
-
-	return (*counterMove)[prevPiece][prevMove.GetTo()][currentPiece][move.GetTo()];
-}
-

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -49,20 +49,13 @@ public:
 	void AddButterfly(const Position& position, Move move, int change);
 	int16_t GetButterfly(const Position& position, Move move) const;
 
-	void AddCounterMove(const Position& position, Move move, int change);
-	int16_t GetCounterMove(const Position& position, Move move) const;
-
 private:
 	void AddHistory(int16_t& val, int change);
 
 	// [side][from][to]
 	using ButterflyType = std::array<std::array<std::array<int16_t, N_SQUARES>, N_SQUARES>, N_PLAYERS>;
 
-	//[prev_piece][prev_to][piece][to]
-	using CounterMoveType = std::array<std::array<std::array<std::array<int16_t, N_SQUARES>, N_PIECES>, N_SQUARES>, N_PIECES>;
-
 	std::unique_ptr<ButterflyType> butterfly = std::make_unique<ButterflyType>();
-	std::unique_ptr<CounterMoveType> counterMove = std::make_unique<CounterMoveType>();
 };
 
 struct SearchData

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -46,14 +46,23 @@ public:
 	History& operator=(const History& other);
 	History& operator=(History&&) = default;
 	
-	int16_t& Butterfly(Players side, Square from, Square to);
-	int16_t  Butterfly(Players side, Square from, Square to) const;
+	void AddButterfly(const Position& position, Move move, int change);
+	int16_t GetButterfly(const Position& position, Move move) const;
+
+	void AddCounterMove(const Position& position, Move move, int change);
+	int16_t GetCounterMove(const Position& position, Move move) const;
 
 private:
+	void AddHistory(int16_t& val, int change);
+
 	// [side][from][to]
 	using ButterflyType = std::array<std::array<std::array<int16_t, N_SQUARES>, N_SQUARES>, N_PLAYERS>;
 
+	//[prev_piece][prev_to][piece][to]
+	using CounterMoveType = std::array<std::array<std::array<std::array<int16_t, N_SQUARES>, N_PIECES>, N_SQUARES>, N_PIECES>;
+
 	std::unique_ptr<ButterflyType> butterfly = std::make_unique<ButterflyType>();
+	std::unique_ptr<CounterMoveType> counterMove = std::make_unique<CounterMoveType>();
 };
 
 struct SearchData
@@ -75,20 +84,15 @@ public:
 	void AddNode() { nodes++; }
 	void AddTbHit() { tbHits++; }
 
-	void AddHistory(int16_t& val, int change);
-
 	uint64_t GetThreadNodes() const { return nodes; }
 
 	void ResetSeldepth() { selDepth = 0; }
 	void ReportDepth(int distanceFromRoot) { selDepth = std::max(distanceFromRoot, selDepth); }
 	int GetSelDepth() const { return selDepth; }
 
-	int16_t& Butterfly(const Position& position, Move move);
-	int16_t  Butterfly(const Position& position, Move move) const;
-
-private:
 	History history;
 
+private:
 	friend class ThreadSharedData;
 	uint64_t tbHits = 0;
 	uint64_t nodes = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.17.3";
+string version = "10.17.4";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 0.01 +- 2.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 28528 W: 5469 L: 5468 D: 17591
```