### PR TITLE
Correctly calculate TT table pressure

### DIFF
--- a/src/TranspositionTable.cpp
+++ b/src/TranspositionTable.cpp
@@ -92,7 +92,7 @@ int TranspositionTable::GetCapacity(int halfmove) const
 
     for (int i = 0; i < 1000; i++) //1000 chosen specifically, because result needs to be 'per mill'
     {
-        if (table[i / TTBucket::SIZE].entry[i % TTBucket::SIZE].GetAge() == static_cast<char>(halfmove % HALF_MOVE_MODULO))
+        if (table[i / TTBucket::SIZE].entry[i % TTBucket::SIZE].GetAge() == TTEntry::CalculateAge(halfmove, 0))
             count++;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 16);
 
-string version = "10.23.1";
+string version = "10.23.5";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 0.36 +- 4.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [-10.00, 0.00]
GAMES | N: 6792 W: 1201 L: 1194 D: 4397
```