### PR TITLE
eval_correction_history_adj_depth

### DIFF
--- a/src/History.cpp
+++ b/src/History.cpp
@@ -53,11 +53,11 @@ int16_t* CorrectionHistory::get(const GameState& position)
     return &table[stm][pawn_hash % pawn_hash_table_size];
 }
 
-void CorrectionHistory::add(const GameState& position, int, int eval_diff)
+void CorrectionHistory::add(const GameState& position, int depth, int eval_diff)
 {
     auto* entry = get(position);
     // give a higher weight to high depth observations
-    auto ewa_weight = 1;
+    auto ewa_weight = std::clamp(depth, 1, 16);
     // calculate the EWA, clamping to the min/max accordingly
     auto new_value
         = (*entry * (ewa_weight_scale - ewa_weight) + eval_diff * eval_scale * ewa_weight) / ewa_weight_scale;


### PR DESCRIPTION
```
Elo   | 4.08 +- 3.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16450 W: 4322 L: 4129 D: 7999
Penta | [225, 1910, 3780, 2067, 243]
http://chess.grantnet.us/test/37483/
```