### PR TITLE
SPSA LTC tune

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -159,7 +159,7 @@ void SearchPosition(GameState& position, SearchLocalState& local, SearchSharedSt
 SearchResult AspirationWindowSearch(
     GameState& position, SearchStackState* ss, SearchLocalState& local, SearchSharedState& shared, Score mid_score)
 {
-    Score delta = 13;
+    Score delta = 12;
     Score alpha = std::max<Score>(Score::Limits::MATED, mid_score - delta);
     Score beta = std::min<Score>(Score::Limits::MATE, mid_score + delta);
 
@@ -429,7 +429,7 @@ std::optional<Score> null_move_pruning(GameState& position, SearchStackState* ss
         return std::nullopt;
     }
 
-    const int reduction = 4 + depth / 6 + std::min(3, (static_score - beta).value() / 253);
+    const int reduction = 4 + depth / 6 + std::min(3, (static_score - beta).value() / 245);
 
     ss->move = Move::Uninitialized;
     position.ApplyNullMove();
@@ -472,7 +472,7 @@ template <bool pv_node>
 std::optional<Score> singular_extensions(GameState& position, SearchStackState* ss, SearchLocalState& local,
     SearchSharedState& shared, int depth, const Score tt_score, const Move tt_move, const Score beta, int& extensions)
 {
-    Score sbeta = tt_score - 58 * depth / 64;
+    Score sbeta = tt_score - 56 * depth / 64;
     int sdepth = depth / 2;
 
     ss->singular_exclusion = tt_move;
@@ -485,7 +485,7 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
     // forced lines we limit the number of multiple_extensions down one line. We focus on non_pv nodes becuase
     // in particular we want to verify cut nodes which rest on a single good move and ensure we haven't
     // overlooked a potential non-pv line.
-    if (!pv_node && result.GetScore() < sbeta - 12 && ss->multiple_extensions < 7)
+    if (!pv_node && result.GetScore() < sbeta - 11 && ss->multiple_extensions < 7)
     {
         extensions += 2;
         ss->multiple_extensions++;
@@ -528,7 +528,7 @@ int reduction(int depth, int seen_moves, int history)
     if constexpr (pv_node)
         r--;
 
-    r -= history / 3869;
+    r -= history / 3922;
 
     return std::max(0, r);
 }
@@ -693,7 +693,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
     //
     // If the static score is far above beta we fail high.
     if (!pv_node && !InCheck && ss->singular_exclusion == Move::Uninitialized && depth < 8
-        && staticScore - 96 * depth >= beta)
+        && staticScore - 93 * depth >= beta)
     {
         return beta;
     }
@@ -762,7 +762,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
         // Step 12: Futility pruning
         //
         // Prune quiet moves if we are significantly below alpha. TODO: this implementation is a little strange
-        if (!pv_node && !InCheck && depth < 10 && staticScore + 31 + 15 * depth + 12 * depth * depth < alpha
+        if (!pv_node && !InCheck && depth < 10 && staticScore + 31 + 13 * depth + 11 * depth * depth < alpha
             && score > Score::tb_loss_in(MAX_DEPTH))
         {
             gen.SkipQuiets();
@@ -782,7 +782,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
         // testing for singularity. To test for singularity, we do a reduced depth search on the TT score lowered by
         // some margin. If this search fails low, this implies all alternative moves are much worse and the TT move
         // is singular.
-        if (!root_node && ss->singular_exclusion == Move::Uninitialized && depth >= 6 && tt_entry
+        if (!root_node && ss->singular_exclusion == Move::Uninitialized && depth >= 7 && tt_entry
             && tt_depth + 3 >= depth && tt_cutoff != SearchResultType::UPPER_BOUND && tt_move == move)
         {
             if (auto value
@@ -887,7 +887,7 @@ SearchResult Quiescence(GameState& position, SearchStackState* ss, SearchLocalSt
         int SEE = gen.GetSEE(move);
 
         // delta pruning
-        if (staticScore + SEE + 253 < alpha)
+        if (staticScore + SEE + 280 < alpha)
         {
             break;
         }

--- a/src/SearchConstants.h
+++ b/src/SearchConstants.h
@@ -11,10 +11,10 @@
 #define TUNEABLE_CONSTANT const inline
 #endif
 
-TUNEABLE_CONSTANT double LMR_constant = 1.21;
-TUNEABLE_CONSTANT double LMR_depth_coeff = -1.32;
-TUNEABLE_CONSTANT double LMR_move_coeff = 1.49;
-TUNEABLE_CONSTANT double LMR_depth_move_coeff = 0.23;
+TUNEABLE_CONSTANT double LMR_constant = 1.19;
+TUNEABLE_CONSTANT double LMR_depth_coeff = -1.48;
+TUNEABLE_CONSTANT double LMR_move_coeff = 1.91;
+TUNEABLE_CONSTANT double LMR_depth_move_coeff = 0.12;
 
 inline auto Initialise_LMR_reduction()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "11.28.0";
+constexpr std::string_view version = "11.29.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 3.77 +- 2.91 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15686 W: 3572 L: 3402 D: 8712
Penta | [85, 1815, 3880, 1971, 92]
http://chess.grantnet.us/test/37365/
```
```
Elo   | 2.46 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 42954 W: 10816 L: 10512 D: 21626
Penta | [558, 5074, 9940, 5316, 589]
http://chess.grantnet.us/test/37364/
```