### PR TITLE
Don't allow TT eval correction to return unproven mate scores in q-search

### DIFF
--- a/src/Score.h
+++ b/src/Score.h
@@ -175,4 +175,9 @@ public:
         return Score(30000);
     };
 };
+
+inline Score abs(Score val)
+{
+    return std::abs(val.value());
+}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "11.32.1";
+constexpr std::string_view version = "11.32.2";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | -0.56 +- 1.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.04 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 48002 W: 11976 L: 12053 D: 23973
Penta | [570, 5635, 11683, 5528, 585]
http://chess.grantnet.us/test/37533/
```