### PR TITLE
Probe Transposition Table in Quiescence search

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -858,7 +858,19 @@ SearchResult Quiescence(GameState& position, SearchStackState* ss, SearchLocalSt
         return *value;
     }
 
-    // Step 2: Stand-pat. We assume if all captures are bad, there's at least one quiet move that maintains the static
+    // Step 2: Probe transposition table
+    const auto [tt_entry, tt_score, tt_depth, tt_cutoff, tt_move] = probe_tt(position, distance_from_root);
+
+    // Step 3: Check if we can use the TT entry to return early
+    if (!pv_node && ss->singular_exclusion == Move::Uninitialized && tt_entry && tt_depth >= depth)
+    {
+        if (auto value = tt_cutoff_node(position, distance_from_root, tt_score, tt_cutoff, tt_move, alpha, beta))
+        {
+            return *value;
+        }
+    }
+
+    // Step 4: Stand-pat. We assume if all captures are bad, there's at least one quiet move that maintains the static
     // score
     auto staticScore = EvaluatePositionNet(position, local.eval_cache);
     alpha = std::max(alpha, staticScore);
@@ -869,6 +881,7 @@ SearchResult Quiescence(GameState& position, SearchStackState* ss, SearchLocalSt
 
     Move bestmove = Move::Uninitialized;
     auto score = staticScore;
+    auto original_alpha = alpha;
 
     StagedMoveGenerator gen(position, ss, local, Move::Uninitialized, true);
     Move move;
@@ -900,11 +913,17 @@ SearchResult Quiescence(GameState& position, SearchStackState* ss, SearchLocalSt
             return SCORE_UNDEFINED;
         }
 
-        // Step 3: Update best score and check for fail-high
+        // Step 5: Update best score and check for fail-high
         if (update_search_stats<pv_node>(ss, gen, depth, search_score, move, score, bestmove, alpha, beta))
         {
             break;
         }
+    }
+
+    // Step 6: Update transposition table
+    if (!local.aborting_search && ss->singular_exclusion == Move::Uninitialized)
+    {
+        AddScoreToTable(score, original_alpha, position.Board(), depth, distance_from_root, beta, bestmove);
     }
 
     return SearchResult(score, bestmove);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "11.26.1";
+constexpr std::string_view version = "11.27.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 0.66 +- 1.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 56366 W: 12598 L: 12491 D: 31277
Penta | [339, 6679, 14053, 6760, 352]
http://chess.grantnet.us/test/37354/
```

```
Elo   | 2.53 +- 2.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 40730 W: 10396 L: 10099 D: 20235
Penta | [551, 4862, 9274, 5095, 583]
http://chess.grantnet.us/test/37351/
```