### PR TITLE
Fix time loss bug

### DIFF
--- a/src/TimeManage.cpp
+++ b/src/TimeManage.cpp
@@ -30,5 +30,5 @@ bool SearchTimeManage::ContinueSearch() const
 bool SearchTimeManage::AbortSearch() const
 {
     auto elapsed_ms = timer.ElapsedMs();
-    return (elapsed_ms > soft_limit_ && elapsed_ms > hard_limit_);
+    return (elapsed_ms >= soft_limit_ || elapsed_ms >= hard_limit_);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 10);
 
-string version = "11.7.3";
+string version = "11.8.0";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
$ ./cutechess-ob -repeat -recover -variant standard -concurrency 20 -games 1280 -engine dir=Engines/ cmd=./Halogen-time-fix.exe proto=uci tc=0.001+1 option.Threads=1 option.Hash=8 name=Halogen-time-fix -engine dir=Engines/ cmd=./Halogen-no-fix.exe proto=uci tc=0.001+1 option.Threads=1 option.Hash=8 name=Halogen-no-fix -openings file=Books/UHO_4060_v2.epd format=epd order=random start=1 -srand 36525 -pgnout PGNs/time_test.pgn

Finished game 170 (Halogen-no-fix vs Halogen-time-fix): 0-1 {White loses on time}
Score of Halogen-time-fix vs Halogen-no-fix: 68 - 27 - 56  [0.636] 151
```
At high increment time controls soft_limit_ may be much greater than hard_limit_, and the logic to abort the search may result in a time-loss. This fix appears to lose ELO at STC, but I suspect this is simply due to abusing the OB timemargin of 250ms. 

```
Elo   | -18.14 +- 9.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 2396 W: 532 L: 657 D: 1207
Penta | [33, 312, 620, 213, 20]
```