### PR TITLE
Add huge page support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -73,10 +73,6 @@ ifeq ($(detected_OS),Windows)
     LDFLAGS += -static
 endif
 
-ifeq ($(detected_OS),Linux)
-	CXXFLAGS += -DMADV_RANDOM
-endif
-
 # Detect if CXX is g++ or clang++, in this order.
 ifeq '' '$(findstring clang++,$(CXX))'
   	CXXFLAGS += -fconstexpr-ops-limit=1000000000

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -46,3 +46,4 @@ static_assert(sizeof(TTEntry) == 16, "TTEntry is not 16 bytes");
 static_assert(sizeof(TTBucket) == 64, "TTBucket is not 64 bytes");
 static_assert(alignof(TTBucket) == 64, "TTBucket alignment is not 64 bytes");
 static_assert(std::is_trivially_copyable_v<TTBucket>);
+static_assert(std::is_trivially_destructible_v<TTBucket>);

--- a/src/TranspositionTable.cpp
+++ b/src/TranspositionTable.cpp
@@ -3,11 +3,22 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <iterator>
+#include <memory>
+
+#ifdef __linux__
+#include <sys/mman.h>
+#endif
 
 #include "BitBoardDefine.h"
 #include "TTEntry.h"
+
+TranspositionTable ::~TranspositionTable()
+{
+    Deallocate();
+}
 
 uint64_t TranspositionTable::HashFunction(const uint64_t& key) const
 {
@@ -96,21 +107,48 @@ int TranspositionTable::GetCapacity(int halfmove) const
 
 void TranspositionTable::ResetTable()
 {
-    table.reset(new TTBucket[size_]);
+    Reallocate();
 }
 
 void TranspositionTable::SetSize(uint64_t MB)
 {
-    Reallocate(CalculateEntryCount(MB));
+    size_ = CalculateEntryCount(MB);
+    hash_mask_ = size_ - 1;
+    Reallocate();
+
+    // size should be a power of two
+    assert(GetBitCount(size_) == 1);
 }
 
-void TranspositionTable::Reallocate(size_t size)
+void TranspositionTable::Reallocate()
 {
-    // size should be a power of two
-    assert(GetBitCount(size) == 1);
-    size_ = size;
-    hash_mask_ = size - 1;
-    table.reset(new TTBucket[size]);
+    Deallocate();
+
+#ifdef __linux__
+    constexpr static size_t huge_page_size = 2 * 1024 * 1024;
+    const size_t bytes = size_ * sizeof(TTBucket);
+    table = static_cast<TTBucket*>(std::aligned_alloc(huge_page_size, bytes));
+    madvise(table, bytes, MADV_HUGEPAGE);
+    std::uninitialized_default_construct_n(table, size_);
+#else
+    table = new TTBucket[size_];
+#endif
+}
+
+void TranspositionTable::Deallocate()
+{
+#ifdef __linux__
+    if (table)
+    {
+        std::destroy_n(table, size_);
+        std::free(table);
+    }
+#else
+    if (table)
+    {
+        delete[] table;
+    }
+#endif
 }
 
 void TranspositionTable::PreFetch(uint64_t key) const

--- a/src/TranspositionTable.h
+++ b/src/TranspositionTable.h
@@ -12,8 +12,10 @@ class TranspositionTable
 public:
     TranspositionTable()
     {
-        Reallocate(CalculateEntryCount(32)); // 32MB default
+        SetSize(32); // 32MB default
     }
+
+    ~TranspositionTable();
 
     size_t GetSize() const
     {
@@ -37,7 +39,8 @@ public:
 
 private:
     uint64_t HashFunction(const uint64_t& key) const;
-    void Reallocate(size_t size);
+    void Reallocate();
+    void Deallocate();
 
     static constexpr uint64_t CalculateEntryCount(uint64_t MB)
     {
@@ -45,7 +48,7 @@ private:
     }
 
     // raw array and memset allocates quicker than std::vector
-    std::unique_ptr<TTBucket[]> table;
+    TTBucket* table;
     size_t size_;
     uint64_t hash_mask_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 10);
 
-string version = "11.15.2";
+string version = "11.16.0";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Large speedup (15%) when hash is large:

Before:
```
$ taskset -c 2 ./engines/Halogen-11.15.1.exe 
Halogen 11.15.1 x64 POPCNT
setoption name Hash value 16384
go movetime 60000
...
info depth 28 seldepth 41 score cp 42 time 45661 nodes 200983759 nps 4401000 hashfull 12 tbhits 0 pv d2d4 g8f6 g1f3 d7d5 c2c4 e7e6 g2g3 f8e7 f1g2 e8g8 e1g1 d5c4 d1a4 c7c5 d4c5 e7c5 a4c4 c5b6 b1c3 b8c6 f1d1 d8e7 c3a4 e6e5 a4b6 a7b6 c1g5 c8e6 c4c3
```

After:
```
$ taskset -c 2 ./engines/Halogen-pgo.exe 
Halogen 11.15.1 x64 POPCNT
setoption name Hash value 16384
go movetime 60000
...
info depth 28 seldepth 41 score cp 42 time 38262 nodes 200983759 nps 5252000 hashfull 12 tbhits 0 pv d2d4 g8f6 g1f3 d7d5 c2c4 e7e6 g2g3 f8e7 f1g2 e8g8 e1g1 d5c4 d1a4 c7c5 d4c5 e7c5 a4c4 c5b6 b1c3 b8c6 f1d1 d8e7 c3a4 e6e5 a4b6 a7b6 c1g5 c8e6 c4c3 
```