### PR TITLE
Add singular extensions

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -447,7 +447,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
             && tt_entry.has_value() && tt_entry->GetDepth() + 2 >= depthRemaining
             && tt_entry->GetCutoff() != EntryType::UPPERBOUND && tt_entry->GetMove() == move)
         {
-            Score sbeta = tt_entry->GetScore() - depthRemaining * 2;
+            Score sbeta = tt_entry->GetScore() - depthRemaining * 4;
             int sdepth = depthRemaining / 2;
 
             ss->singular_exclusion = move;

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -447,7 +447,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
             && tt_entry.has_value() && tt_entry->GetDepth() + 2 >= depthRemaining
             && tt_entry->GetCutoff() != EntryType::UPPERBOUND && tt_entry->GetMove() == move)
         {
-            Score sbeta = tt_entry->GetScore() - depthRemaining * 4;
+            Score sbeta = tt_entry->GetScore() - depthRemaining * 2;
             int sdepth = depthRemaining / 2;
 
             ss->singular_exclusion = move;
@@ -514,7 +514,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
 
         // avoid updating Killers or History when aborting the search, or during a singular extension
         // check for fail high cutoff
-        if (!local.aborting_search && ss->singular_exclusion == Move::Uninitialized && a >= beta)
+        if (!local.aborting_search && a >= beta)
         {
             AddKiller(move, ss->killers);
             AddHistory(gen, move, depthRemaining);

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -512,7 +512,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
         UpdateScore(newScore, score, bestMove, move);
         UpdateAlpha(score, a, move, ss);
 
-        // avoid updating Killers or History when aborting the search, or during a singular extension
+        // avoid updating Killers or History when aborting the search
         // check for fail high cutoff
         if (!local.aborting_search && a >= beta)
         {

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -27,6 +27,7 @@ struct SearchStackState
     std::array<Move, 2> killers = {};
 
     Move move = Move::Uninitialized;
+    Move singular_exclusion = Move::Uninitialized;
 };
 
 class SearchStack

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -72,7 +72,7 @@ bool StagedMoveGenerator::Next(Move& move)
         Killer1 = ss->killers[0];
         stage = Stage::GIVE_KILLER_2;
 
-        if (MoveIsLegal(position.Board(), Killer1))
+        if (Killer1 != TTmove && MoveIsLegal(position.Board(), Killer1))
         {
             move = Killer1;
             return true;
@@ -84,7 +84,7 @@ bool StagedMoveGenerator::Next(Move& move)
         Killer2 = ss->killers[1];
         stage = Stage::GIVE_BAD_LOUD;
 
-        if (MoveIsLegal(position.Board(), Killer2))
+        if (Killer2 != TTmove && MoveIsLegal(position.Board(), Killer2))
         {
             move = Killer2;
             return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 14);
 
-string version = "11.6.0";
+string version = "11.7.0";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
Elo   | 12.70 +- 7.72 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3422 W: 816 L: 691 D: 1915
Penta | [20, 357, 830, 486, 18]
http://chess.grantnet.us/test/36314/
```
```
Elo   | 4.59 +- 4.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13616 W: 3370 L: 3190 D: 7056
Penta | [184, 1560, 3130, 1760, 174]
http://chess.grantnet.us/test/36312/
```