### PR TITLE
Align TT entries with cache lines, use memset to avoid lazy loading of pages 

### DIFF
--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -1,13 +1,14 @@
 #pragma once
 #include <array>
+#include <climits>
 #include <cstddef>
 #include <cstdint>
+#include <new>
 #include <type_traits>
 
 #include "Move.h"
 
 constexpr unsigned int HALF_MOVE_MODULO = 16;
-constexpr size_t BucketSize = 4;
 
 enum class EntryType : char
 {
@@ -24,13 +25,13 @@ public:
     TTEntry() = default;
     TTEntry(Move best, uint64_t ZobristKey, int Score, int Depth, int currentTurnCount, int distanceFromRoot, EntryType Cutoff);
 
-    bool IsAncient(unsigned int currentTurnCount, unsigned int distanceFromRoot) const { return halfmove != static_cast<char>((currentTurnCount - distanceFromRoot) % (HALF_MOVE_MODULO)); }
+    bool IsAncient(unsigned int currentTurnCount, unsigned int distanceFromRoot) const { return halfmove != CalculateAge(currentTurnCount, distanceFromRoot); }
 
     void SetHalfMove(int currentTurnCount, int distanceFromRoot) { halfmove = CalculateAge(currentTurnCount, distanceFromRoot); } //halfmove is from current position, distanceFromRoot adjusts this to get what the halfmove was at the root of the search
     void MateScoreAdjustment(int distanceFromRoot);
     void Reset();
 
-    static uint8_t CalculateAge(int currenthalfmove, int distanceFromRoot) { return (currenthalfmove - distanceFromRoot) % (HALF_MOVE_MODULO); }
+    static uint8_t CalculateAge(int currentTurnCount, int distanceFromRoot) { return (currentTurnCount - distanceFromRoot) % (HALF_MOVE_MODULO) + 1; }
 
     uint64_t GetKey() const { return key; }
     int GetScore() const { return score; }
@@ -43,16 +44,20 @@ private:
     /*Arranged to minimize padding*/
     uint64_t key; //8 bytes
     Move bestMove; //2 bytes
-    short int score; //2 bytes
-    char depth; //1 bytes
+    int16_t score; // 2 bytes
+    int8_t depth; // 1 bytes
     EntryType cutoff; //1 bytes
-    char halfmove; //1 bytes		(is stored as the halfmove at the ROOT of this current search, modulo 16)
+    int8_t halfmove; // 1 bytes	(is stored as the move count at the ROOT of this current search modulo 16 plus 1)
 };
 
 struct TTBucket
 {
+    constexpr static size_t SIZE = 4;
+
     void Reset();
-    std::array<TTEntry, BucketSize> entry;
+    alignas(64) std::array<TTEntry, SIZE> entry;
 };
 
+static_assert(sizeof(TTEntry) == 16, "TTEntry is not 16 bytes");
+static_assert(sizeof(TTBucket) == 64, "TTBucket is not 64 bytes");
 static_assert(std::is_trivial_v<TTBucket>);

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -1,9 +1,7 @@
 #pragma once
 #include <array>
-#include <climits>
 #include <cstddef>
 #include <cstdint>
-#include <new>
 #include <type_traits>
 
 #include "Move.h"

--- a/src/TranspositionTable.h
+++ b/src/TranspositionTable.h
@@ -11,10 +11,9 @@ class TranspositionTable
 {
 public:
     TranspositionTable()
-        : size_(CalculateSize(32))
-        , table(new TTBucket[size_])
     {
-    } //32MB default
+        Reallocate(CalculateEntryCount(32)); // 32MB default
+    }
 
     size_t GetSize() const { return size_; }
     int GetCapacity(int halfmove) const;
@@ -30,10 +29,11 @@ private:
     uint64_t HashFunction(const uint64_t& key) const;
     void Reallocate(size_t size);
 
-    static constexpr uint64_t CalculateSize(uint64_t MB) { return MB * 1024 * 1024 / sizeof(TTBucket); }
+    static constexpr uint64_t CalculateEntryCount(uint64_t MB) { return MB * 1024 * 1024 / sizeof(TTBucket); }
 
-    size_t size_;
+    // raw array and memset allocates quicker than std::vector
     std::unique_ptr<TTBucket[]> table;
+    size_t size_;
 };
 
 bool CheckEntry(const TTEntry& entry, uint64_t key, int depth);


### PR DESCRIPTION
```
ELO   | 2.05 +- 3.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 12368 W: 2199 L: 2126 D: 8043
```

```
ELO   | 6.14 +- 4.75 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 5712 W: 845 L: 744 D: 4123
```