### PR TITLE
Use hardware_destructive_interference_size to avoid false sharing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 10);
 
-string version = "11.11.0";
+string version = "11.11.1";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
Elo   | 0.60 +- 3.25 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 19692 W: 4454 L: 4420 D: 10818
Penta | [111, 2313, 4965, 2345, 112]
http://chess.grantnet.us/test/36587/
```