### PR TITLE
Adjust correction_max to 16

### DIFF
--- a/src/History.h
+++ b/src/History.h
@@ -68,7 +68,7 @@ struct CorrectionHistory
 {
     // must be a power of 2, for fast hash lookup
     static constexpr size_t pawn_hash_table_size = 16384;
-    static constexpr Score correction_max = 32;
+    static constexpr Score correction_max = 16;
     static constexpr int eval_scale = 512;
     static constexpr int ewa_weight_scale = 256;
     static_assert(correction_max.value() * eval_scale < std::numeric_limits<int16_t>::max());


### PR DESCRIPTION
```
Elo   | 4.10 +- 3.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 17464 W: 4619 L: 4413 D: 8432
Penta | [277, 2019, 3955, 2183, 298]
http://chess.grantnet.us/test/37500/
```