### PR TITLE
Tune LMR heuristic 

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -519,7 +519,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
         Score search_score = 0;
 
         // late move reductions
-        if (seen_moves > 3)
+        if (seen_moves > 1)
         {
             reduction = Reduction(depth, seen_moves);
 

--- a/src/Search.h
+++ b/src/Search.h
@@ -8,10 +8,10 @@ class SearchSharedState;
 
 /*Tuneable search constants*/
 
-constexpr double LMR_constant = -0.76;
-constexpr double LMR_depth_coeff = 0.39;
-constexpr double LMR_move_coeff = 0.12;
-constexpr double LMR_depth_move_coeff = 0.67;
+constexpr double LMR_constant = -0.71;
+constexpr double LMR_depth_coeff = -1.52;
+constexpr double LMR_move_coeff = 0.87;
+constexpr double LMR_depth_move_coeff = 0.70;
 
 constexpr int Null_constant = 4;
 constexpr int Null_depth_quotent = 6;

--- a/src/Search.h
+++ b/src/Search.h
@@ -8,10 +8,10 @@ class SearchSharedState;
 
 /*Tuneable search constants*/
 
-constexpr double LMR_constant = -0.71;
-constexpr double LMR_depth_coeff = -1.52;
-constexpr double LMR_move_coeff = 0.87;
-constexpr double LMR_depth_move_coeff = 0.70;
+constexpr double LMR_constant = -2.56;
+constexpr double LMR_depth_coeff = -1.49;
+constexpr double LMR_move_coeff = 5;
+constexpr double LMR_depth_move_coeff = -0.5;
 
 constexpr int Null_constant = 4;
 constexpr int Null_depth_quotent = 6;

--- a/src/Search.h
+++ b/src/Search.h
@@ -8,10 +8,10 @@ class SearchSharedState;
 
 /*Tuneable search constants*/
 
-constexpr double LMR_constant = -2.56;
-constexpr double LMR_depth_coeff = -1.49;
-constexpr double LMR_move_coeff = 5;
-constexpr double LMR_depth_move_coeff = -0.5;
+constexpr double LMR_constant = 1.00;
+constexpr double LMR_depth_coeff = -2.03;
+constexpr double LMR_move_coeff = 0.15;
+constexpr double LMR_depth_move_coeff = 1.18;
 
 constexpr int Null_constant = 4;
 constexpr int Null_depth_quotent = 6;

--- a/src/Search.h
+++ b/src/Search.h
@@ -8,10 +8,10 @@ class SearchSharedState;
 
 /*Tuneable search constants*/
 
-constexpr double LMR_constant = 1.00;
-constexpr double LMR_depth_coeff = -2.03;
-constexpr double LMR_move_coeff = 0.15;
-constexpr double LMR_depth_move_coeff = 1.18;
+constexpr double LMR_constant = 1.05;
+constexpr double LMR_depth_coeff = -2.06;
+constexpr double LMR_move_coeff = 0.20;
+constexpr double LMR_depth_move_coeff = 1.17;
 
 constexpr int Null_constant = 4;
 constexpr int Null_depth_quotent = 6;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool chess960, boo
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 10);
 
-string version = "11.16.1";
+string version = "11.17.0";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
Elo   | 3.07 +- 2.43 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22624 W: 5158 L: 4958 D: 12508
Penta | [136, 2604, 5652, 2764, 156]
http://chess.grantnet.us/test/36849/
```

```
Elo   | 12.21 +- 6.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.24 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4328 W: 1182 L: 1030 D: 2116
Penta | [46, 473, 1005, 563, 77]
http://chess.grantnet.us/test/36847/
```