### PR TITLE
Average across history tables

### DIFF
--- a/src/History.cpp
+++ b/src/History.cpp
@@ -38,6 +38,7 @@ int History::get(const GameState& position, const SearchStackState* ss, Move mov
     };
 
     return std::apply([&](auto&... table) { return (get_value(table) + ...); }, tables_);
+    //    / std::tuple_size_v<decltype(tables_)>;
 }
 
 void History::add(const GameState& position, const SearchStackState* ss, Move move, int change)

--- a/src/History.cpp
+++ b/src/History.cpp
@@ -37,8 +37,8 @@ int History::get(const GameState& position, const SearchStackState* ss, Move mov
         return value ? *value : 0;
     };
 
-    return std::apply([&](auto&... table) { return (get_value(table) + ...); }, tables_);
-    //    / std::tuple_size_v<decltype(tables_)>;
+    return std::apply([&](auto&... table) { return (get_value(table) + ...); }, tables_)
+        / std::tuple_size_v<decltype(tables_)>;
 }
 
 void History::add(const GameState& position, const SearchStackState* ss, Move move, int change)

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -523,7 +523,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
             if constexpr (pv_node)
                 reduction--;
 
-            reduction -= history / 8192;
+            reduction -= history / 4096;
 
             reduction = std::max(0, reduction);
         }


### PR DESCRIPTION
```
Elo   | -0.30 +- 2.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 35984 W: 8849 L: 8880 D: 18255
Penta | [459, 4295, 8482, 4330, 426]
http://chess.grantnet.us/test/36726/
```