### PR TITLE
Use TT evaluation to correct static eval

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -634,27 +634,44 @@ Score TerminalScore(const BoardState& board, int distanceFromRoot)
     }
 }
 
-Score get_search_eval(
-    const GameState& position, const Score tt_eval, TTEntry* const tt_entry, int depth, int distance_from_root)
+Score get_search_eval(const GameState& position, TTEntry* const tt_entry, const Score tt_eval, const Score tt_score,
+    const SearchResultType tt_cutoff, int depth, int distance_from_root)
 {
-    if (tt_eval != SCORE_UNDEFINED)
-    {
-        return tt_eval;
-    }
-
-    const auto static_score = Evaluate(position);
-
     if (tt_entry)
     {
-        tt_entry->static_eval = static_score;
+        const auto static_eval = [&]
+        {
+            if (tt_eval != SCORE_UNDEFINED)
+            {
+                return tt_eval;
+            }
+            {
+                const auto eval = Evaluate(position);
+                tt_entry->static_eval = eval;
+                return eval;
+            }
+        }();
+
+        // use the tt_score to improve the static eval if possible
+        if (tt_score != SCORE_UNDEFINED
+            && (tt_cutoff == SearchResultType::EXACT
+                || (tt_cutoff == SearchResultType::LOWER_BOUND && tt_score >= static_eval)
+                || (tt_cutoff == SearchResultType::UPPER_BOUND && tt_score <= static_eval)))
+        {
+            return tt_score;
+        }
+        else
+        {
+            return static_eval;
+        }
     }
     else
     {
+        const auto static_eval = Evaluate(position);
         tTable.AddEntry(Move::Uninitialized, position.Board().GetZobristKey(), SCORE_UNDEFINED, depth,
-            position.Board().half_turn_count, distance_from_root, SearchResultType::EMPTY, static_score);
+            position.Board().half_turn_count, distance_from_root, SearchResultType::EMPTY, static_eval);
+        return static_eval;
     }
-
-    return static_score;
 }
 
 template <SearchType search_type>
@@ -711,7 +728,8 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
         return Quiescence<qsearch_type>(position, ss, local, shared, depth, alpha, beta);
     }
 
-    const auto staticScore = get_search_eval(position, tt_eval, tt_entry, depth, distance_from_root);
+    const auto staticScore
+        = get_search_eval(position, tt_entry, tt_eval, tt_score, tt_cutoff, depth, distance_from_root);
 
     // Step 6: Static null move pruning (a.k.a reverse futility pruning)
     //
@@ -894,7 +912,8 @@ SearchResult Quiescence(GameState& position, SearchStackState* ss, SearchLocalSt
 
     // Step 4: Stand-pat. We assume if all captures are bad, there's at least one quiet move that maintains the static
     // score
-    const auto staticScore = get_search_eval(position, tt_eval, tt_entry, depth, distance_from_root);
+    const auto staticScore
+        = get_search_eval(position, tt_entry, tt_eval, tt_score, tt_cutoff, depth, distance_from_root);
     alpha = std::max(alpha, staticScore);
     if (alpha >= beta)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "11.31.0";
+constexpr std::string_view version = "11.32.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 5.16 +- 3.66 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10240 W: 2418 L: 2266 D: 5556
Penta | [67, 1171, 2496, 1315, 71]
http://chess.grantnet.us/test/37495/
```
```
Elo   | 11.00 +- 6.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4422 W: 1184 L: 1044 D: 2194
Penta | [46, 499, 1001, 599, 66]
http://chess.grantnet.us/test/37494/
```