### PR TITLE
Add Multi-Cut pruning

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -490,7 +490,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
             // Multi-Cut: In this case, we have proven that at least one other move appears to fail high, along with
             // the TT move having a LOWER_BOUND score of significantly above beta. In this case, we can assume the node
             // will fail high and we return a soft bound.
-            else if (sbeta > beta)
+            else if (sbeta >= beta)
             {
                 return sbeta;
             }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -476,6 +476,14 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
             {
                 extensions += 1;
             }
+
+            // Multi-Cut: In this case, we have proven that at least one other move appears to fail high, along with
+            // the TT move having a LOWER_BOUND score of significantly above beta. In this case, we can assume the node
+            // will fail high and we return a soft bound.
+            else if (sbeta > beta)
+            {
+                return sbeta;
+            }
         }
 
         int history = local.history.Get(position, ss, move);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 10);
 
-string version = "11.9.0";
+string version = "11.10.0";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
Elo   | 3.62 +- 3.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16612 W: 3835 L: 3662 D: 9115
Penta | [98, 1875, 4199, 2024, 110]
http://chess.grantnet.us/test/36545/
```
```
Elo   | 3.27 +- 3.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22008 W: 5210 L: 5003 D: 11795
Penta | [205, 2553, 5309, 2704, 233]
http://chess.grantnet.us/test/36494/
```