### PR TITLE
Adjust time controls to more smoothly apply the buffer time

### DIFF
--- a/src/SearchLimits.cpp
+++ b/src/SearchLimits.cpp
@@ -186,9 +186,9 @@ void SearchLimits::SetInfinite()
     mateLimit = std::make_unique<NullMateChecker>();
 }
 
-void SearchLimits::SetTimeLimits(int maxTime, int allocatedTime)
+void SearchLimits::SetTimeLimits(int soft_limit, int hard_limit)
 {
-    timeManager = SearchTimeManage(maxTime, allocatedTime);
+    timeManager = SearchTimeManage(soft_limit, hard_limit);
     timeLimit = std::make_unique<TimeChecker>();
 }
 

--- a/src/SearchLimits.h
+++ b/src/SearchLimits.h
@@ -27,7 +27,7 @@ public:
     // Returns true if more than half of the allocated time is remaining
     bool ShouldContinueSearch() const;
 
-    void SetTimeLimits(int maxTime, int allocatedTime);
+    void SetTimeLimits(int soft_limit, int hard_limit);
     void SetDepthLimit(int depth);
     void SetMateLimit(int moves);
     void SetNodeLimit(uint64_t nodes);
@@ -44,7 +44,7 @@ public:
     }
 
 private:
-    SearchTimeManage timeManager;
+    SearchTimeManage timeManager { 0, 0 };
 
     std::unique_ptr<iDepthChecker> depthLimit;
     std::unique_ptr<iTimeChecker> timeLimit;

--- a/src/TimeManage.cpp
+++ b/src/TimeManage.cpp
@@ -7,9 +7,9 @@ int Timer::ElapsedMs() const
     return (get_time_point() - Begin);
 }
 
-SearchTimeManage::SearchTimeManage(int maxTime, int allocatedTime)
-    : AllocatedSearchTimeMS(allocatedTime)
-    , MaxTimeMS(maxTime)
+SearchTimeManage::SearchTimeManage(int soft_limit, int hard_limit)
+    : soft_limit_(soft_limit)
+    , hard_limit_(hard_limit)
 {
 }
 
@@ -17,10 +17,18 @@ bool SearchTimeManage::ContinueSearch() const
 {
     // if AllocatedSearchTimeMS == MaxTimeMS then we have recieved a 'go movetime X' command and we should not abort
     // search early
-    return (AllocatedSearchTimeMS == MaxTimeMS || timer.ElapsedMs() < AllocatedSearchTimeMS / 2);
+    if (soft_limit_ == hard_limit_)
+    {
+        return true;
+    }
+
+    auto elapsed_ms = timer.ElapsedMs();
+
+    return (elapsed_ms < soft_limit_ / 2 && elapsed_ms < hard_limit_);
 }
 
 bool SearchTimeManage::AbortSearch() const
 {
-    return (timer.ElapsedMs() > (std::min)(AllocatedSearchTimeMS, MaxTimeMS - BufferTime));
+    auto elapsed_ms = timer.ElapsedMs();
+    return (elapsed_ms > soft_limit_ && elapsed_ms > hard_limit_);
 }

--- a/src/TimeManage.h
+++ b/src/TimeManage.h
@@ -54,7 +54,7 @@ private:
 class SearchTimeManage
 {
 public:
-    SearchTimeManage(int maxTime = 0, int allocatedTime = 0);
+    SearchTimeManage(int soft_limit, int hard_limit);
 
     bool ContinueSearch() const;
     bool AbortSearch() const; // Is the remaining time all used up?
@@ -71,8 +71,10 @@ public:
 
 private:
     Timer timer;
-    int AllocatedSearchTimeMS;
-    int MaxTimeMS;
 
-    constexpr static int BufferTime = 100;
+    // The amount of time we have allocated to this turn. If the position is indecisive the search might extend this
+    int soft_limit_;
+
+    // The hard limit we cannot exceed.
+    int hard_limit_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 14);
 
-string version = "11.4.7";
+string version = "11.5.0";
 
 int main(int argc, char* argv[])
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,6 +127,9 @@ int main(int argc, char* argv[])
         {
             shared->limits = {};
 
+            // The amount of time we leave on the clock for safety
+            constexpr static int BufferTime = 100;
+
             int wtime = 0;
             int btime = 0;
             int winc = 0;
@@ -169,7 +172,7 @@ int main(int argc, char* argv[])
                 {
                     int searchTime = 0;
                     iss >> searchTime;
-                    shared->limits.SetTimeLimits(searchTime, searchTime);
+                    shared->limits.SetTimeLimits(searchTime - BufferTime, searchTime - BufferTime);
                 }
 
                 else if (token == "nodes")
@@ -185,19 +188,31 @@ int main(int argc, char* argv[])
 
             if (myTime != 0)
             {
-                int AllocatedTime = 0;
-
                 if (movestogo != 0)
-                    AllocatedTime = myTime / (movestogo + 1) * 3 / 2; // repeating time control
-                else if (myInc != 0)
-                    // use a greater proportion of remaining time as the game continues, so that we use it all up and
-                    // get to just increment
-                    AllocatedTime = myTime * (1 + position.Board().half_turn_count / timeIncCoeffA) / timeIncCoeffB
-                        + myInc; // increment time control
-                else
-                    AllocatedTime = myTime / 20; // sudden death time control
+                {
+                    // repeating time control
 
-                shared->limits.SetTimeLimits(myTime, AllocatedTime);
+                    // We divide the available time by the number of movestogo (which can be zero) and then adjust
+                    // by 1.5x. This ensures we use more of the available time earlier.
+                    shared->limits.SetTimeLimits(
+                        (myTime - BufferTime) / (movestogo + 1) * 3 / 2, (myTime - BufferTime));
+                }
+                else if (myInc != 0)
+                {
+                    // increment time control
+
+                    // We start by using 1/30th of the remaining time plus the increment. As we move through the game we
+                    // use a higher proportion of the available time so that we get down to just using the increment
+                    shared->limits.SetTimeLimits(
+                        (myTime - BufferTime) * (1 + position.Board().half_turn_count / timeIncCoeffA) / timeIncCoeffB
+                            + myInc,
+                        (myTime - BufferTime));
+                }
+                else
+                {
+                    // Sudden death time control. We use 1/20th of the remaining time each turn
+                    shared->limits.SetTimeLimits((myTime - BufferTime) / 20, (myTime - BufferTime));
+                }
             }
 
             if (searchThread.joinable())


### PR DESCRIPTION
```
Elo   | 5.82 +- 5.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9492 W: 2532 L: 2373 D: 4587
Penta | [109, 1038, 2297, 1189, 113]
http://chess.grantnet.us/test/36202/
```

```
Elo   | 7.41 +- 5.78 (95%)
SPRT  | 8.0+0.00s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7410 W: 2064 L: 1906 D: 3440
Penta | [114, 804, 1740, 904, 143]
http://chess.grantnet.us/test/36203/
```

```
Elo   | 10.22 +- 7.13 (95%)
SPRT  | 40/8.0+0.00s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4592 W: 1225 L: 1090 D: 2277
Penta | [45, 463, 1153, 582, 53]
http://chess.grantnet.us/test/36204/
```
