### PR TITLE
Adjust TT replacement scheme for matching keys

### DIFF
--- a/src/TranspositionTable.cpp
+++ b/src/TranspositionTable.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <iostream>
 #include <iterator>
 #include <optional>
 
@@ -27,26 +28,37 @@ void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, Score s
     if (score < Score::Limits::EVAL_MIN)
         score -= distanceFromRoot;
 
-    for (auto& entry : table[hash].entry)
-    {
-        if (entry.GetKey() == EMPTY || entry.GetKey() == ZobristKey)
-        {
-            entry = TTEntry(best, ZobristKey, score, Depth, Turncount, distanceFromRoot, Cutoff);
-            return;
-        }
-    }
-
     // Keep in mind age from each generation goes up so lower (generally) means older
     int8_t currentAge = TTEntry::CalculateAge(Turncount, distanceFromRoot);
     std::array<int8_t, TTBucket::SIZE> scores = {};
+    auto& bucket = table[hash].entry;
 
     for (size_t i = 0; i < TTBucket::SIZE; i++)
     {
-        int8_t age_diff = currentAge - table[hash].entry[i].GetAge();
-        scores[i] = table[hash].entry[i].GetDepth() - 4 * (age_diff >= 0 ? age_diff : age_diff + HALF_MOVE_MODULO);
+        // each bucket fills from the first entry, and only once all entries are full do we use the replacement scheme
+        if (bucket[i].GetKey() == EMPTY)
+        {
+            bucket[i] = TTEntry(best, ZobristKey, score, Depth, Turncount, distanceFromRoot, Cutoff);
+            return;
+        }
+
+        // avoid having multiple entries in a bucket for the same position.
+        if (bucket[i].GetKey() == ZobristKey)
+        {
+            // always replace if exact, or if the depth is sufficiently high. There's a trade-off here between wanting
+            // to save the higher depth entry, and wanting to save the newer entry (which might have better bounds)
+            if (Cutoff == EntryType::EXACT || Depth >= bucket[i].GetDepth() - 2)
+            {
+                bucket[i] = TTEntry(best, ZobristKey, score, Depth, Turncount, distanceFromRoot, Cutoff);
+            }
+            return;
+        }
+
+        int8_t age_diff = currentAge - bucket[i].GetAge();
+        scores[i] = bucket[i].GetDepth() - 4 * (age_diff >= 0 ? age_diff : age_diff + HALF_MOVE_MODULO);
     }
 
-    table[hash].entry[std::distance(scores.begin(), std::min_element(scores.begin(), scores.end()))]
+    bucket[std::distance(scores.begin(), std::min_element(scores.begin(), scores.end()))]
         = TTEntry(best, ZobristKey, score, Depth, Turncount, distanceFromRoot, Cutoff);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 10);
 
-string version = "11.10.0";
+string version = "11.10.1";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
Elo   | 3.77 +- 3.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18456 W: 4628 L: 4428 D: 9400
Penta | [200, 2204, 4260, 2324, 240]
http://chess.grantnet.us/test/36564/
```

```
Elo   | -0.36 +- 3.02 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22396 W: 4938 L: 4961 D: 12497
Penta | [112, 2662, 5671, 2643, 110]
http://chess.grantnet.us/test/36565/
```