### PR TITLE
Align network weights/bias/accumulators to 32 bytes for better AVX2 support

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -11,10 +11,10 @@
 
 INCBIN(Net, EVALFILE);
 
-std::array<std::array<int16_t, HIDDEN_NEURONS>, INPUT_NEURONS> Network::hiddenWeights = {};
-std::array<int16_t, HIDDEN_NEURONS> Network::hiddenBias = {};
-std::array<int16_t, HIDDEN_NEURONS* 2> Network::outputWeights = {};
-int16_t Network::outputBias = {};
+alignas(32) std::array<std::array<int16_t, HIDDEN_NEURONS>, INPUT_NEURONS> Network::hiddenWeights = {};
+alignas(32) std::array<int16_t, HIDDEN_NEURONS> Network::hiddenBias = {};
+alignas(32) std::array<int16_t, HIDDEN_NEURONS* 2> Network::outputWeights = {};
+alignas(32) int16_t Network::outputBias = {};
 
 constexpr int16_t L1_SCALE = 128;
 constexpr int16_t L2_SCALE = 128;

--- a/src/Network.h
+++ b/src/Network.h
@@ -13,7 +13,7 @@ class BoardState;
 
 struct HalfAccumulator
 {
-    std::array<std::array<int16_t, HIDDEN_NEURONS>, N_PLAYERS> side;
+    alignas(32) std::array<std::array<int16_t, HIDDEN_NEURONS>, N_PLAYERS> side;
 
     bool operator==(const HalfAccumulator& rhs) const { return side == rhs.side; }
 };
@@ -45,8 +45,8 @@ private:
 
     std::vector<HalfAccumulator> AccumulatorStack;
 
-    static std::array<std::array<int16_t, HIDDEN_NEURONS>, INPUT_NEURONS> hiddenWeights;
-    static std::array<int16_t, HIDDEN_NEURONS> hiddenBias;
-    static std::array<int16_t, HIDDEN_NEURONS * 2> outputWeights;
-    static int16_t outputBias;
+    alignas(32) static std::array<std::array<int16_t, HIDDEN_NEURONS>, INPUT_NEURONS> hiddenWeights;
+    alignas(32) static std::array<int16_t, HIDDEN_NEURONS> hiddenBias;
+    alignas(32) static std::array<int16_t, HIDDEN_NEURONS * 2> outputWeights;
+    alignas(32) static int16_t outputBias;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 14);
 
-string version = "11.4.1";
+string version = "11.4.2";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
Elo   | 1.63 +- 4.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 13406 W: 3505 L: 3442 D: 6459
Penta | [165, 1542, 3244, 1569, 183]
```