### PR TITLE
Compress TT entries to 10 bytes

### DIFF
--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -41,7 +41,7 @@ public:
 
 struct alignas(32) TTBucket : public std::array<TTEntry, 3>
 {
-    constexpr static auto size = 4;
+    constexpr static auto size = 3;
 };
 
 static_assert(sizeof(TTEntry) == 10, "TTEntry is not 16 bytes");

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -37,17 +37,15 @@ public:
     {
         return meta.load(std::memory_order_relaxed);
     }
-
-    char unused[6];
 };
 
-struct alignas(64) TTBucket : public std::array<TTEntry, 4>
+struct alignas(32) TTBucket : public std::array<TTEntry, 3>
 {
     constexpr static auto size = 4;
 };
 
-static_assert(sizeof(TTEntry) == 16, "TTEntry is not 16 bytes");
-static_assert(sizeof(TTBucket) == 64, "TTBucket is not 64 bytes");
-static_assert(alignof(TTBucket) == 64, "TTBucket alignment is not 64 bytes");
+static_assert(sizeof(TTEntry) == 10, "TTEntry is not 16 bytes");
+static_assert(sizeof(TTBucket) == 32, "TTBucket is not 32 bytes");
+static_assert(alignof(TTBucket) == 32, "TTBucket alignment is not 32 bytes");
 static_assert(std::is_trivially_copyable_v<TTBucket>);
 static_assert(std::is_trivially_destructible_v<TTBucket>);

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -44,8 +44,8 @@ struct alignas(32) TTBucket : public std::array<TTEntry, 3>
     constexpr static auto size = 3;
 };
 
-static_assert(sizeof(TTEntry) == 10, "TTEntry is not 16 bytes");
-static_assert(sizeof(TTBucket) == 32, "TTBucket is not 32 bytes");
-static_assert(alignof(TTBucket) == 32, "TTBucket alignment is not 32 bytes");
+static_assert(sizeof(TTEntry) == 10);
+static_assert(sizeof(TTBucket) == 32);
+static_assert(alignof(TTBucket) == 32);
 static_assert(std::is_trivially_copyable_v<TTBucket>);
 static_assert(std::is_trivially_destructible_v<TTBucket>);


### PR DESCRIPTION
```
Elo   | 0.10 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 30614 W: 7680 L: 7671 D: 15263
Penta | [414, 3585, 7284, 3626, 398]
http://chess.grantnet.us/test/37347/
```