### PR TITLE
Fix code for TT eval correction

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "11.32.0";
+constexpr std::string_view version = "11.32.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | -0.71 +- 2.65 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18704 W: 4200 L: 4238 D: 10266
Penta | [125, 2190, 4734, 2204, 99]
http://chess.grantnet.us/test/37513/
```
```
Elo   | 1.99 +- 1.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 85000 W: 21641 L: 21154 D: 42205
Penta | [1117, 10212, 19430, 10549, 1192]
http://chess.grantnet.us/test/37512/
```