### PR TITLE
Use a more efficient memory layout for PV tables

### DIFF
--- a/src/MoveGeneration.cpp
+++ b/src/MoveGeneration.cpp
@@ -198,7 +198,7 @@ void AppendLegalMoves(Square from, uint64_t to, Position& position, MoveFlag fla
         Square target = static_cast<Square>(LSBpop(to));
         Move move(from, target, flag);
         if (!(pinned & SquareBB[from]) || !MovePutsSelfInCheck(position, move))
-            moves.Append(move);
+            moves.emplace_back(move);
     }
 }
 
@@ -211,7 +211,7 @@ void AppendLegalMoves(uint64_t from, Square to, Position& position, MoveFlag fla
         Square source = static_cast<Square>(LSBpop(from));
         Move move(source, to, flag);
         if (!(pinned & SquareBB[source]) || !MovePutsSelfInCheck(position, move))
-            moves.Append(move);
+            moves.emplace_back(move);
     }
 }
 
@@ -316,7 +316,7 @@ void PawnPushes(Position& position, FixedVector<T>& moves, uint64_t pinned)
         Move move(start, end, QUIET);
 
         if (!(pinned & SquareBB[start]) || !MovePutsSelfInCheck(position, move))
-            moves.Append(move);
+            moves.emplace_back(move);
     }
 }
 
@@ -349,10 +349,10 @@ void PawnPromotions(Position& position, FixedVector<T>& moves, uint64_t pinned)
         if ((pinned & SquareBB[start]) && MovePutsSelfInCheck(position, move))
             continue;
 
-        moves.Append(move);
-        moves.Append(start, end, ROOK_PROMOTION);
-        moves.Append(start, end, BISHOP_PROMOTION);
-        moves.Append(start, end, QUEEN_PROMOTION);
+        moves.emplace_back(move);
+        moves.emplace_back(start, end, ROOK_PROMOTION);
+        moves.emplace_back(start, end, BISHOP_PROMOTION);
+        moves.emplace_back(start, end, QUEEN_PROMOTION);
     }
 }
 
@@ -386,7 +386,7 @@ void PawnDoublePushes(Position& position, FixedVector<T>& moves, uint64_t pinned
         Move move(start, end, PAWN_DOUBLE_MOVE);
 
         if (!(pinned & SquareBB[start]) || !MovePutsSelfInCheck(position, move))
-            moves.Append(move);
+            moves.emplace_back(move);
     }
 }
 
@@ -435,13 +435,13 @@ void PawnCaptures(Position& position, FixedVector<T>& moves, uint64_t pinned)
 
         if (GetRank(end) == RANK_1 || GetRank(end) == RANK_8)
         {
-            moves.Append(start, end, KNIGHT_PROMOTION_CAPTURE);
-            moves.Append(start, end, ROOK_PROMOTION_CAPTURE);
-            moves.Append(start, end, BISHOP_PROMOTION_CAPTURE);
-            moves.Append(start, end, QUEEN_PROMOTION_CAPTURE);
+            moves.emplace_back(start, end, KNIGHT_PROMOTION_CAPTURE);
+            moves.emplace_back(start, end, ROOK_PROMOTION_CAPTURE);
+            moves.emplace_back(start, end, BISHOP_PROMOTION_CAPTURE);
+            moves.emplace_back(start, end, QUEEN_PROMOTION_CAPTURE);
         }
         else
-            moves.Append(move);
+            moves.emplace_back(move);
     }
 
     while (rightAttack != 0)
@@ -455,13 +455,13 @@ void PawnCaptures(Position& position, FixedVector<T>& moves, uint64_t pinned)
 
         if (GetRank(end) == RANK_1 || GetRank(end) == RANK_8)
         {
-            moves.Append(start, end, KNIGHT_PROMOTION_CAPTURE);
-            moves.Append(start, end, ROOK_PROMOTION_CAPTURE);
-            moves.Append(start, end, BISHOP_PROMOTION_CAPTURE);
-            moves.Append(start, end, QUEEN_PROMOTION_CAPTURE);
+            moves.emplace_back(start, end, KNIGHT_PROMOTION_CAPTURE);
+            moves.emplace_back(start, end, ROOK_PROMOTION_CAPTURE);
+            moves.emplace_back(start, end, BISHOP_PROMOTION_CAPTURE);
+            moves.emplace_back(start, end, QUEEN_PROMOTION_CAPTURE);
         }
         else
-            moves.Append(move);
+            moves.emplace_back(move);
     }
 }
 
@@ -520,7 +520,7 @@ void CastleMoves(const Position& position, FixedVector<T>& moves)
     std::vector<Move> tmp;
     CastleMoves(position, tmp);
     for (auto& move : tmp)
-        moves.Append(move);
+        moves.emplace_back(move);
 }
 
 template <PieceTypes pieceType, bool capture, typename T>

--- a/src/MoveList.h
+++ b/src/MoveList.h
@@ -50,10 +50,6 @@ private:
     static_assert(std::is_trivial_v<T>);
 
 public:
-    //Pass arguments to construct the ExtendedMove()
-    template <typename... Args>
-    void Append(Args&&... args);
-
     using iterator = typename decltype(list)::iterator;
     using const_iterator = typename decltype(list)::const_iterator;
 
@@ -71,13 +67,19 @@ public:
     const T& operator[](size_t index) const { return list[index]; }
     T& operator[](size_t index) { return list[index]; }
 
+    template <typename... Args>
+    void emplace_back(Args&&... args)
+    {
+        list[moveCount++] = { args... };
+    }
+
+    template <class InputIt>
+    void append(InputIt first, InputIt last)
+    {
+        std::copy(first, last, end());
+        moveCount += std::distance(first, last);
+    }
+
 private:
     size_t moveCount = 0;
 };
-
-template <typename T>
-template <typename... Args>
-inline void FixedVector<T>::Append(Args&&... args)
-{
-    list[moveCount++] = { args... };
-}

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -12,9 +12,9 @@ void AddScoreToTable(int Score, int alphaOriginal, const Position& position, int
 void UpdateBounds(const TTEntry& entry, int& alpha, int& beta);
 int TerminalScore(const Position& position, int distanceFromRoot);
 int extension(const Position& position);
-void AddKiller(Move move, int distanceFromRoot, std::vector<std::array<Move, 2>>& KillerMoves);
+void AddKiller(Move move, int distanceFromRoot, std::array<std::array<Move, 2>, MAX_DEPTH>& KillerMoves);
 void AddHistory(const MoveGenerator& gen, const Move& move, SearchData& locals, int depthRemaining);
-void UpdatePV(Move move, int distanceFromRoot, std::vector<std::vector<Move>>& PvTable);
+void UpdatePV(Move move, int distanceFromRoot, std::array<BasicMoveList, MAX_DEPTH>& PvTable);
 int Reduction(int depth, int i);
 constexpr int matedIn(int distanceFromRoot);
 constexpr int mateIn(int distanceFromRoot);
@@ -518,13 +518,13 @@ int Reduction(int depth, int i)
     return LMR_reduction[std::min(63, std::max(0, depth))][std::min(63, std::max(0, i))];
 }
 
-void UpdatePV(Move move, int distanceFromRoot, std::vector<std::vector<Move>>& PvTable)
+void UpdatePV(Move move, int distanceFromRoot, std::array<BasicMoveList, MAX_DEPTH>& PvTable)
 {
     PvTable[distanceFromRoot].clear();
-    PvTable[distanceFromRoot].push_back(move);
+    PvTable[distanceFromRoot].emplace_back(move);
 
     if (distanceFromRoot + 1 < static_cast<int>(PvTable.size()))
-        PvTable[distanceFromRoot].insert(PvTable[distanceFromRoot].end(), PvTable[distanceFromRoot + 1].begin(), PvTable[distanceFromRoot + 1].end());
+        PvTable[distanceFromRoot].append(PvTable[distanceFromRoot + 1].begin(), PvTable[distanceFromRoot + 1].end());
 }
 
 bool UseTransposition(const TTEntry& entry, int alpha, int beta)
@@ -696,7 +696,7 @@ SearchResult Quiescence(Position& position, unsigned int initialDepth, int alpha
     return SearchResult(Score, bestmove);
 }
 
-void AddKiller(Move move, int distanceFromRoot, std::vector<std::array<Move, 2>>& KillerMoves)
+void AddKiller(Move move, int distanceFromRoot, std::array<std::array<Move, 2>, MAX_DEPTH>& KillerMoves)
 {
     if (move.IsCapture() || move.IsPromotion() || KillerMoves[distanceFromRoot][0] == move)
         return;

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -5,8 +5,6 @@ TranspositionTable tTable;
 SearchData::SearchData(const SearchLimits& Limits)
     : limits(Limits)
 {
-    PvTable.resize(MAX_DEPTH);
-    KillerMoves.resize(MAX_DEPTH);
 }
 
 ThreadSharedData::ThreadSharedData(const SearchLimits& limits, const SearchParameters& parameters, bool NoOutput)
@@ -46,7 +44,7 @@ void ThreadSharedData::ReportResult(unsigned int depth, double Time, int score, 
     if (alpha < score && score < beta && depth > threadDepthCompleted && !MultiPVExcludeMoveUnlocked(move))
     {
         if (!noOutput)
-            PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, move, locals);
+            PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, locals);
 
         if (GetMultiPVCount() == 0)
         {
@@ -67,13 +65,13 @@ void ThreadSharedData::ReportResult(unsigned int depth, double Time, int score, 
 
     if (score < lowestAlpha && score <= alpha && !noOutput && Time > 5000 && depth == threadDepthCompleted + 1)
     {
-        PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, move, locals);
+        PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, locals);
         lowestAlpha = alpha;
     }
 
     if (score > highestBeta && score >= beta && !noOutput && Time > 5000 && depth == threadDepthCompleted + 1)
     {
-        PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, move, locals);
+        PrintSearchInfo(depth, Time, abs(score) > TB_WIN_SCORE, score, alpha, beta, position, locals);
         highestBeta = beta;
     }
 }
@@ -139,7 +137,7 @@ SearchData& ThreadSharedData::GetData(unsigned int threadID)
     return threadlocalData[threadID];
 }
 
-void ThreadSharedData::PrintSearchInfo(unsigned int depth, double Time, bool isCheckmate, int score, int alpha, int beta, const Position& position, const Move& move, const SearchData& locals) const
+void ThreadSharedData::PrintSearchInfo(unsigned int depth, double Time, bool isCheckmate, int score, int alpha, int beta, const Position& position, const SearchData& locals) const
 {
     /*
 	Here we avoid excessive use of std::cout and instead append to a string in order
@@ -147,10 +145,7 @@ void ThreadSharedData::PrintSearchInfo(unsigned int depth, double Time, bool isC
 	time controls.
 	*/
 
-    std::vector<Move> pv = locals.PvTable[0];
-
-    if (pv.size() == 0)
-        pv.push_back(move);
+    const BasicMoveList& pv = locals.PvTable[0];
 
     std::stringstream ss;
 

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -82,8 +82,8 @@ private:
     //--------------------------------------------------------------------------------------------
 
 public:
-    std::vector<std::vector<Move>> PvTable;
-    std::vector<std::array<Move, 2>> KillerMoves; //2 moves indexed by distanceFromRoot
+    std::array<BasicMoveList, MAX_DEPTH> PvTable = {};
+    std::array<std::array<Move, 2>, MAX_DEPTH> KillerMoves = {}; //2 moves indexed by distanceFromRoot
 
     EvalCacheTable evalTable;
     SearchLimits limits;
@@ -139,7 +139,7 @@ public:
     SearchData& GetData(unsigned int threadID);
 
 private:
-    void PrintSearchInfo(unsigned int depth, double Time, bool isCheckmate, int score, int alpha, int beta, const Position& position, const Move& move, const SearchData& locals) const;
+    void PrintSearchInfo(unsigned int depth, double Time, bool isCheckmate, int score, int alpha, int beta, const Position& position, const SearchData& locals) const;
     bool MultiPVExcludeMoveUnlocked(Move move) const;
 
     mutable std::mutex ioMutex;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.20.4";
+string version = "10.20.5";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 5.13 +- 5.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 6632 W: 1314 L: 1216 D: 4102
```