### PR TITLE
Fix compiler OOM issues

### DIFF
--- a/src/Magic.cpp
+++ b/src/Magic.cpp
@@ -1,1 +1,0 @@
-#include "Magic.h"

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,6 @@ SRCS := \
 	Score.cpp \
 	EGTB.cpp \
 	History.cpp \
-	Magic.cpp \
 	Pyrrhic/tbprobe.c
 
 # String substitution for every C/C++ file.


### PR DESCRIPTION
With older versions of GCC, compiling constexpr magic bitboards in more than one translation unit causes the memory usage to exceed 8GB. This PR limits constexpr magic bitboards to a single TU (`MoveGeneration.cpp`)