### PR TITLE
Adjust scale to 160

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -18,7 +18,7 @@ alignas(32) int16_t Network::outputBias = {};
 
 constexpr int16_t L1_SCALE = 255;
 constexpr int16_t L2_SCALE = 64;
-constexpr double SCALE_FACTOR = 400; // Found empirically to maximize elo
+constexpr double SCALE_FACTOR = 160; // Found empirically to maximize elo
 
 template <typename T, size_t SIZE>
 [[nodiscard]] std::array<T, SIZE> ReLU(const std::array<T, SIZE>& source)


### PR DESCRIPTION
```
Elo   | 38.65 +- 6.60 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=8MB
Games | N: 5000 W: 1739 L: 1185 D: 2076
Penta | [78, 472, 988, 742, 220]
http://chess.grantnet.us/test/37368/
```