### PR TITLE
Remove Killer move workaround, tune LMR scheme as a linear regression with interaction factor

### DIFF
--- a/src/Search.h
+++ b/src/Search.h
@@ -11,7 +11,9 @@ class SearchSharedState;
 /*Tuneable search constants*/
 
 constexpr double LMR_constant = -1.76;
-constexpr double LMR_coeff = 1.03;
+constexpr double LMR_depth_coeff = 0;
+constexpr double LMR_move_coeff = 0;
+constexpr double LMR_depth_move_coeff = 1.03;
 
 constexpr int Null_constant = 4;
 constexpr int Null_depth_quotent = 6;

--- a/src/Search.h
+++ b/src/Search.h
@@ -10,10 +10,10 @@ class SearchSharedState;
 
 /*Tuneable search constants*/
 
-constexpr double LMR_constant = -1.76;
-constexpr double LMR_depth_coeff = 0;
-constexpr double LMR_move_coeff = 0;
-constexpr double LMR_depth_move_coeff = 1.03;
+constexpr double LMR_constant = -0.76;
+constexpr double LMR_depth_coeff = 0.39;
+constexpr double LMR_move_coeff = 0.12;
+constexpr double LMR_depth_move_coeff = 0.67;
 
 constexpr int Null_constant = 4;
 constexpr int Null_depth_quotent = 6;

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -72,7 +72,7 @@ bool StagedMoveGenerator::Next(Move& move)
         Killer1 = ss->killers[0];
         stage = Stage::GIVE_KILLER_2;
 
-        if (MoveIsLegal(position.Board(), Killer1))
+        if (Killer1 != TTmove && MoveIsLegal(position.Board(), Killer1))
         {
             move = Killer1;
             return true;
@@ -84,7 +84,7 @@ bool StagedMoveGenerator::Next(Move& move)
         Killer2 = ss->killers[1];
         stage = Stage::GIVE_BAD_LOUD;
 
-        if (MoveIsLegal(position.Board(), Killer2))
+        if (Killer1 != TTmove && MoveIsLegal(position.Board(), Killer2))
         {
             move = Killer2;
             return true;

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -84,7 +84,7 @@ bool StagedMoveGenerator::Next(Move& move)
         Killer2 = ss->killers[1];
         stage = Stage::GIVE_BAD_LOUD;
 
-        if (Killer1 != TTmove && MoveIsLegal(position.Board(), Killer2))
+        if (Killer2 != TTmove && MoveIsLegal(position.Board(), Killer2))
         {
             move = Killer2;
             return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 14);
 
-string version = "11.5.5";
+string version = "11.6.0";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Removing the killer workaround causes elo loss due to interactions with LMR. After tuning LMR with a new scheme the patch overall gains elo.
```
Elo   | 4.19 +- 3.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13668 W: 3199 L: 3034 D: 7435
Penta | [92, 1566, 3360, 1717, 99]
http://chess.grantnet.us/test/36304/
```
```
Elo   | 4.51 +- 4.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13868 W: 3527 L: 3347 D: 6994
Penta | [156, 1646, 3201, 1724, 207]
http://chess.grantnet.us/test/36302/
```