### PR TITLE
Add counter move history

### DIFF
--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -116,11 +116,13 @@ bool MoveGenerator::Next(Move& move)
 void MoveGenerator::AdjustHistory(const Move& move, SearchData& Locals, int depthRemaining) const
 {
 	Locals.history.AddButterfly(position, move, depthRemaining * depthRemaining);
+	Locals.history.AddCounterMove(position, move, depthRemaining * depthRemaining);
 
 	for (auto const& m : quietMoves)
 	{
 		if (m.move == move) break;
 		Locals.history.AddButterfly(position, m.move, -depthRemaining * depthRemaining);
+		Locals.history.AddCounterMove(position, m.move, -depthRemaining * depthRemaining);
 	}
 }
 
@@ -279,7 +281,7 @@ void MoveGenerator::OrderMoves(ExtendedMoveList& moves)
 		//Quiet
 		else
 		{
-			int history = locals.history.GetButterfly(position, moves[i].move);
+			int history = locals.history.GetButterfly(position, moves[i].move) + locals.history.GetCounterMove(position, moves[i].move);
 			moves[i].score = std::clamp<int>(history, std::numeric_limits<decltype(moves[i].score)>::min(), std::numeric_limits<decltype(moves[i].score)>::max());
 		}
 	}

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -311,3 +311,39 @@ int16_t History::GetButterfly(const Position& position, Move move) const
 
 	return (*butterfly)[position.GetTurn()][move.GetFrom()][move.GetTo()];
 }
+
+void History::AddCounterMove(const Position& position, Move move, int change)
+{
+	Move prevMove = position.GetPreviousMove();
+	if (prevMove == Move::Uninitialized) return;
+
+	assert(move != Move::Uninitialized);
+
+	Pieces prevPiece = position.GetSquare(prevMove.GetTo());
+	Pieces currentPiece = position.GetSquare(move.GetFrom());
+
+	assert(prevPiece != N_PIECES);
+	assert(currentPiece != N_PIECES);
+	assert(prevMove.GetTo() != N_SQUARES);
+	assert(move.GetTo() != N_SQUARES);
+
+	AddHistory((*counterMove)[prevPiece][prevMove.GetTo()][currentPiece][move.GetTo()], change);
+}
+
+int16_t History::GetCounterMove(const Position& position, Move move) const
+{
+	Move prevMove = position.GetPreviousMove();
+	if (prevMove == Move::Uninitialized) return 0;
+
+	assert(move != Move::Uninitialized);
+
+	Pieces prevPiece = position.GetSquare(prevMove.GetTo());
+	Pieces currentPiece = position.GetSquare(move.GetFrom());
+
+	assert(prevPiece != N_PIECES);
+	assert(currentPiece != N_PIECES);
+	assert(prevMove.GetTo() != N_SQUARES);
+	assert(move.GetTo() != N_SQUARES);
+
+	return (*counterMove)[prevPiece][prevMove.GetTo()][currentPiece][move.GetTo()];
+}

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -49,13 +49,20 @@ public:
 	void AddButterfly(const Position& position, Move move, int change);
 	int16_t GetButterfly(const Position& position, Move move) const;
 
+	void AddCounterMove(const Position& position, Move move, int change);
+	int16_t GetCounterMove(const Position& position, Move move) const;
+
 private:
 	void AddHistory(int16_t& val, int change);
 
 	// [side][from][to]
 	using ButterflyType = std::array<std::array<std::array<int16_t, N_SQUARES>, N_SQUARES>, N_PLAYERS>;
 
+	//[prev_piece][prev_to][piece][to]
+	using CounterMoveType = std::array<std::array<std::array<std::array<int16_t, N_SQUARES>, N_PIECES>, N_SQUARES>, N_PIECES>;
+
 	std::unique_ptr<ButterflyType> butterfly = std::make_unique<ButterflyType>();
+	std::unique_ptr<CounterMoveType> counterMove = std::make_unique<CounterMoveType>();
 };
 
 struct SearchData

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.17.5";
+string version = "10.18";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 5.38 +- 3.66 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10072 W: 1544 L: 1388 D: 7140
```
```
ELO   | 0.54 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 44288 W: 8486 L: 8417 D: 27385
```