### PR TITLE
Compress TT entries to 10 bytes

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -392,7 +392,7 @@ std::tuple<TTEntry*, Score, int, SearchResultType, Move> probe_tt(
         ? convert_from_tt_score(tt_entry->score.load(std::memory_order_relaxed), distance_from_root)
         : SCORE_UNDEFINED;
     const auto tt_depth = tt_entry ? tt_entry->depth.load(std::memory_order_relaxed) : 0;
-    const auto tt_cutoff = tt_entry ? tt_entry->cutoff.load(std::memory_order_relaxed) : SearchResultType::EMPTY;
+    const auto tt_cutoff = tt_entry ? tt_entry->get_meta().type : SearchResultType::EMPTY;
     const auto tt_move = tt_entry ? tt_entry->move.load(std::memory_order_relaxed) : Move::Uninitialized;
 
     return { tt_entry, tt_score, tt_depth, tt_cutoff, tt_move };

--- a/src/TTEntry.cpp
+++ b/src/TTEntry.cpp
@@ -22,5 +22,5 @@ Score convert_from_tt_score(Score val, int distance_from_root)
 
 uint8_t get_generation(int currentTurnCount, int distanceFromRoot)
 {
-    return (currentTurnCount - distanceFromRoot) % (HALF_MOVE_MODULO) + 1;
+    return (currentTurnCount - distanceFromRoot) % GENERATION_MAX;
 }

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -20,14 +20,16 @@ class TTEntry
 public:
     TTEntry() = default;
 
-    /*Arranged to minimize padding*/
-    std::atomic<uint64_t> key = 0; // 8 bytes
+    std::atomic<uint16_t> key = 0; // 2 bytes
     std::atomic<Move> move = Move::Uninitialized; // 2 bytes
     std::atomic<Score> score { 0 }; // 2 bytes
+    std::atomic<Score> static_eval { 0 }; // 2 bytes
     std::atomic<int8_t> depth = 0; // 1 bytes
     std::atomic<SearchResultType> cutoff = SearchResultType::EMPTY; // 1 bytes
     // is stored as the move count at the ROOT of this current search modulo 16 plus 1
     std::atomic<int8_t> generation = 0; // 1 bytes
+
+    char unused[5];
 };
 
 struct alignas(64) TTBucket : public std::array<TTEntry, 4>

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -37,17 +37,15 @@ public:
     {
         return meta.load(std::memory_order_relaxed);
     }
-
-    char unused[6];
 };
 
-struct alignas(64) TTBucket : public std::array<TTEntry, 4>
+struct alignas(32) TTBucket : public std::array<TTEntry, 3>
 {
-    constexpr static auto size = 4;
+    constexpr static auto size = 3;
 };
 
-static_assert(sizeof(TTEntry) == 16, "TTEntry is not 16 bytes");
-static_assert(sizeof(TTBucket) == 64, "TTBucket is not 64 bytes");
-static_assert(alignof(TTBucket) == 64, "TTBucket alignment is not 64 bytes");
+static_assert(sizeof(TTEntry) == 10);
+static_assert(sizeof(TTBucket) == 32);
+static_assert(alignof(TTBucket) == 32);
 static_assert(std::is_trivially_copyable_v<TTBucket>);
 static_assert(std::is_trivially_destructible_v<TTBucket>);

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -8,8 +8,6 @@
 #include "Move.h"
 #include "Score.h"
 
-constexpr unsigned int HALF_MOVE_MODULO = 16;
-
 Score convert_to_tt_score(Score val, int distance_from_root);
 Score convert_from_tt_score(Score val, int distance_from_root);
 uint8_t get_generation(int currentTurnCount, int distanceFromRoot);

--- a/src/TranspositionTable.cpp
+++ b/src/TranspositionTable.cpp
@@ -15,7 +15,7 @@
 #include "BitBoardDefine.h"
 #include "TTEntry.h"
 
-TranspositionTable ::~TranspositionTable()
+TranspositionTable::~TranspositionTable()
 {
     Deallocate();
 }
@@ -24,16 +24,20 @@ void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, Score s
     int distanceFromRoot, SearchResultType Cutoff)
 {
     score = convert_to_tt_score(score, distanceFromRoot);
-
-    // Keep in mind age from each generation goes up so lower (generally) means older
+    auto key16 = uint16_t(ZobristKey);
     int8_t current_generation = get_generation(Turncount, distanceFromRoot);
     std::array<int8_t, TTBucket::size> scores = {};
     auto& bucket = GetBucket(ZobristKey);
 
     const auto write_to_entry = [&](auto& entry)
     {
-        entry.move = best;
-        entry.key = ZobristKey;
+        // in q-search we want to avoid overwriting the best move if we don't have one
+        if (best != Move::Uninitialized || entry.key != key16)
+        {
+            entry.move = best;
+        }
+
+        entry.key = key16;
         entry.score = score;
         entry.depth = Depth;
         entry.cutoff = Cutoff;
@@ -50,7 +54,7 @@ void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, Score s
         }
 
         // avoid having multiple entries in a bucket for the same position.
-        if (bucket[i].key == ZobristKey)
+        if (bucket[i].key == key16)
         {
             // always replace if exact, or if the depth is sufficiently high. There's a trade-off here between wanting
             // to save the higher depth entry, and wanting to save the newer entry (which might have better bounds)
@@ -71,11 +75,12 @@ void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, Score s
 TTEntry* TranspositionTable::GetEntry(uint64_t key, int distanceFromRoot, int half_turn_count)
 {
     auto& bucket = GetBucket(key);
+    auto key16 = uint16_t(key);
 
     // we return by copy here because other threads are reading/writing to this same table.
     for (auto& entry : bucket)
     {
-        if (entry.key == key)
+        if (entry.key == key16)
         {
             // reset the age of this entry to mark it as not old
             entry.generation = get_generation(half_turn_count, distanceFromRoot);
@@ -89,11 +94,16 @@ TTEntry* TranspositionTable::GetEntry(uint64_t key, int distanceFromRoot, int ha
 int TranspositionTable::GetCapacity(int halfmove) const
 {
     int count = 0;
+    int8_t current_generation = get_generation(halfmove, 0);
 
-    for (int i = 0; i < 1000; i++) // 1000 chosen specifically, because result needs to be 'per mill'
+    // 1000 chosen specifically, because result needs to be 'per mill'
+    for (int i = 0; i < 1000; i++)
     {
-        if (table[i / TTBucket::size][i % TTBucket::size].generation == get_generation(halfmove, 0))
+        auto& entry = table[i / TTBucket::size][i % TTBucket::size];
+        if (entry.key != EMPTY && entry.generation == current_generation)
+        {
             count++;
+        }
     }
 
     return count;


### PR DESCRIPTION
Non-regression at STC:
```
Elo   | 6.86 +- 5.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 5016 W: 1380 L: 1281 D: 2355
Penta | [62, 544, 1222, 593, 87]
http://chess.grantnet.us/test/37349/
```
Elo gaining at LTC with small hash:
```
Elo   | 5.13 +- 3.64 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=1MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10088 W: 2342 L: 2193 D: 5553
Penta | [64, 1117, 2538, 1256, 69]
http://chess.grantnet.us/test/37348/
```
Elo gaining at SMP STC with small hash:
```
Elo   | 13.63 +- 6.72 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=1MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3342 W: 870 L: 739 D: 1733
Penta | [27, 357, 788, 456, 43]
http://chess.grantnet.us/test/37350/
```