### PR TITLE
Preserve history tables between searches

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -51,7 +51,7 @@ uint64_t SearchThread(Position position, ThreadSharedData& sharedData)
         }
     }
 
-    sharedData.Reset();
+    sharedData.ResetNewSearch();
 
     //Limit the MultiPV setting to be at most the number of legal moves
     BasicMoveList moves;

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -34,7 +34,7 @@ SearchResult Quiescence(Position& position, unsigned int initialDepth, int alpha
 
 void InitSearch();
 
-uint64_t SearchThread(Position position, SearchParameters parameters, const SearchLimits& limits, bool noOutput)
+uint64_t SearchThread(Position position, ThreadSharedData& sharedData)
 {
     //Probe TB at root
     if (GetBitCount(position.GetAllPieces()) <= TB_LARGEST
@@ -51,18 +51,19 @@ uint64_t SearchThread(Position position, SearchParameters parameters, const Sear
         }
     }
 
+    sharedData.Reset();
+
     //Limit the MultiPV setting to be at most the number of legal moves
     BasicMoveList moves;
     moves.clear();
     LegalMoves(position, moves);
-    parameters.multiPV = std::min<int>(parameters.multiPV, moves.size());
+    sharedData.SetMultiPv(std::min<int>(sharedData.GetParameters().multiPV, moves.size()));
 
     InitSearch();
 
     std::vector<std::thread> threads;
-    ThreadSharedData sharedData(limits, parameters, noOutput);
 
-    for (int i = 0; i < parameters.threads; i++)
+    for (int i = 0; i < sharedData.GetParameters().threads; i++)
     {
         threads.emplace_back(std::thread([=, &sharedData] { SearchPosition(position, sharedData, i); }));
     }
@@ -122,16 +123,16 @@ void SearchPosition(Position position, ThreadSharedData& sharedData, unsigned in
     {
         int depth = sharedData.GetDepth();
 
-        if (sharedData.GetData(threadID).limits.CheckDepthLimit(depth))
+        if (sharedData.GetData(threadID).limits->CheckDepthLimit(depth))
             break;
-        if (!sharedData.GetData(threadID).limits.CheckContinueSearch())
+        if (!sharedData.GetData(threadID).limits->CheckContinueSearch())
             sharedData.ReportWantsToStop(threadID);
 
         try
         {
             SearchResult curSearch = AspirationWindowSearch(position, depth, prevScore, sharedData.GetData(threadID), sharedData, threadID);
-            sharedData.ReportResult(depth, sharedData.GetData(threadID).limits.ElapsedTime(), curSearch.GetScore(), alpha, beta, position, curSearch.GetMove(), sharedData.GetData(threadID));
-            if (sharedData.GetData(threadID).limits.CheckMateLimit(curSearch.GetScore()))
+            sharedData.ReportResult(depth, sharedData.GetData(threadID).limits->ElapsedTime(), curSearch.GetScore(), alpha, beta, position, curSearch.GetMove(), sharedData.GetData(threadID));
+            if (sharedData.GetData(threadID).limits->CheckMateLimit(curSearch.GetScore()))
                 break;
             prevScore = curSearch.GetScore();
         }
@@ -165,19 +166,19 @@ SearchResult AspirationWindowSearch(Position position, int depth, int prevScore,
             break;
         if (sharedData.ThreadAbort(depth))
             break;
-        if (depth > 1 && sharedData.GetData(threadID).limits.CheckTimeLimit())
+        if (depth > 1 && sharedData.GetData(threadID).limits->CheckTimeLimit())
             break;
 
         if (search.GetScore() <= alpha)
         {
-            sharedData.ReportResult(depth, locals.limits.ElapsedTime(), alpha, alpha, beta, position, search.GetMove(), locals);
+            sharedData.ReportResult(depth, locals.limits->ElapsedTime(), alpha, alpha, beta, position, search.GetMove(), locals);
             beta = (alpha + beta) / 2;
             alpha = std::max<int>(MATED, alpha - delta);
         }
 
         if (search.GetScore() >= beta)
         {
-            sharedData.ReportResult(depth, locals.limits.ElapsedTime(), beta, alpha, beta, position, search.GetMove(), locals);
+            sharedData.ReportResult(depth, locals.limits->ElapsedTime(), beta, alpha, beta, position, search.GetMove(), locals);
             sharedData.UpdateBestMove(search.GetMove());
             beta = std::min<int>(MATE, beta + delta);
         }
@@ -198,7 +199,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
     locals.PvTable[distanceFromRoot].clear();
 
     //See if we should abort the search
-    if (initialDepth > 1 && locals.limits.CheckTimeLimit())
+    if (initialDepth > 1 && locals.GetThreadNodes() % 1024 == 0 && locals.limits->CheckTimeLimit())
         throw TimeAbort(); //Am I out of time?
     if (sharedData.ThreadAbort(initialDepth))
         throw ThreadDepthAbort(); //Has this depth been finished by another thread?
@@ -650,7 +651,7 @@ SearchResult Quiescence(Position& position, unsigned int initialDepth, int alpha
     locals.PvTable[distanceFromRoot].clear();
 
     //See if we should abort the search
-    if (initialDepth > 1 && locals.limits.CheckTimeLimit())
+    if (initialDepth > 1 && locals.GetThreadNodes() % 1024 == 0 && locals.limits->CheckTimeLimit())
         throw TimeAbort(); //Am I out of time?
     if (sharedData.ThreadAbort(initialDepth))
         throw ThreadDepthAbort(); //Has this depth been finished by another thread?

--- a/src/Search.h
+++ b/src/Search.h
@@ -49,4 +49,4 @@ private:
     Move m_move;
 };
 
-uint64_t SearchThread(Position position, SearchParameters parameters, const SearchLimits& limits, bool noOutput = false);
+uint64_t SearchThread(Position position, ThreadSharedData& sharedData);

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -11,24 +11,29 @@ void History::Reset()
 SearchData::SearchData(SearchLimits* Limits)
     : limits(Limits)
 {
-    Reset();
+    ResetNewGame();
 }
 
-void SearchData::Reset()
+void SearchData::ResetNewSearch()
 {
     tbHits = 0;
     nodes = 0;
     selDepth = 0;
     threadWantsToStop = false;
-    history.Reset();
 
     PvTable = {};
     KillerMoves = {};
 }
 
+void SearchData::ResetNewGame()
+{
+    ResetNewSearch();
+    history.Reset();
+}
+
 ThreadSharedData::ThreadSharedData(const SearchLimits& limits, const SearchParameters& parameters)
 {
-    Reset();
+    ResetNewGame();
     SetLimits(limits);
     SetMultiPv(parameters.multiPV);
     SetThreads(parameters.threads);
@@ -49,7 +54,7 @@ void ThreadSharedData::SetThreads(int threads)
         threadlocalData.emplace_back(&limits_);
 }
 
-void ThreadSharedData::Reset()
+void ThreadSharedData::ResetNewSearch()
 {
     threadDepthCompleted = 0;
     currentBestMove = Move::Uninitialized;
@@ -58,7 +63,20 @@ void ThreadSharedData::Reset()
     highestBeta = 0;
 
     limits_.Reset();
-    std::for_each(threadlocalData.begin(), threadlocalData.end(), [](auto& data) { data.Reset(); });
+    std::for_each(threadlocalData.begin(), threadlocalData.end(), [](auto& data) { data.ResetNewSearch(); });
+    MultiPVExclusion.clear();
+}
+
+void ThreadSharedData::ResetNewGame()
+{
+    threadDepthCompleted = 0;
+    currentBestMove = Move::Uninitialized;
+    prevScore = 0;
+    lowestAlpha = 0;
+    highestBeta = 0;
+
+    limits_.Reset();
+    std::for_each(threadlocalData.begin(), threadlocalData.end(), [](auto& data) { data.ResetNewGame(); });
     MultiPVExclusion.clear();
 }
 

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -20,7 +20,6 @@ void SearchData::Reset()
     nodes = 0;
     selDepth = 0;
     threadWantsToStop = false;
-    evalTable.Reset();
     history.Reset();
 
     PvTable = {};

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -100,7 +100,8 @@ public:
     void ReportDepth(int distanceFromRoot) { selDepth = std::max(distanceFromRoot, selDepth); }
     int GetSelDepth() const { return selDepth; }
 
-    void Reset();
+    void ResetNewSearch();
+    void ResetNewGame();
 
 private:
     friend class ThreadSharedData;
@@ -147,7 +148,8 @@ public:
     void SetThreads(int threads);
     const SearchParameters& GetParameters() { return param; }
 
-    void Reset();
+    void ResetNewSearch();
+    void ResetNewGame();
 
 private:
     void PrintSearchInfo(unsigned int depth, double Time, bool isCheckmate, int score, int alpha, int beta, const Position& position, const SearchData& locals) const;

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -20,12 +20,12 @@ public:
     void SetDepthLimit(int depth);
     void SetMateLimit(int moves);
 
-    int ElapsedTime() const { return SearchTimeManager.ElapsedMs(); }
+    int ElapsedTime() const { return TimeManager.ElapsedMs(); }
+
+    void Reset() { TimeManager.Reset(); }
 
 private:
-    SearchTimeManage SearchTimeManager;
-    mutable int PeriodicCheck = 0;
-
+    SearchTimeManage TimeManager;
     int depthLimit = -1;
     int mateLimit = -1;
     bool IsInfinite = false;
@@ -33,13 +33,13 @@ private:
     bool timeLimitEnabled = false;
     bool depthLimitEnabled = false;
     bool mateLimitEnabled = false;
-
-    mutable bool periodicTimeLimit = false;
 };
 
 class History
 {
 public:
+    History() { Reset(); }
+
     void AddButterfly(const Position& position, Move move, int change);
     int16_t GetButterfly(const Position& position, Move move) const;
 
@@ -53,6 +53,8 @@ public:
     static int CounterMove_max;
     static int CounterMove_scale;
 
+    void Reset();
+
 private:
     void AddHistory(int16_t& val, int change, int max, int scale);
 
@@ -62,8 +64,8 @@ private:
     // [side][prev_piece][prev_to][piece][to]
     using CounterMoveType = std::array<std::array<std::array<std::array<std::array<int16_t, N_SQUARES>, N_PIECE_TYPES>, N_SQUARES>, N_PIECE_TYPES>, N_PLAYERS>;
 
-    std::unique_ptr<ButterflyType> butterfly = std::make_unique<ButterflyType>();
-    std::unique_ptr<CounterMoveType> counterMove = std::make_unique<CounterMoveType>();
+    std::unique_ptr<ButterflyType> butterfly;
+    std::unique_ptr<CounterMoveType> counterMove;
 };
 
 inline int History::Butterfly_max = 16384;
@@ -74,7 +76,7 @@ inline int History::CounterMove_scale = 64;
 
 struct SearchData
 {
-    explicit SearchData(const SearchLimits& Limits);
+    explicit SearchData(SearchLimits* Limits);
 
     //--------------------------------------------------------------------------------------------
 private:
@@ -86,7 +88,8 @@ public:
     std::array<std::array<Move, 2>, MAX_DEPTH> KillerMoves = {}; //2 moves indexed by distanceFromRoot
 
     EvalCacheTable evalTable;
-    SearchLimits limits;
+    History history;
+    SearchLimits* limits;
 
     void AddNode() { nodes++; }
     void AddTbHit() { tbHits++; }
@@ -97,13 +100,14 @@ public:
     void ReportDepth(int distanceFromRoot) { selDepth = std::max(distanceFromRoot, selDepth); }
     int GetSelDepth() const { return selDepth; }
 
-    History history;
+    void Reset();
 
 private:
     friend class ThreadSharedData;
-    uint64_t tbHits = 0;
-    uint64_t nodes = 0;
-    int selDepth = 0;
+    uint64_t tbHits;
+    uint64_t nodes;
+    int selDepth;
+    bool threadWantsToStop;
 
     //--------------------------------------------------------------------------------------------
 private:
@@ -120,7 +124,7 @@ struct SearchParameters
 class ThreadSharedData
 {
 public:
-    ThreadSharedData(const SearchLimits& limits, const SearchParameters& parameters, bool NoOutput = false);
+    ThreadSharedData(const SearchLimits& limits = {}, const SearchParameters& parameters = {});
 
     Move GetBestMove() const;
     unsigned int GetDepth() const;
@@ -138,23 +142,27 @@ public:
 
     SearchData& GetData(unsigned int threadID);
 
+    void SetLimits(const SearchLimits& limits);
+    void SetMultiPv(int multiPv) { param.multiPV = multiPv; }
+    void SetThreads(int threads);
+    const SearchParameters& GetParameters() { return param; }
+
+    void Reset();
+
 private:
     void PrintSearchInfo(unsigned int depth, double Time, bool isCheckmate, int score, int alpha, int beta, const Position& position, const SearchData& locals) const;
     bool MultiPVExcludeMoveUnlocked(Move move) const;
 
     mutable std::mutex ioMutex;
-    unsigned int threadDepthCompleted = 0; //The depth that has been completed. When the first thread finishes a depth it increments this. All other threads should stop searching that depth
-    Move currentBestMove = Move::Uninitialized; //Whoever finishes first gets to update this as long as they searched deeper than threadDepth
-    int prevScore = 0; //if threads abandon the search, we need to know what the score was in order to set new alpha/beta bounds
-    int lowestAlpha = 0;
-    int highestBeta = 0;
-    bool noOutput; //Do not write anything to the concole
+    unsigned int threadDepthCompleted; //The depth that has been completed. When the first thread finishes a depth it increments this. All other threads should stop searching that depth
+    Move currentBestMove; //Whoever finishes first gets to update this as long as they searched deeper than threadDepth
+    int prevScore; //if threads abandon the search, we need to know what the score was in order to set new alpha/beta bounds
+    int lowestAlpha;
+    int highestBeta;
 
     SearchParameters param;
+    SearchLimits limits_;
 
     std::vector<SearchData> threadlocalData;
     std::vector<Move> MultiPVExclusion; //Moves that we ignore at the root for MPV mode
-
-    //TODO: probably put this inside of SearchData
-    std::vector<bool> ThreadWantsToStop; //Threads signal here that they want to stop searching, but will keep going until all threads want to stop
 };

--- a/src/TimeManage.cpp
+++ b/src/TimeManage.cpp
@@ -1,27 +1,14 @@
 #include "TimeManage.h"
 
-void Timer::Start()
-{
-    Begin = get_time_point();
-}
-
-void Timer::Restart()
-{
-    Begin = get_time_point();
-}
-
 int Timer::ElapsedMs() const
 {
     return (get_time_point() - Begin);
 }
 
 SearchTimeManage::SearchTimeManage(int maxTime, int allocatedTime)
+    : AllocatedSearchTimeMS(allocatedTime)
+    , MaxTimeMS(maxTime)
 {
-    timer.Restart();
-    timer.Start();
-    AllocatedSearchTimeMS = allocatedTime;
-    MaxTimeMS = maxTime;
-    BufferTime = 100; //TODO: Make this a constant somewhere and reduce its value
 }
 
 bool SearchTimeManage::ContinueSearch() const

--- a/src/TimeManage.h
+++ b/src/TimeManage.h
@@ -35,12 +35,13 @@ static inline double get_time_point()
 class Timer
 {
 public:
-    void Start();
-    void Restart();
+    Timer() { Reset(); }
+
     int ElapsedMs() const;
+    void Reset() { Begin = get_time_point(); }
 
 private:
-    double Begin = 0;
+    double Begin;
 };
 
 class SearchTimeManage
@@ -52,9 +53,12 @@ public:
     bool AbortSearch() const; //Is the remaining time all used up?
     int ElapsedMs() const { return timer.ElapsedMs(); }
 
+    void Reset() { timer.Reset(); }
+
 private:
     Timer timer;
     int AllocatedSearchTimeMS;
     int MaxTimeMS;
-    int BufferTime;
+
+    constexpr static int BufferTime = 100;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.21";
+string version = "10.22";
 
 int main(int argc, char* argv[])
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,7 @@ int main(int argc, char* argv[])
         {
             position.StartingPosition();
             tTable.ResetTable();
+            data.ResetNewGame();
         }
 
         else if (token == "position")
@@ -185,6 +186,7 @@ int main(int argc, char* argv[])
                 if (token == "Hash")
                 {
                     tTable.ResetTable();
+                    data.ResetNewGame();
                 }
             }
 
@@ -561,6 +563,7 @@ void Bench(int depth)
         }
 
         tTable.ResetTable();
+        data.ResetNewGame();
         nodeCount += SearchThread(position, data);
     }
 


### PR DESCRIPTION
```
ELO   | 5.15 +- 3.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10664 W: 1617 L: 1459 D: 7588
```
```
ELO   | 9.60 +- 5.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5648 W: 1202 L: 1046 D: 3400
```
```
ELO   | 6.67 +- 4.25 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7816 W: 1266 L: 1116 D: 5434
```