### PR TITLE
Don't apply NMP if the tt_score is an upper-bound below beta

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -708,7 +708,8 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
     // fail high assuming there is at least one move in the current position that would allow us to improve. This
     // heruistic fails in zugzwang positions, so we have a verification search.
     if (!pv_node && !InCheck && ss->singular_exclusion == Move::Uninitialized && (ss - 1)->move != Move::Uninitialized
-        && distance_from_root >= ss->nmp_verification_depth && staticScore > beta)
+        && distance_from_root >= ss->nmp_verification_depth && staticScore > beta
+        && !(tt_entry && tt_cutoff == SearchResultType::UPPER_BOUND && tt_score < beta))
     {
         if (auto value = null_move_pruning(position, ss, local, shared, distance_from_root, depth, staticScore, beta))
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "11.24.0";
+constexpr std::string_view version = "11.25.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 9.48 +- 5.27 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4658 W: 1079 L: 952 D: 2627
Penta | [23, 492, 1177, 609, 28]
http://chess.grantnet.us/test/37313/
```
```
Elo   | 9.99 +- 5.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5078 W: 1303 L: 1157 D: 2618
Penta | [62, 557, 1154, 705, 61]
http://chess.grantnet.us/test/37311/
```