### PR TITLE
Correctly cap history scores

### DIFF
--- a/src/History.h
+++ b/src/History.h
@@ -13,7 +13,7 @@ struct HistoryTable
 {
     static constexpr void adjust_history(int16_t& entry, int change)
     {
-        std::clamp(change, -Derived::max_value / Derived::scale, Derived::max_value / Derived::scale);
+        change = std::clamp(change, -Derived::max_value / Derived::scale, Derived::max_value / Derived::scale);
         entry += Derived::scale * change - entry * abs(change) * Derived::scale / Derived::max_value;
     }
 


### PR DESCRIPTION
```
Elo   | 4.25 +- 4.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 6698 W: 1558 L: 1476 D: 3664
Penta | [31, 723, 1774, 775, 46]
http://chess.grantnet.us/test/36927/
```
```
Elo   | 1.03 +- 2.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 16594 W: 4146 L: 4097 D: 8351
Penta | [170, 1919, 4107, 1894, 207]
http://chess.grantnet.us/test/36926/
```