### PR TITLE
Remove atomics in Transposition table

### DIFF
--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run
         run: |
           cd bin
-          TSAN_OPTIONS="suppressions=../test/tsan.supp" ./Halogen <<EOF
+          TSAN_OPTIONS="suppressions=../src/test/tsan.supp" ./Halogen <<EOF
           setoption name Threads value 2
           setoption name MultiPV value 8
           ucinewgame

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run
         run: |
           cd bin
-          ./Halogen <<EOF
+          TSAN_OPTIONS="suppressions=../test/tsan.supp" ./Halogen <<EOF
           setoption name Threads value 2
           setoption name MultiPV value 8
           ucinewgame

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -387,10 +387,10 @@ std::tuple<TTEntry*, Score, int, SearchResultType, Move, Score> probe_tt(
     auto* tt_entry
         = tTable.GetEntry(position.Board().GetZobristKey(), distance_from_root, position.Board().half_turn_count);
     const auto tt_score = tt_entry ? convert_from_tt_score(tt_entry->score, distance_from_root) : SCORE_UNDEFINED;
-    const auto tt_depth = tt_entry ? int(tt_entry->depth) : 0;
-    const auto tt_cutoff = tt_entry ? TTMeta(tt_entry->meta).type : SearchResultType::EMPTY;
-    const auto tt_move = tt_entry ? Move(tt_entry->move) : Move::Uninitialized;
-    const auto tt_eval = tt_entry ? Score(tt_entry->static_eval) : SCORE_UNDEFINED;
+    const auto tt_depth = tt_entry ? tt_entry->depth : 0;
+    const auto tt_cutoff = tt_entry ? tt_entry->meta.type : SearchResultType::EMPTY;
+    const auto tt_move = tt_entry ? tt_entry->move : Move::Uninitialized;
+    const auto tt_eval = tt_entry ? tt_entry->static_eval : SCORE_UNDEFINED;
     return { tt_entry, tt_score, tt_depth, tt_cutoff, tt_move, tt_eval };
 }
 

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -20,7 +20,7 @@ struct TTMeta
     uint8_t generation : 6;
 };
 
-// 16 bytes
+// 10 bytes
 class TTEntry
 {
 public:

--- a/src/TTEntry.h
+++ b/src/TTEntry.h
@@ -26,12 +26,12 @@ class TTEntry
 public:
     TTEntry() = default;
 
-    atomic_relaxed<uint16_t> key = 0; // 2 bytes
-    atomic_relaxed<Move> move = Move::Uninitialized; // 2 bytes
-    atomic_relaxed<Score> score = SCORE_UNDEFINED; // 2 bytes
-    atomic_relaxed<Score> static_eval = SCORE_UNDEFINED; // 2 bytes
-    atomic_relaxed<int8_t> depth = 0; // 1 bytes
-    atomic_relaxed<TTMeta> meta = TTMeta { SearchResultType::EMPTY, 0 }; // 1 byte
+    uint16_t key = 0; // 2 bytes
+    Move move = Move::Uninitialized; // 2 bytes
+    Score score = SCORE_UNDEFINED; // 2 bytes
+    Score static_eval = SCORE_UNDEFINED; // 2 bytes
+    int8_t depth = 0; // 1 bytes
+    TTMeta meta = TTMeta { SearchResultType::EMPTY, 0 }; // 1 byte
 };
 
 struct alignas(32) TTBucket : public std::array<TTEntry, 3>

--- a/src/TranspositionTable.cpp
+++ b/src/TranspositionTable.cpp
@@ -84,8 +84,7 @@ TTEntry* TranspositionTable::GetEntry(uint64_t key, int distanceFromRoot, int ha
         if (entry.key == key16)
         {
             // reset the age of this entry to mark it as not old
-            TTMeta meta = entry.meta;
-            entry.meta = TTMeta { meta.type, get_generation(half_turn_count, distanceFromRoot) };
+            entry.meta.generation = get_generation(half_turn_count, distanceFromRoot);
             return &entry;
         }
     }
@@ -102,8 +101,7 @@ int TranspositionTable::GetCapacity(int halfmove) const
     for (int i = 0; i < 1000; i++)
     {
         auto& entry = table[i / TTBucket::size][i % TTBucket::size];
-        TTMeta meta = entry.meta;
-        if (entry.key != EMPTY && meta.generation == current_generation)
+        if (entry.key != EMPTY && entry.meta.generation == current_generation)
         {
             count++;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "11.30.0";
+constexpr std::string_view version = "11.31.0";
 
 void PrintVersion()
 {

--- a/src/test/tsan.supp
+++ b/src/test/tsan.supp
@@ -1,0 +1,3 @@
+# Using atomics in TT is a slowdown, so we silence the data race warnings
+race:TranspositionTable::GetEntry
+race:TranspositionTable::AddEntry


### PR DESCRIPTION
```
Elo   | 2.22 +- 1.73 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 47368 W: 11742 L: 11439 D: 24187
Penta | [381, 5571, 11505, 5818, 409]
http://chess.grantnet.us/test/37471/
```