### PR TITLE
Adjust futility pruning scheme with a quadratic

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -402,7 +402,8 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
     if (!tt_entry && depth > 3)
         depth--;
 
-    bool FutileNode = depth < Futility_depth && staticScore + Futility_constant + Futility_coeff * depth < alpha;
+    bool FutileNode = depth < Futility_depth
+        && staticScore + Futility_constant + Futility_linear * depth + Futility_quad * depth * depth < alpha;
 
     StagedMoveGenerator gen(position, ss, local, tt_move, false);
     Move move;

--- a/src/SearchConstants.h
+++ b/src/SearchConstants.h
@@ -20,9 +20,9 @@ TUNEABLE_CONSTANT int Null_constant = 4;
 TUNEABLE_CONSTANT int Null_depth_quotent = 6;
 TUNEABLE_CONSTANT int Null_beta_quotent = 250;
 
-TUNEABLE_CONSTANT int Futility_constant = 20;
-TUNEABLE_CONSTANT int Futility_coeff = 82;
-TUNEABLE_CONSTANT int Futility_depth = 15;
+TUNEABLE_CONSTANT int Futility_constant = 69;
+TUNEABLE_CONSTANT int Futility_coeff = 66;
+TUNEABLE_CONSTANT int Futility_depth = 10;
 
 TUNEABLE_CONSTANT Score aspiration_window_mid_width = 15;
 

--- a/src/SearchConstants.h
+++ b/src/SearchConstants.h
@@ -20,10 +20,10 @@ TUNEABLE_CONSTANT int Null_constant = 4;
 TUNEABLE_CONSTANT int Null_depth_quotent = 6;
 TUNEABLE_CONSTANT int Null_beta_quotent = 250;
 
-TUNEABLE_CONSTANT int Futility_constant = 69;
-TUNEABLE_CONSTANT int Futility_linear = 20;
-TUNEABLE_CONSTANT int Futility_quad = 7;
-TUNEABLE_CONSTANT int Futility_depth = 10;
+TUNEABLE_CONSTANT int Futility_constant = 27;
+TUNEABLE_CONSTANT int Futility_linear = 13;
+TUNEABLE_CONSTANT int Futility_quad = 16;
+TUNEABLE_CONSTANT int Futility_depth = 8;
 
 TUNEABLE_CONSTANT Score aspiration_window_mid_width = 15;
 

--- a/src/SearchConstants.h
+++ b/src/SearchConstants.h
@@ -21,7 +21,8 @@ TUNEABLE_CONSTANT int Null_depth_quotent = 6;
 TUNEABLE_CONSTANT int Null_beta_quotent = 250;
 
 TUNEABLE_CONSTANT int Futility_constant = 69;
-TUNEABLE_CONSTANT int Futility_coeff = 66;
+TUNEABLE_CONSTANT int Futility_linear = 20;
+TUNEABLE_CONSTANT int Futility_quad = 7;
 TUNEABLE_CONSTANT int Futility_depth = 10;
 
 TUNEABLE_CONSTANT Score aspiration_window_mid_width = 15;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "11.21.1";
+constexpr std::string_view version = "11.22.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 4.15 +- 3.12 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13492 W: 3105 L: 2944 D: 7443
Penta | [75, 1535, 3362, 1702, 72]
http://chess.grantnet.us/test/37168/
```
```
Elo   | -0.90 +- 3.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 17742 W: 4489 L: 4535 D: 8718
Penta | [254, 2130, 4146, 2090, 251]
http://chess.grantnet.us/test/37167/
```