### PR TITLE
Cap history adjustments

### DIFF
--- a/src/History.h
+++ b/src/History.h
@@ -13,6 +13,7 @@ struct HistoryTable
 {
     static constexpr void adjust_history(int16_t& entry, int change)
     {
+        std::clamp(change, -Derived::max_value / Derived::scale, Derived::max_value / Derived::scale);
         entry += Derived::scale * change - entry * abs(change) * Derived::scale / Derived::max_value;
     }
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -799,7 +799,7 @@ void AddKiller(Move move, std::array<Move, 2>& killers)
 
 void AddHistory(const StagedMoveGenerator& gen, const Move& move, int depthRemaining)
 {
-    if (depthRemaining > 20 || move.IsCapture() || move.IsPromotion())
+    if (move.IsCapture() || move.IsPromotion())
         return;
     gen.AdjustHistory(move, depthRemaining * depthRemaining, -depthRemaining * depthRemaining);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 10);
 
-string version = "11.16.0";
+string version = "11.16.1";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
Elo   | 0.42 +- 2.36 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 21608 W: 4785 L: 4759 D: 12064
Penta | [115, 2356, 5812, 2430, 91]
http://chess.grantnet.us/test/36832/
```
```Elo   | 0.76 +- 2.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.06 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 19140 W: 4669 L: 4627 D: 9844
Penta | [189, 2232, 4709, 2228, 212]
http://chess.grantnet.us/test/36829/
```