### PR TITLE
Bugfix: Move stack was not reset between UCI commands

### DIFF
--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -319,6 +319,7 @@ void Position::Reset()
 {
 	PreviousKeys.clear();
 	key = EMPTY;
+	moveStack.clear();
 
 	ResetBoard();
 	InitParameters();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.17.4";
+string version = "10.17.5";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 6.82 +- 5.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 5352 W: 1102 L: 997 D: 3253
```