### PR TITLE
Replace TT index function with mulhi_64 algorithm

### DIFF
--- a/src/TranspositionTable.h
+++ b/src/TranspositionTable.h
@@ -33,20 +33,11 @@ public:
     TTEntry* GetEntry(uint64_t key, int distanceFromRoot, int half_turn_count);
 
 private:
-    uint64_t HashFunction(const uint64_t& key) const;
     void Reallocate();
     void Deallocate();
-
-    static constexpr uint64_t CalculateEntryCount(uint64_t MB)
-    {
-        return MB * 1024 * 1024 / sizeof(TTBucket);
-    }
+    TTBucket& GetBucket(uint64_t key) const;
 
     // raw array and memset allocates quicker than std::vector
     TTBucket* table;
     size_t size_;
-    uint64_t hash_mask_;
 };
-
-bool CheckEntry(const TTEntry& entry, uint64_t key, int depth);
-bool CheckEntry(const TTEntry& entry, uint64_t key);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "11.26.0";
+constexpr std::string_view version = "11.26.1";
 
 void PrintVersion()
 {

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -219,7 +219,7 @@ auto Uci::options_handler()
     return uci_options {
         button_option { "Clear Hash", [this] { handle_setoption_clear_hash(); } },
         check_option { "UCI_Chess960", false, [this](bool value) { handle_setoption_chess960(value); } },
-        spin_option { "Hash", 32, 1, 262144, [this](auto value) { return handle_setoption_hash(value); } },
+        spin_option { "Hash", 32, 1, 262144, [this](auto value) { handle_setoption_hash(value); } },
         spin_option { "Threads", 1, 1, 256, [this](auto value) { handle_setoption_threads(value); } },
         spin_option { "MultiPV", 1, 1, 256, [this](auto value) { handle_setoption_multipv(value); } },
         string_option { "SyzygyPath", "<empty>", [this](auto value) { handle_setoption_syzygy_path(value); } },

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -344,16 +344,9 @@ void Uci::handle_setoption_clear_hash()
     shared.ResetNewGame();
 }
 
-bool Uci::handle_setoption_hash(int value)
+void Uci::handle_setoption_hash(int value)
 {
-    if (GetBitCount(value) != 1)
-    {
-        std::cout << "info error transposition table size must be a power of two" << std::endl;
-        return false;
-    }
-
     tTable.SetSize(value);
-    return true;
 }
 
 void Uci::handle_setoption_threads(int value)

--- a/src/uci/uci.h
+++ b/src/uci/uci.h
@@ -49,7 +49,7 @@ public:
     void handle_position_startpos();
     void handle_go(go_ctx& ctx);
     void handle_setoption_clear_hash();
-    bool handle_setoption_hash(int value);
+    void handle_setoption_hash(int value);
     void handle_setoption_threads(int value);
     void handle_setoption_syzygy_path(std::string_view value);
     void handle_setoption_multipv(int value);


### PR DESCRIPTION
Supports variable (not power of 2) TT sizes with a index determined by the higher order bits of the key
```
Elo   | -0.66 +- 1.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 52256 W: 13049 L: 13149 D: 26058
Penta | [702, 6197, 12404, 6149, 676]
http://chess.grantnet.us/test/37339/
```