### PR TITLE
Improve pinned piece detection

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position);
 uint64_t Perft(unsigned int depth, GameState& position);
 void Bench(int depth = 14);
 
-string version = "11.2";
+string version = "11.2.1";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
ELO   | 4.17 +- 12.84 (95%)
CONF  | 8.0+0.08s Threads=1 Hash=8MB
GAMES | N: 1000 W: 184 L: 172 D: 644
```

Tested for non-regression.

Baseline perft: `63768194 nps`
Current perft: `65712350 nps`
Change: `+3.05%`