### PR TITLE
Rewrite search control flow to avoid exceptions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,7 @@ PEXTFLAGS   = $(POPCNTFLAGS) -DUSE_PEXT -mbmi2
 AVX2FLAGS   = -DUSE_AVX2 -msse -msse3 -mpopcnt -mavx2 -msse4.1 -mssse3 -msse2
 
 LDFLAGS   = -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -lm
-CXXFLAGS := $(INC_FLAGS) -MMD -MP -DEVALFILE=\"$(EVALFILE)\"
+CXXFLAGS := -fno-exceptions -MMD -MP -DEVALFILE=\"$(EVALFILE)\"
 
 ifeq ($(OS),Windows_NT)     # is Windows_NT on XP, 2000, 7, Vista, 10...
     detected_OS := Windows

--- a/src/MoveGeneration.cpp
+++ b/src/MoveGeneration.cpp
@@ -66,14 +66,13 @@ void LegalMoves(const BoardState& board, T& moves)
 template <typename T>
 void QuiescenceMoves(const BoardState& board, T& moves)
 {
-    switch (board.stm)
+    if (board.stm == WHITE)
     {
-    case WHITE:
         return AddQuiescenceMoves<WHITE>(board, moves, PinnedMask<WHITE>(board));
-    case BLACK:
+    }
+    else
+    {
         return AddQuiescenceMoves<BLACK>(board, moves, PinnedMask<BLACK>(board));
-    default:
-        throw std::invalid_argument("board object without turn set");
     }
 }
 
@@ -120,14 +119,13 @@ void AddQuiescenceMoves(const BoardState& board, T& moves, uint64_t pinned)
 template <typename T>
 void QuietMoves(const BoardState& board, T& moves)
 {
-    switch (board.stm)
+    if (board.stm == WHITE)
     {
-    case WHITE:
         return AddQuietMoves<WHITE>(board, moves, PinnedMask<WHITE>(board));
-    case BLACK:
+    }
+    else
+    {
         return AddQuietMoves<BLACK>(board, moves, PinnedMask<BLACK>(board));
-    default:
-        throw std::invalid_argument("board object without turn set");
     }
 }
 

--- a/src/Score.h
+++ b/src/Score.h
@@ -7,10 +7,6 @@
 class Score
 {
 public:
-    // This makes Score trivial allowing uninitialized allocation within arrays.
-    // TODO: this isn't the case anymore
-    Score() = default;
-
     constexpr Score(int value)
         : value_(value)
     {
@@ -147,8 +143,6 @@ public:
 private:
     int16_t value_;
 };
-
-static_assert(std::is_trivial_v<Score>);
 
 static constexpr Score SCORE_UNDEFINED = -32768;
 

--- a/src/Score.h
+++ b/src/Score.h
@@ -150,6 +150,8 @@ private:
 
 static_assert(std::is_trivial_v<Score>);
 
+static constexpr Score SCORE_UNDEFINED = -32768;
+
 namespace std
 {
 template <>

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -6,10 +6,8 @@
 #include <atomic>
 #include <cmath>
 #include <ctime>
-#include <exception>
 #include <iostream>
 #include <limits>
-#include <memory>
 #include <thread>
 #include <vector>
 
@@ -73,6 +71,8 @@ void UpdateScore(Score newScore, Score& score, Move& bestMove, const Move& move)
 SearchResult Quiescence(GameState& position, unsigned int initialDepth, Score alpha, Score beta, int colour,
     unsigned int distanceFromRoot, int depthRemaining, SearchData& locals, ThreadSharedData& sharedData);
 
+bool should_abort_search(int initial_depth, SearchData& locals, const ThreadSharedData& shared_data);
+
 uint64_t SearchThread(GameState position, ThreadSharedData& sharedData)
 {
     // Probe TB at root
@@ -128,22 +128,6 @@ void PrintBestMove(Move Best, const BoardState& board, bool chess960)
     std::cout << std::endl;
 }
 
-struct TimeAbort : public std::exception
-{
-    const char* what() const throw()
-    {
-        return "no more time remaining";
-    }
-};
-
-struct ThreadDepthAbort : public std::exception
-{
-    const char* what() const throw()
-    {
-        return "another thread finished this depth";
-    }
-};
-
 void SearchPosition(GameState position, ThreadSharedData& sharedData, unsigned int threadID)
 {
     auto alpha = std::numeric_limits<Score>::min();
@@ -163,26 +147,29 @@ void SearchPosition(GameState position, ThreadSharedData& sharedData, unsigned i
         if (!sharedData.GetLimits().ShouldContinueSearch())
             sharedData.ReportWantsToStop(threadID);
 
-        try
+        SearchResult curSearch
+            = AspirationWindowSearch(position, depth, prevScore, sharedData.GetData(threadID), sharedData);
+
+        // If we aborted because another thread finished the depth we were on, get that score and continue to that
+        // depth.
+        if (sharedData.ThreadAbort(depth))
         {
-            SearchResult curSearch
-                = AspirationWindowSearch(position, depth, prevScore, sharedData.GetData(threadID), sharedData);
-            sharedData.ReportResult(depth, sharedData.GetLimits().ElapsedTime(), curSearch.GetScore(), alpha, beta,
-                position, curSearch.GetMove(), sharedData.GetData(threadID), sharedData.GetParameters().chess960);
-            if (sharedData.GetLimits().HitMateLimit(curSearch.GetScore()))
-                break;
-            prevScore = curSearch.GetScore();
-        }
-        catch (ThreadDepthAbort&)
-        {
-            // curSearch probably is some garbage result, make sure not to use it for anything
             prevScore = sharedData.GetAspirationScore();
+            sharedData.GetData(threadID).aborting_search = false;
+            continue;
         }
-        catch (TimeAbort&)
+
+        // Else, if we aborted then we should return
+        if (sharedData.GetData(threadID).aborting_search)
         {
-            // no time to wait around, return immediately.
             return;
         }
+
+        sharedData.ReportResult(depth, sharedData.GetLimits().ElapsedTime(), curSearch.GetScore(), alpha, beta,
+            position, curSearch.GetMove(), sharedData.GetData(threadID), sharedData.GetParameters().chess960);
+        if (sharedData.GetLimits().HitMateLimit(curSearch.GetScore()))
+            break;
+        prevScore = curSearch.GetScore();
     }
 }
 
@@ -200,6 +187,11 @@ SearchResult AspirationWindowSearch(
         locals.ResetSeldepth();
         search = NegaScout(
             position, depth, depth, alpha, beta, position.Board().stm ? 1 : -1, 0, false, locals, sharedData);
+
+        if (locals.aborting_search)
+        {
+            return SCORE_UNDEFINED;
+        }
 
         if (alpha < search.GetScore() && search.GetScore() < beta)
             break;
@@ -233,20 +225,18 @@ SearchResult AspirationWindowSearch(
 SearchResult NegaScout(GameState& position, unsigned int initialDepth, int depthRemaining, Score alpha, Score beta,
     int colour, unsigned int distanceFromRoot, bool allowedNull, SearchData& locals, ThreadSharedData& sharedData)
 {
+    // check if we should abort the search
+    if (should_abort_search(initialDepth, locals, sharedData))
+    {
+        return SCORE_UNDEFINED;
+    }
+
     locals.ReportDepth(distanceFromRoot);
     locals.AddNode();
 
     if (distanceFromRoot >= MAX_DEPTH)
         return 0; // Have we reached max depth?
     locals.PvTable[distanceFromRoot].clear();
-
-    // See if we should abort the search
-    if (initialDepth > 1 && !KeepSearching)
-        throw TimeAbort();
-    if (initialDepth > 1 && locals.GetThreadNodes() % 1024 == 0 && sharedData.GetLimits().HitTimeLimit())
-        throw TimeAbort(); // Am I out of time?
-    if (sharedData.ThreadAbort(initialDepth))
-        throw ThreadDepthAbort(); // Has this depth been finished by another thread?
 
     if (DeadPosition(position.Board()))
         return 0; // Is this position a dead draw?
@@ -460,7 +450,9 @@ SearchResult NegaScout(GameState& position, unsigned int initialDepth, int depth
         UpdateScore(newScore, score, bestMove, move);
         UpdateAlpha(score, a, move, distanceFromRoot, locals);
 
-        if (a >= beta) // Fail high cutoff
+        // avoid updating Killers or History when aborting the search
+        // check for fail high cutoff
+        if (!locals.aborting_search && a >= beta)
         {
             AddKiller(move, distanceFromRoot, locals.KillerMoves);
             AddHistory(gen, move, locals, depthRemaining);
@@ -478,7 +470,11 @@ SearchResult NegaScout(GameState& position, unsigned int initialDepth, int depth
 
     score = std::min(score, MaxScore);
 
-    AddScoreToTable(score, alpha, position.Board(), depthRemaining, distanceFromRoot, beta, bestMove);
+    // avoid adding scores to the TT when we are aborting the search
+    if (!locals.aborting_search)
+    {
+        AddScoreToTable(score, alpha, position.Board(), depthRemaining, distanceFromRoot, beta, bestMove);
+    }
 
     return SearchResult(score, bestMove);
 }
@@ -676,6 +672,12 @@ Score TerminalScore(const BoardState& board, int distanceFromRoot)
 SearchResult Quiescence(GameState& position, unsigned int initialDepth, Score alpha, Score beta, int colour,
     unsigned int distanceFromRoot, int depthRemaining, SearchData& locals, ThreadSharedData& sharedData)
 {
+    // check if we should abort the search
+    if (should_abort_search(initialDepth, locals, sharedData))
+    {
+        return SCORE_UNDEFINED;
+    }
+
     locals.ReportDepth(distanceFromRoot);
     locals.AddNode();
 
@@ -683,13 +685,6 @@ SearchResult Quiescence(GameState& position, unsigned int initialDepth, Score al
         return 0; // Have we reached max depth?
     locals.PvTable[distanceFromRoot].clear();
 
-    // See if we should abort the search
-    if (initialDepth > 1 && !KeepSearching)
-        throw TimeAbort();
-    if (initialDepth > 1 && locals.GetThreadNodes() % 1024 == 0 && sharedData.GetLimits().HitTimeLimit())
-        throw TimeAbort(); // Am I out of time?
-    if (sharedData.ThreadAbort(initialDepth))
-        throw ThreadDepthAbort(); // Has this depth been finished by another thread?
     if (DeadPosition(position.Board()))
         return 0; // Is this position a dead draw?
 
@@ -749,4 +744,37 @@ void AddHistory(const StagedMoveGenerator& gen, const Move& move, SearchData& lo
     if (depthRemaining > 20 || move.IsCapture() || move.IsPromotion())
         return;
     gen.AdjustHistory(move, locals, depthRemaining);
+}
+
+bool should_abort_search(int initial_depth, SearchData& locals, const ThreadSharedData& shared_data)
+{
+    // If we are currently in the process of aborting, do so as quickly as possible
+    if (locals.aborting_search)
+    {
+        return true;
+    }
+
+    // See if we should abort the search. We get this signal if all threads have decided they want to stop, or we
+    // receive a 'stop' command from the uci input
+    if (initial_depth > 1 && !KeepSearching)
+    {
+        locals.aborting_search = true;
+        return true;
+    }
+
+    // Check if we have breached the time limit.
+    if (initial_depth > 1 && locals.GetThreadNodes() % 1024 == 0 && shared_data.GetLimits().HitTimeLimit())
+    {
+        locals.aborting_search = true;
+        return true;
+    }
+
+    // If the current depth has been completed by another thread, we abort and resume at the higher depth
+    if (shared_data.ThreadAbort(initial_depth))
+    {
+        locals.aborting_search = true;
+        return true;
+    }
+
+    return false;
 }

--- a/src/Search.h
+++ b/src/Search.h
@@ -62,4 +62,4 @@ private:
     Move m_move;
 };
 
-uint64_t SearchThread(GameState position, ThreadSharedData& sharedData);
+uint64_t SearchThread(GameState& position, ThreadSharedData& sharedData);

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -31,6 +31,7 @@ void SearchData::ResetNewSearch()
     nodes = 0;
     selDepth = 0;
     threadWantsToStop = false;
+    aborting_search = false;
 
     PvTable = {};
     KillerMoves = {};

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -198,9 +198,9 @@ private:
     // Whoever finishes first gets to update this as long as they searched deeper than threadDepth
     Move currentBestMove;
     // if threads abandon the search, we need to know what the score was in order to set new alpha/beta bounds
-    Score prevScore;
-    Score lowestAlpha;
-    Score highestBeta;
+    Score prevScore = 0;
+    Score lowestAlpha = 0;
+    Score highestBeta = 0;
 
     SearchParameters param;
     SearchLimits limits_;

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -109,6 +109,9 @@ public:
     void ResetNewSearch();
     void ResetNewGame();
 
+    // Set to true when the search is unwinding and trying to return.
+    bool aborting_search;
+
 private:
     friend class ThreadSharedData;
     uint64_t tbHits;
@@ -175,7 +178,7 @@ public:
         return param;
     }
 
-    const SearchLimits& GetLimits()
+    const SearchLimits& GetLimits() const
     {
         return limits_;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 14);
 
-string version = "11.4.2";
+string version = "11.4.6";
 
 int main(int argc, char* argv[])
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -203,7 +203,7 @@ int main(int argc, char* argv[])
                 searchThread.join();
 
             data.SetLimits(std::move(limits));
-            searchThread = thread([position, &data] { SearchThread(position, data); });
+            searchThread = thread([position, &data]() mutable { SearchThread(position, data); });
         }
 
         else if (token == "setoption")


### PR DESCRIPTION
```
Elo   | 5.21 +- 6.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 6202 W: 1636 L: 1543 D: 3023
Penta | [66, 691, 1512, 748, 84]
http://chess.grantnet.us/test/36183/
```