### PR TITLE
Avoid duplicate search on Killer move when it is also the TT move

### DIFF
--- a/src/Search.h
+++ b/src/Search.h
@@ -28,7 +28,7 @@ constexpr int Delta_margin = 200;
 constexpr int SNMP_coeff = 119;
 constexpr int SNMP_depth = 8;
 
-constexpr int LMP_constant = 10;
+constexpr int LMP_constant = 11;
 constexpr int LMP_coeff = 7;
 constexpr int LMP_depth = 6;
 

--- a/src/StagedMoveGenerator.h
+++ b/src/StagedMoveGenerator.h
@@ -57,6 +57,11 @@ public:
         return stage;
     }
 
+    Move TTMove()
+    {
+        return TTmove;
+    }
+
 private:
     void OrderMoves(ExtendedMoveList& moves);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 14);
 
-string version = "11.5.4";
+string version = "11.5.5";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
Elo   | -2.47 +- 3.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -1.67 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 23810 W: 5871 L: 6040 D: 11899
Penta | [334, 2912, 5528, 2851, 280]
http://chess.grantnet.us/test/36288/
```
