### PR TITLE
Template move generation code on the side to move

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.20.6";
+string version = "10.20.6a";
 
 int main(int argc, char* argv[])
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.20.6a";
+string version = "10.20.7";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 10.82 +- 6.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4784 W: 1000 L: 851 D: 2933
```
```
    10.20.7.exe   |   10.20.6.exe    |
        mu        |        mu        |     SE      DF      t         p     speedup (%)
------------------+------------------|
       3565000.000|       3478000.000|
       3564500.000|       3477500.000|  707.107    2  123.036580  0.000066   2.470889
       3561000.000|       3477000.000|  3559.026   4   23.601962  0.000019   2.387042
       3551000.000|       3474000.000| 10739.336   6   7.169903   0.000372   2.192171
       3553400.000|       3474400.000|  8667.179   8   9.114845   0.000017   2.248214
       3553500.000|       3474000.000|  7088.723   10  11.214995  0.000001   2.262540
       3554857.143|       3473714.286|  6149.498   12  13.195037  0.000000   2.308943
       3555875.000|       3474000.000|  5429.541   14  15.079545  0.000000   2.329344
       3555777.778|       3472666.667|  4971.524   16  16.717432  0.000000   2.364993
       3557300.000|       3471600.000|  4819.520   18  17.781852  0.000000   2.438504
       3557636.364|       3471636.364|  4372.529   20  19.668252  0.000000   2.446910
       3557583.333|       3472666.667|  4122.723   22  20.597229  0.000000   2.415751
       3557923.077|       3472307.692|  3824.426   24  22.386468  0.000000   2.435635
       3557214.286|       3469642.857|  4487.817   26  19.513146  0.000000   2.492478
       3557200.000|       3469800.000|  4180.909   28  20.904545  0.000000   2.487548
```