### PR TITLE
Don't clear the hash table between bench searches

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -537,8 +537,6 @@ void Bench(int depth)
             break;
         }
 
-        tTable.ResetTable();
-        data.ResetNewGame();
         data.limits.ResetTimer();
         SearchThread(position, data);
         nodeCount += data.nodes();


### PR DESCRIPTION
```
$ python3 ./speedup.py 
        Halogen-11.11.1.exe         |       Halogen-pext-avx2.exe        |
        mu              sigma       |        mu              sigma       |   Sp(1)/Sp(2)      3*sigma   
------------------------------------+------------------------------------+------------------------------------
       4041750.000          3594.645|       5051525.000          4330.273|     -19.988 %  +/-  0.251 %
```

Improves bench speed by around 20%. Regular search is unaffected.