### PR TITLE
Correctly apply mate distance pruning

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -378,7 +378,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
 
     // mate distance pruning
     alpha = std::max(Score::mated_in(distance_from_root), alpha);
-    beta = std::min(Score::mate_in(distance_from_root), beta);
+    beta = std::min(Score::mate_in(distance_from_root + 1), beta);
     if (alpha >= beta)
         return alpha;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool check_legalit
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 10);
 
-string version = "11.20.0";
+string version = "11.20.1";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Baseline:
```
Total fens:    6556
Found mates:   1040
Best mates:    699
Complete PVs:  1031/1040 (99.1%)
Complete best PVs:  699/699(100.0%)
```

Dev:
```
Total fens:    6556
Found mates:   1044
Best mates:    711
Complete PVs:  1035/1044 (99.1%)
Complete best PVs:  711/711 (100.0%)
```

```
Elo   | 0.24 +- 2.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 24384 W: 6255 L: 6238 D: 11891
Penta | [351, 2738, 5974, 2801, 328]
http://chess.grantnet.us/test/37097/
```