### PR TITLE
Simplify the code for history tables

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -396,7 +396,7 @@ SearchResult NegaScout(Position& position, unsigned int initialDepth, int depthR
                 break;
         }
 
-        int history = locals.history.GetButterfly(position, move) + locals.history.GetCounterMove(position, move);
+        int history = locals.history.Get(position, move);
 
         position.ApplyMove(move);
         tTable.PreFetch(position.GetZobristKey()); //load the transposition into l1 cache. ~5% speedup

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -259,6 +259,17 @@ void ThreadSharedData::PrintSearchInfo(unsigned int depth, double Time, bool isC
     std::cout << ss.str() << std::endl;
 }
 
+void History::Add(const Position& position, Move move, int change)
+{
+    AddButterfly(position, move, change);
+    AddCounterMove(position, move, change);
+}
+
+int History::Get(const Position& position, Move move) const
+{
+    return GetButterfly(position, move) + GetCounterMove(position, move);
+}
+
 void History::AddHistory(int16_t& val, int change, int max, int scale)
 {
     val += scale * change - val * abs(change) * scale / max;

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -22,6 +22,18 @@ class History
 {
 public:
     History() { Reset(); }
+    void Reset();
+
+    void Add(const Position& position, Move move, int change);
+    int Get(const Position& position, Move move) const;
+
+private:
+    // Tuneable history constants
+    static constexpr int Butterfly_max = 16384;
+    static constexpr int Butterfly_scale = 32;
+
+    static constexpr int CounterMove_max = 16384;
+    static constexpr int CounterMove_scale = 64;
 
     void AddButterfly(const Position& position, Move move, int change);
     int16_t GetButterfly(const Position& position, Move move) const;
@@ -29,16 +41,6 @@ public:
     void AddCounterMove(const Position& position, Move move, int change);
     int16_t GetCounterMove(const Position& position, Move move) const;
 
-    // Tuneable history constants
-    static int Butterfly_max;
-    static int Butterfly_scale;
-
-    static int CounterMove_max;
-    static int CounterMove_scale;
-
-    void Reset();
-
-private:
     void AddHistory(int16_t& val, int change, int max, int scale);
 
     // [side][from][to]
@@ -50,12 +52,6 @@ private:
     std::unique_ptr<ButterflyType> butterfly;
     std::unique_ptr<CounterMoveType> counterMove;
 };
-
-inline int History::Butterfly_max = 16384;
-inline int History::Butterfly_scale = 32;
-
-inline int History::CounterMove_max = 16384;
-inline int History::CounterMove_scale = 64;
 
 struct SearchData
 {

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -130,15 +130,14 @@ bool StagedMoveGenerator::Next(Move& move)
 
 void StagedMoveGenerator::AdjustHistory(const Move& move, SearchData& Locals, int depthRemaining) const
 {
-    Locals.history.AddButterfly(position, move, depthRemaining * depthRemaining);
-    Locals.history.AddCounterMove(position, move, depthRemaining * depthRemaining);
+    Locals.history.Add(position, move, depthRemaining * depthRemaining);
 
     for (auto const& m : quietMoves)
     {
         if (m.move == move)
             break;
-        Locals.history.AddButterfly(position, m.move, -depthRemaining * depthRemaining);
-        Locals.history.AddCounterMove(position, m.move, -depthRemaining * depthRemaining);
+
+        Locals.history.Add(position, m.move, -depthRemaining * depthRemaining);
     }
 }
 
@@ -297,7 +296,7 @@ void StagedMoveGenerator::OrderMoves(ExtendedMoveList& moves)
         // Quiet
         else
         {
-            int history = locals.history.GetButterfly(position, moves[i].move) + locals.history.GetCounterMove(position, moves[i].move);
+            int history = locals.history.Get(position, moves[i].move);
             moves[i].score = std::clamp<int>(history, std::numeric_limits<decltype(moves[i].score)>::min(), std::numeric_limits<decltype(moves[i].score)>::max());
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ uint64_t PerftDivide(unsigned int depth, Position& position);
 uint64_t Perft(unsigned int depth, Position& position);
 void Bench(int depth = 14);
 
-string version = "10.23.11";
+string version = "10.23.12";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 0.45 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 22920 W: 4006 L: 3976 D: 14938
```