### PR TITLE
Improve allocation speed for transposition table

### DIFF
--- a/src/TTEntry.cpp
+++ b/src/TTEntry.cpp
@@ -1,14 +1,5 @@
 #include "TTEntry.h"
 
-TTEntry::TTEntry() : bestMove(Move::Uninitialized)
-{
-	key = EMPTY;
-	score = -1;
-	depth = -1;
-	cutoff = EntryType::EMPTY_ENTRY;
-	halfmove = -1;
-}
-
 TTEntry::TTEntry(Move best, uint64_t ZobristKey, int Score, int Depth, int currentTurnCount, int distanceFromRoot, EntryType Cutoff) : bestMove(best)
 {
 	assert(Score < SHRT_MAX && Score > SHRT_MIN);

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -17,7 +17,7 @@ enum class EntryType : char {
 class TTEntry
 {
 public:
-	TTEntry();
+	TTEntry() = default;
 	TTEntry(Move best, uint64_t ZobristKey, int Score, int Depth, int currentTurnCount, int distanceFromRoot, EntryType Cutoff);
 
 	bool IsAncient(unsigned int currentTurnCount, unsigned int distanceFromRoot) const { return halfmove != static_cast<char>((currentTurnCount - distanceFromRoot) % (HALF_MOVE_MODULO)); }
@@ -50,4 +50,6 @@ struct TTBucket
 	void Reset();
 	std::array<TTEntry, BucketSize> entry;
 };
+
+static_assert(std::is_trivial_v<TTBucket>);
 

--- a/src/TranspositionTable.cpp
+++ b/src/TranspositionTable.cpp
@@ -81,7 +81,7 @@ int TranspositionTable::GetCapacity(int halfmove) const
 
 	for (int i = 0; i < 1000; i++)	//1000 chosen specifically, because result needs to be 'per mill'
 	{
-		if (table.at(i / BucketSize).entry[i % BucketSize].GetAge() == static_cast<char>(halfmove % HALF_MOVE_MODULO))
+		if (table[i / BucketSize].entry[i % BucketSize].GetAge() == static_cast<char>(halfmove % HALF_MOVE_MODULO))
 			count++;
 	}
 
@@ -90,16 +90,12 @@ int TranspositionTable::GetCapacity(int halfmove) const
 
 void TranspositionTable::ResetTable()
 {
-	for (size_t i = 0; i < table.size(); i++)
-	{
-		table[i].Reset();
-	}
+	table.reallocate(table.size());
 }
 
 void TranspositionTable::SetSize(uint64_t MB)
 {
-	table.clear();
-	table.resize(MB * 1024 * 1024 / sizeof(TTBucket));
+	table.reallocate(CalculateSize(MB));
 }
 
 void TranspositionTable::PreFetch(uint64_t key) const

--- a/src/TranspositionTable.h
+++ b/src/TranspositionTable.h
@@ -5,10 +5,37 @@
 #include <algorithm>
 #include "TTEntry.h"
 
+// To allocate the transposition table, we need to do so on the heap to avoid a
+// stack overflow. A std::vector<T> would be a natural choice but has the one
+// drawback of expensive allocation. There is no way to resize a vector while
+// leaving its elements uninitialized. FastAllocateVector manages a dynamic
+// array with extremely cheap reallocations when needed. The interface is
+// minimal and only satisfies the requirements of a TranspositionTable class.
+
+template <typename T>
+class FastAllocateVector
+{
+public:
+	FastAllocateVector(size_t size) { reallocate(size); }
+
+	// make_unique<T[]>(size) will initialize the pointed to value which would defeat the purpose
+	// of FastAllocateVector
+	void reallocate(size_t size) { size_ = size; table.reset(new T[size]); }
+
+	const T& operator[](size_t index) const { return table[index]; }
+	      T& operator[](size_t index)       { return table[index]; }
+
+	size_t size() const { return size_; }
+
+private:
+	std::unique_ptr<T[]> table;
+	size_t size_;
+};
+
 class TranspositionTable
 {
 public:
-	TranspositionTable() { SetSize(32);	};
+	TranspositionTable() : table(FastAllocateVector<TTBucket>(CalculateSize(32))) {} //32MB default
 
 	size_t GetSize() const { return table.size(); }
 	int GetCapacity(int halfmove) const;
@@ -22,8 +49,9 @@ public:
 
 private:
 	uint64_t HashFunction(const uint64_t& key) const;
+	static constexpr uint64_t CalculateSize(uint64_t MB) { return MB * 1024 * 1024 / sizeof(TTBucket); }
 
-	std::vector<TTBucket> table;
+	FastAllocateVector<TTBucket> table;
 };
 
 bool CheckEntry(const TTEntry& entry, uint64_t key, int depth);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.18";
+string version = "10.18.1";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 5.89 +- 4.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 5840 W: 896 L: 797 D: 4147
```
```
ELO   | 9.69 +- 6.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 3944 W: 806 L: 696 D: 2442
```