### PR TITLE
Use the in-check move generators in regular search

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position);
 uint64_t Perft(unsigned int depth, GameState& position);
 void Bench(int depth = 14);
 
-string version = "11.2.1";
+string version = "11.3";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Tested for non-regression:
```
ELO   | 8.96 +- 12.56 (95%)
CONF  | 8.0+0.08s Threads=1 Hash=8MB
GAMES | N: 1008 W: 186 L: 160 D: 662
```

Bench speed comparison:
```
        dev       |      master      |
        mu        |        mu        |     SE      DF      t         p     speedup (%) 
------------------+------------------|
       3281000.000|       3175000.000|
       3296500.000|       3187500.000| 19912.308   2   5.474001   0.031790   3.362122  
       3300000.000|       3190000.000| 12274.635   4   8.961570   0.000858   3.389831  
       3306000.000|       3188750.000| 10625.245   6   11.035040  0.000033   3.610609  
       3304400.000|       3180200.000| 11974.974   8   10.371630  0.000006   3.830614  
       3299166.667|       3181333.333| 11147.745   10  10.570150  0.000001   3.636551  
       3298285.714|       3178285.714|  9941.324   12  12.070826  0.000000   3.705664  
       3297625.000|       3176000.000|  8932.160   14  13.616527  0.000000   3.757555  
       3296888.889|       3170444.444|  9667.465   16  13.079380  0.000000   3.910250  
       3295200.000|       3169500.000|  8860.712   18  14.186218  0.000000   3.888812  
       3294727.273|       3168363.636|  8108.765   20  15.583586  0.000000   3.910316  
       3292750.000|       3168416.667|  7661.972   22  16.227329  0.000000   3.848634  
       3290692.308|       3168153.846|  7346.926   24  16.678876  0.000000   3.794438  
       3289142.857|       3167571.429|  7000.449   26  17.366234  0.000000   3.765737  
       3289266.667|       3166466.667|  6611.198   28  18.574546  0.000000   3.804370  
       3289062.500|       3165687.500|  6236.444   30  19.782910  0.000000   3.822766  
       3286588.235|       3164529.412|  6463.800   32  18.883447  0.000000   3.784114  
       3286000.000|       3162555.556|  6432.771   34  19.189934  0.000000   3.828592  
       3285684.211|       3161473.684|  6188.284   36  20.071885  0.000000   3.853187  
       3285550.000|       3160350.000|  5978.800   38  20.940656  0.000000   3.884640  
       3286285.714|       3159428.571|  5807.923   40  21.842083  0.000000   3.936170  
       3286000.000|       3158636.364|  5601.308   42  22.738194  0.000000   3.952547  
       3285782.609|       3158782.609|  5358.645   44  23.700023  0.000000   3.941305  
       3285791.667|       3158541.667|  5136.174   46  24.775251  0.000000   3.949206  
       3287080.000|       3158280.000|  5098.836   48  25.260665  0.000000   3.996674  
       3286423.077|       3158653.846|  4956.772   50  25.776703  0.000000   3.964863  
       3285592.593|       3158148.148|  4867.756   52  26.181353  0.000000   3.955604  
       3285714.286|       3156714.286|  4906.457   54  26.291885  0.000000   4.004701  
       3285896.552|       3156482.759|  4743.408   56  27.282875  0.000000   4.017578  
       3285966.667|       3156533.333|  4583.382   58  28.239697  0.000000   4.018109  
       3286612.903|       3157483.871|  4579.653   60  28.196248  0.000000   4.007669  
       3286125.000|       3158375.000|  4549.127   62  28.082311  0.000000   3.964621  
       3286575.758|       3158909.091|  4464.166   64  28.598101  0.000000   3.961429  
       3287470.588|       3158794.118|  4423.849   66  29.086997  0.000000   3.992280  
       3287771.429|       3159200.000|  4325.202   68  29.726111  0.000000   3.988584  
       3287833.333|       3159500.000|  4214.487   70  30.450519  0.000000   3.980974  
       3287378.378|       3158594.595|  4222.386   72  30.500238  0.000000   3.995790  
       3287921.053|       3158657.895|  4145.926   74  31.178356  0.000000   4.010287  
       3288410.256|       3158461.538|  4072.482   76  31.908976  0.000000   4.031373  
       3288125.000|       3158225.000|  3986.624   78  32.583959  0.000000   4.030188  
       3288170.732|       3158073.171|  3891.406   80  33.432020  0.000000   4.036383  
       3288238.095|       3158571.429|  3830.763   82  33.848788  0.000000   4.022662  
       3288302.326|       3158325.581|  3749.235   84  34.667539  0.000000   4.032395  
       3288181.818|       3157931.818|  3686.108   86  35.335376  0.000000   4.041195  
       3288288.889|       3158244.444|  3618.384   88  35.939921  0.000000   4.034554  
       3288000.000|       3158891.304|  3609.064   90  35.773459  0.000000   4.005301  
       3287553.191|       3158617.021|  3570.146   92  36.115100  0.000000   4.000396  
       3288250.000|       3158166.667|  3592.105   94  36.213674  0.000000   4.035834  
       3287714.286|       3158448.980|  3569.769   96  36.211114  0.000000   4.010612  
       3287940.000|       3158640.000|  3510.122   98  36.836329  0.000000   4.011429  
       3288333.333|       3159156.863|  3501.377  100  36.893052  0.000000   4.007031
```

Baseline perft: `65257723 nps`
Current perft: `65682443 nps`
Change: `+0.65%`