### PR TITLE
Adjust singular extensions sbeta formula

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -442,7 +442,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
         if (!root_node && ss->singular_exclusion == Move::Uninitialized && depth >= 6 && tt_entry
             && tt_depth + 2 >= depth && tt_cutoff != SearchResultType::UPPER_BOUND && tt_move == move)
         {
-            Score sbeta = tt_score - depth * 2;
+            Score sbeta = tt_score - depth;
             int sdepth = depth / 2;
 
             ss->singular_exclusion = move;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ uint64_t PerftDivide(unsigned int depth, GameState& position, bool check_legalit
 uint64_t Perft(unsigned int depth, GameState& position, bool check_legality);
 void Bench(int depth = 10);
 
-string version = "11.20.1";
+string version = "11.21.0";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
```
Elo   | 5.88 +- 3.98 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8456 W: 1975 L: 1832 D: 4649
Penta | [50, 931, 2142, 1036, 69]
http://chess.grantnet.us/test/37112/
```

```
Elo   | 6.66 +- 4.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8188 W: 2124 L: 1967 D: 4097
Penta | [110, 928, 1859, 1089, 108]
http://chess.grantnet.us/test/37105/
```