### PR TITLE
Flush info string output

### DIFF
--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -186,8 +186,7 @@ void ThreadSharedData::PrintSearchInfo(unsigned int depth, double Time, bool isC
         ss << " ";
     }
 
-    ss << "\n";
-    std::cout << ss.str();
+    std::cout << ss.str() << std::endl;
 }
 
 bool SearchLimits::CheckTimeLimit() const

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.20.5";
+string version = "10.20.6";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 1.47 +- 3.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 14680 W: 2867 L: 2805 D: 9008
```
No effect on playing strength, but this is important for using the engine with a GUI for analysis.