### PR TITLE
Update best move on fail high

### DIFF
--- a/src/BitBoardDefine.h
+++ b/src/BitBoardDefine.h
@@ -6,6 +6,14 @@
 #include <cstdint>
 #include <type_traits>
 
+enum class SearchResultType : uint8_t
+{
+    EMPTY,
+    EXACT,
+    LOWER_BOUND,
+    UPPER_BOUND,
+};
+
 enum Square
 {
     // clang-format off

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -88,57 +88,34 @@ SearchSharedState::SearchSharedState(int threads)
 {
 }
 
-void SearchSharedState::report_search_result(
-    int thread_id, GameState& position, SearchStackState* ss, SearchLocalState& local, int depth, SearchResult result)
+void SearchSharedState::report_search_result(int thread_id, GameState& position, SearchStackState* ss,
+    SearchLocalState& local, int depth, SearchResult result, SearchInfoType type)
 {
     std::scoped_lock lock(lock_);
 
-    auto& results = search_results_[thread_id][depth];
-    results.best_move = result.GetMove();
-    results.score = result.GetScore();
-    results.pv = ss->pv;
+    auto& result_data = search_results_[thread_id][depth];
+    result_data = {
+        depth,
+        result.GetMove(),
+        result.GetScore(),
+        ss->pv,
+        type,
+    };
 
-    PrintInfoDepthString(position, local, depth);
-}
+    // Update the best search result. We want to pick the highest depth result, and using the higher score for
+    // tie-breaks. It adds elo to also include LOWER_BOUND search results as potential best result candidates.
 
-void SearchSharedState::report_aspiration_low_result(
-    GameState&, SearchStackState*, SearchLocalState&, int, SearchResult)
-{
-    /*std::scoped_lock lock(lock_);
-
-    auto elapsed_time = limits.ElapsedTime();
-    auto completed_depth = highest_completed_depth_.load(std::memory_order_acquire);
-
-    if (depth == completed_depth + 1 && result.GetScore() < search_results_[depth].lowest_alpha)
+    if ((result_data.type == SearchInfoType::EXACT || result_data.type == SearchInfoType::LOWER_BOUND)
+        && (!best_search_result_ || (best_search_result_->depth < result_data.depth)
+            || (best_search_result_->depth == result_data.depth && best_search_result_->score < result_data.score)))
     {
-        if (elapsed_time > 5000)
-        {
-            PrintSearchInfo(position, ss, local, depth, result.GetScore(), SearchInfoType::UPPER_BOUND);
-        }
-        search_results_[depth].lowest_alpha = result.GetScore();
-    }*/
-}
+        best_search_result_ = &result_data;
+    }
 
-void SearchSharedState::report_aspiration_high_result(
-    GameState&, SearchStackState*, SearchLocalState&, int, SearchResult)
-{
-    /*std::scoped_lock lock(lock_);
-
-    auto elapsed_time = limits.ElapsedTime();
-    auto completed_depth = highest_completed_depth_.load(std::memory_order_acquire);
-
-    if (depth == completed_depth + 1 && result.GetScore() > search_results_[depth].highest_beta)
+    if (thread_id == 0)
     {
-        if (elapsed_time > 5000)
-        {
-            PrintSearchInfo(position, ss, local, depth, result.GetScore(), SearchInfoType::LOWER_BOUND);
-        }
-        search_results_[depth].highest_beta = result.GetScore();
-
-        // When we fail high, use set this as the best move for the next depth. This gains elo becuase more often than
-        // not a fail high move turns out to be the best.
-        search_results_[completed_depth + 1].best_move = result.GetMove();
-    }*/
+        PrintSearchInfo(position, local, depth, result_data);
+    }
 }
 
 void SearchSharedState::report_thread_wants_to_stop(int thread_id)
@@ -163,45 +140,16 @@ void SearchSharedState::report_thread_wants_to_stop(int thread_id)
     }
 }
 
-BasicMoveList SearchSharedState::get_multi_pv_excluded_moves()
+BasicMoveList SearchSharedState::get_multi_pv_excluded_moves() const
 {
     std::scoped_lock lock(lock_);
     return multi_PV_excluded_moves_;
 }
 
-const SearchSharedState::SearchDepthResults& SearchSharedState::get_best_search_result() const
+SearchSharedState::SearchResults SearchSharedState::get_best_search_result() const
 {
     std::scoped_lock lock(lock_);
-
-    // of each thread, we want the highest depth result. If multiple threads have reached the same depth, we pick the
-    // result with the highest score
-
-    const SearchDepthResults* best = nullptr;
-
-    for (int depth = MAX_DEPTH; depth >= 0; depth--)
-    {
-        for (int thread = 0; thread < get_thread_count(); thread++)
-        {
-            const auto& result = search_results_[thread][depth];
-            if (result.score == SCORE_UNDEFINED)
-            {
-                continue;
-            }
-
-            if (!best || best->score < result.score)
-            {
-                best = &result;
-            }
-        }
-
-        if (best)
-        {
-            return *best;
-        }
-    }
-
-    assert(false);
-    return search_results_[0][0];
+    return *best_search_result_;
 }
 
 uint64_t SearchSharedState::tb_hits() const
@@ -230,8 +178,7 @@ void SearchSharedState::ResetNewSearch()
 {
     search_results_.clear();
     search_results_.resize(get_thread_count());
-    best_result_ = nullptr;
-    highest_completed_depth_ = 0;
+    best_search_result_ = nullptr;
     multi_PV_excluded_moves_.clear();
 
     std::for_each(search_local_states_.begin(), search_local_states_.end(), [](auto& data) { data.ResetNewSearch(); });
@@ -241,37 +188,14 @@ void SearchSharedState::ResetNewGame()
 {
     search_results_.clear();
     search_results_.resize(get_thread_count());
-    highest_completed_depth_ = 0;
+    best_search_result_ = nullptr;
     multi_PV_excluded_moves_.clear();
 
     std::for_each(search_local_states_.begin(), search_local_states_.end(), [](auto& data) { data.ResetNewGame(); });
 }
 
-void SearchSharedState::PrintInfoDepthString(GameState& position, const SearchLocalState& local, int depth)
-{
-    // check if every thread has finished this depth: if so, print out the result with the highest score.
-    SearchDepthResults* best = nullptr;
-
-    for (int thread_id = 0; thread_id < get_thread_count(); thread_id++)
-    {
-        auto& result = search_results_[thread_id][depth];
-
-        if (result.score == SCORE_UNDEFINED)
-        {
-            return;
-        }
-
-        if (!best || best->score < result.score)
-        {
-            best = &result;
-        }
-    }
-
-    PrintSearchInfo(position, local, depth, *best, SearchInfoType::EXACT);
-}
-
-void SearchSharedState::PrintSearchInfo(GameState& position, const SearchLocalState& local, int depth,
-    const SearchDepthResults& data, SearchInfoType type) const
+void SearchSharedState::PrintSearchInfo(
+    GameState& position, const SearchLocalState& local, int depth, const SearchResults& data) const
 {
     /*
     Here we avoid excessive use of std::cout and instead append to a string in order
@@ -295,9 +219,9 @@ void SearchSharedState::PrintSearchInfo(GameState& position, const SearchLocalSt
         stream << " score cp " << data.score.value();
     }
 
-    if (type == SearchInfoType::UPPER_BOUND)
+    if (data.type == SearchInfoType::UPPER_BOUND)
         stream << " upperbound";
-    if (type == SearchInfoType::LOWER_BOUND)
+    if (data.type == SearchInfoType::LOWER_BOUND)
         stream << " lowerbound";
 
     auto elapsed_time = limits.ElapsedTime();

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -101,24 +101,16 @@ public:
 // Search state that is shared between threads.
 class SearchSharedState
 {
-public:
-    enum class SearchInfoType
-    {
-        EMPTY,
-        EXACT,
-        LOWER_BOUND,
-        UPPER_BOUND,
-    };
-
     struct SearchResults
     {
         int depth = 0;
         Move best_move = Move::Uninitialized;
         Score score = SCORE_UNDEFINED;
         BasicMoveList pv = {};
-        SearchInfoType type = SearchInfoType::EMPTY;
+        SearchResultType type = SearchResultType::EMPTY;
     };
 
+public:
     SearchSharedState(int threads);
 
     // Below functions are not thread-safe and should not be called during search
@@ -131,7 +123,7 @@ public:
     // ------------------------------------
 
     void report_search_result(int thread_id, GameState& position, SearchStackState* ss, SearchLocalState& local,
-        int depth, SearchResult result, SearchInfoType type);
+        int depth, SearchResult result, SearchResultType type);
 
     BasicMoveList get_multi_pv_excluded_moves() const;
     SearchResults get_best_search_result() const;

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -101,21 +101,24 @@ public:
 // Search state that is shared between threads.
 class SearchSharedState
 {
+public:
     enum class SearchInfoType
     {
+        EMPTY,
         EXACT,
         LOWER_BOUND,
         UPPER_BOUND,
     };
 
-    struct SearchDepthResults
+    struct SearchResults
     {
+        int depth = 0;
         Move best_move = Move::Uninitialized;
         Score score = SCORE_UNDEFINED;
         BasicMoveList pv = {};
+        SearchInfoType type = SearchInfoType::EMPTY;
     };
 
-public:
     SearchSharedState(int threads);
 
     // Below functions are not thread-safe and should not be called during search
@@ -128,15 +131,10 @@ public:
     // ------------------------------------
 
     void report_search_result(int thread_id, GameState& position, SearchStackState* ss, SearchLocalState& local,
-        int depth, SearchResult result);
-    void report_aspiration_low_result(
-        GameState& position, SearchStackState* ss, SearchLocalState& local, int depth, SearchResult result);
-    void report_aspiration_high_result(
-        GameState& position, SearchStackState* ss, SearchLocalState& local, int depth, SearchResult result);
+        int depth, SearchResult result, SearchInfoType type);
 
-    BasicMoveList get_multi_pv_excluded_moves();
-
-    const SearchDepthResults& get_best_search_result() const;
+    BasicMoveList get_multi_pv_excluded_moves() const;
+    SearchResults get_best_search_result() const;
 
     // Below functions are thread-safe and non-blocking
     // ------------------------------------
@@ -158,20 +156,13 @@ public:
 private:
     mutable std::mutex lock_;
 
-    void PrintInfoDepthString(GameState& position, const SearchLocalState& local, int depth);
-
-    void PrintSearchInfo(GameState& position, const SearchLocalState& local, int depth, const SearchDepthResults& data,
-        SearchInfoType type) const;
+    void PrintSearchInfo(
+        GameState& position, const SearchLocalState& local, int depth, const SearchResults& data) const;
 
     // TODO: fix MultiPV
-    std::vector<std::array<SearchDepthResults, MAX_DEPTH + 1>> search_results_;
+    std::vector<std::array<SearchResults, MAX_DEPTH + 1>> search_results_;
 
-    // Based on the voting model, this is the current best result
-    SearchDepthResults* best_result_ = nullptr;
-
-    // The depth that has been completed. When the first thread finishes a depth it increments this. All other threads
-    // should stop searching that depth
-    std::atomic<int> highest_completed_depth_ = 0;
+    SearchResults* best_search_result_ = nullptr;
 
     // We persist the SearchLocalStates for each thread we have, so that they don't need to be reconstructed each time
     // we start a search. search_local_states_.size() == number of threads. This vector is constructed once when the

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -4,18 +4,11 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "BitBoardDefine.h"
 #include "Move.h"
 #include "Score.h"
 
 constexpr unsigned int HALF_MOVE_MODULO = 16;
-
-enum class EntryType : char
-{
-    EMPTY_ENTRY,
-    EXACT,
-    LOWERBOUND,
-    UPPERBOUND
-};
 
 Score convert_to_tt_score(Score val, int distance_from_root);
 Score convert_from_tt_score(Score val, int distance_from_root);
@@ -32,7 +25,7 @@ public:
     std::atomic<Move> move = Move::Uninitialized; // 2 bytes
     std::atomic<Score> score { 0 }; // 2 bytes
     std::atomic<int8_t> depth = 0; // 1 bytes
-    std::atomic<EntryType> cutoff = EntryType::EMPTY_ENTRY; // 1 bytes
+    std::atomic<SearchResultType> cutoff = SearchResultType::EMPTY; // 1 bytes
     // is stored as the move count at the ROOT of this current search modulo 16 plus 1
     std::atomic<int8_t> generation = 0; // 1 bytes
 };

--- a/src/TranspositionTable.cpp
+++ b/src/TranspositionTable.cpp
@@ -26,7 +26,7 @@ uint64_t TranspositionTable::HashFunction(const uint64_t& key) const
 }
 
 void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, Score score, int Depth, int Turncount,
-    int distanceFromRoot, EntryType Cutoff)
+    int distanceFromRoot, SearchResultType Cutoff)
 {
     size_t hash = HashFunction(ZobristKey);
     score = convert_to_tt_score(score, distanceFromRoot);
@@ -60,7 +60,7 @@ void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, Score s
         {
             // always replace if exact, or if the depth is sufficiently high. There's a trade-off here between wanting
             // to save the higher depth entry, and wanting to save the newer entry (which might have better bounds)
-            if (Cutoff == EntryType::EXACT || Depth >= bucket[i].depth - 3)
+            if (Cutoff == SearchResultType::EXACT || Depth >= bucket[i].depth - 3)
             {
                 write_to_entry(bucket[i]);
             }

--- a/src/TranspositionTable.h
+++ b/src/TranspositionTable.h
@@ -30,7 +30,7 @@ public:
     void SetSize(uint64_t MB);
 
     void AddEntry(const Move& best, uint64_t ZobristKey, Score Score, int Depth, int Turncount, int distanceFromRoot,
-        EntryType Cutoff);
+        SearchResultType Cutoff);
 
     void PreFetch(uint64_t key) const;
 


### PR DESCRIPTION
```
Elo   | 14.28 +- 6.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3068 W: 785 L: 659 D: 1624
Penta | [21, 309, 758, 415, 31]
http://chess.grantnet.us/test/36872/
```

```
Elo   | 3.05 +- 5.79 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 0.53 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4326 W: 1021 L: 983 D: 2322
Penta | [33, 519, 1028, 543, 40]
http://chess.grantnet.us/test/36871/
```