### PR TITLE
Add double singular extensions

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -259,6 +259,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
         return 0; // Have we reached max depth?
 
     ss->pv.clear();
+    ss->multiple_extensions = (ss - 1)->multiple_extensions;
 
     if (DeadPosition(position.Board()))
         return 0; // Is this position a dead draw?
@@ -472,7 +473,16 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
 
             ss->singular_exclusion = Move::Uninitialized;
 
-            if (result.GetScore() < sbeta)
+            // Extending the SE idea, if the score is far below sbeta we extend by two. To avoid extending too much down
+            // forced lines we limit the number of multiple_extensions down one line. We focus on non_pv nodes becuase
+            // in particular we want to verify cut nodes which rest on a single good move and ensure we haven't
+            // overlooked a potential non-pv line.
+            if (!pv_node && result.GetScore() < sbeta - 16 && ss->multiple_extensions < 8)
+            {
+                extensions += 2;
+                ss->multiple_extensions++;
+            }
+            else if (result.GetScore() < sbeta)
             {
                 extensions += 1;
             }

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -28,6 +28,7 @@ struct SearchStackState
 
     Move move = Move::Uninitialized;
     Move singular_exclusion = Move::Uninitialized;
+    int multiple_extensions = 0;
 };
 
 class SearchStack

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 10);
 
-string version = "11.8.0";
+string version = "11.9.0";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
Elo   | 4.11 +- 3.87 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13534 W: 3047 L: 2887 D: 7600
Penta | [60, 1551, 3397, 1687, 72]
http://chess.grantnet.us/test/36531/
```
```
Elo   | 3.52 +- 3.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 19348 W: 4627 L: 4431 D: 10290
Penta | [185, 2263, 4616, 2391, 219]
http://chess.grantnet.us/test/36491/
```