### PR TITLE
Update default network to e9c3f4f5.nn

### DIFF
--- a/src/BoardState.cpp
+++ b/src/BoardState.cpp
@@ -3,7 +3,6 @@
 #include "BitBoardDefine.h"
 #include "Move.h"
 #include "MoveGeneration.h"
-#include "Network.h"
 #include "Zobrist.h"
 
 #include <charconv>
@@ -320,7 +319,7 @@ std::ostream& operator<<(std::ostream& os, const BoardState& b)
     return os;
 }
 
-void BoardState::ApplyMove(Move move, Network& net)
+void BoardState::ApplyMove(Move move)
 {
     key.ToggleSTM();
 
@@ -336,8 +335,8 @@ void BoardState::ApplyMove(Move move, Network& net)
     switch (move.GetFlag())
     {
     case QUIET:
-        SetSquareAndUpdate(move.GetTo(), GetSquare(move.GetFrom()), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        SetSquareAndUpdate(move.GetTo(), GetSquare(move.GetFrom()));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     case PAWN_DOUBLE_MOVE:
     {
@@ -369,8 +368,8 @@ void BoardState::ApplyMove(Move move, Network& net)
             }
         }
 
-        SetSquareAndUpdate(move.GetTo(), Piece(PAWN, stm), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        SetSquareAndUpdate(move.GetTo(), Piece(PAWN, stm));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     }
     case A_SIDE_CASTLE:
@@ -380,10 +379,10 @@ void BoardState::ApplyMove(Move move, Network& net)
         Square rook_start = LSB(old_castle_squares & RankBB[stm == WHITE ? RANK_1 : RANK_8]);
         Square rook_end = stm == WHITE ? SQ_D1 : SQ_D8;
 
-        ClearSquareAndUpdate(king_start, net);
-        ClearSquareAndUpdate(rook_start, net);
-        SetSquareAndUpdate(king_end, Piece(KING, stm), net);
-        SetSquareAndUpdate(rook_end, Piece(ROOK, stm), net);
+        ClearSquareAndUpdate(king_start);
+        ClearSquareAndUpdate(rook_start);
+        SetSquareAndUpdate(king_end, Piece(KING, stm));
+        SetSquareAndUpdate(rook_end, Piece(ROOK, stm));
 
         break;
     }
@@ -394,58 +393,58 @@ void BoardState::ApplyMove(Move move, Network& net)
         Square rook_start = MSB(old_castle_squares & RankBB[stm == WHITE ? RANK_1 : RANK_8]);
         Square rook_end = stm == WHITE ? SQ_F1 : SQ_F8;
 
-        ClearSquareAndUpdate(king_start, net);
-        ClearSquareAndUpdate(rook_start, net);
-        SetSquareAndUpdate(king_end, Piece(KING, stm), net);
-        SetSquareAndUpdate(rook_end, Piece(ROOK, stm), net);
+        ClearSquareAndUpdate(king_start);
+        ClearSquareAndUpdate(rook_start);
+        SetSquareAndUpdate(king_end, Piece(KING, stm));
+        SetSquareAndUpdate(rook_end, Piece(ROOK, stm));
 
         break;
     }
     case CAPTURE:
-        ClearSquareAndUpdate(move.GetTo(), net);
-        SetSquareAndUpdate(move.GetTo(), GetSquare(move.GetFrom()), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        ClearSquareAndUpdate(move.GetTo());
+        SetSquareAndUpdate(move.GetTo(), GetSquare(move.GetFrom()));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     case EN_PASSANT:
-        SetSquareAndUpdate(move.GetTo(), GetSquare(move.GetFrom()), net);
-        ClearSquareAndUpdate(GetPosition(GetFile(move.GetTo()), GetRank(move.GetFrom())), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        SetSquareAndUpdate(move.GetTo(), GetSquare(move.GetFrom()));
+        ClearSquareAndUpdate(GetPosition(GetFile(move.GetTo()), GetRank(move.GetFrom())));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     case KNIGHT_PROMOTION:
-        SetSquareAndUpdate(move.GetTo(), Piece(KNIGHT, stm), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        SetSquareAndUpdate(move.GetTo(), Piece(KNIGHT, stm));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     case BISHOP_PROMOTION:
-        SetSquareAndUpdate(move.GetTo(), Piece(BISHOP, stm), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        SetSquareAndUpdate(move.GetTo(), Piece(BISHOP, stm));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     case ROOK_PROMOTION:
-        SetSquareAndUpdate(move.GetTo(), Piece(ROOK, stm), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        SetSquareAndUpdate(move.GetTo(), Piece(ROOK, stm));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     case QUEEN_PROMOTION:
-        SetSquareAndUpdate(move.GetTo(), Piece(QUEEN, stm), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        SetSquareAndUpdate(move.GetTo(), Piece(QUEEN, stm));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     case KNIGHT_PROMOTION_CAPTURE:
-        ClearSquareAndUpdate(move.GetTo(), net);
-        SetSquareAndUpdate(move.GetTo(), Piece(KNIGHT, stm), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        ClearSquareAndUpdate(move.GetTo());
+        SetSquareAndUpdate(move.GetTo(), Piece(KNIGHT, stm));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     case BISHOP_PROMOTION_CAPTURE:
-        ClearSquareAndUpdate(move.GetTo(), net);
-        SetSquareAndUpdate(move.GetTo(), Piece(BISHOP, stm), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        ClearSquareAndUpdate(move.GetTo());
+        SetSquareAndUpdate(move.GetTo(), Piece(BISHOP, stm));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     case ROOK_PROMOTION_CAPTURE:
-        ClearSquareAndUpdate(move.GetTo(), net);
-        SetSquareAndUpdate(move.GetTo(), Piece(ROOK, stm), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        ClearSquareAndUpdate(move.GetTo());
+        SetSquareAndUpdate(move.GetTo(), Piece(ROOK, stm));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     case QUEEN_PROMOTION_CAPTURE:
-        ClearSquareAndUpdate(move.GetTo(), net);
-        SetSquareAndUpdate(move.GetTo(), Piece(QUEEN, stm), net);
-        ClearSquareAndUpdate(move.GetFrom(), net);
+        ClearSquareAndUpdate(move.GetTo());
+        SetSquareAndUpdate(move.GetTo(), Piece(QUEEN, stm));
+        ClearSquareAndUpdate(move.GetFrom());
         break;
     default:
         assert(0);
@@ -460,7 +459,6 @@ void BoardState::ApplyMove(Move move, Network& net)
     stm = !stm;
 
     assert(key.Verify(*this));
-    assert(net.Verify(*this));
 }
 
 void BoardState::ApplyNullMove()
@@ -479,17 +477,15 @@ void BoardState::ApplyNullMove()
     assert(key.Verify(*this));
 }
 
-void BoardState::SetSquareAndUpdate(Square square, Pieces piece, Network& net)
+void BoardState::SetSquareAndUpdate(Square square, Pieces piece)
 {
-    net.AddInput(square, piece);
     key.TogglePieceSquare(piece, square);
     SetSquare(square, piece);
 }
 
-void BoardState::ClearSquareAndUpdate(Square square, Network& net)
+void BoardState::ClearSquareAndUpdate(Square square)
 {
     Pieces piece = GetSquare(square);
-    net.RemoveInput(square, piece);
     key.TogglePieceSquare(piece, square);
     ClearSquare(square);
 }

--- a/src/BoardState.h
+++ b/src/BoardState.h
@@ -81,7 +81,7 @@ public:
     bool InitialiseFromFen(const std::array<std::string_view, 6>& fen);
     void UpdateCastleRights(Move move, Zobrist& zobrist_key);
 
-    void ApplyMove(Move move, Network& net);
+    void ApplyMove(Move move);
     void ApplyNullMove();
 
     // given a from/to square, infer which MoveFlag matches the current position (ignoring promotions)
@@ -90,8 +90,8 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const BoardState& b);
 
 private:
-    void SetSquareAndUpdate(Square square, Pieces piece, Network& net);
-    void ClearSquareAndUpdate(Square square, Network& net);
+    void SetSquareAndUpdate(Square square, Pieces piece);
+    void ClearSquareAndUpdate(Square square);
 
     // optimization: GetWhitePieces/GetBlackPieces can return a precalculated bitboard
     // which is updated only when needed

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -18,9 +18,10 @@ GameState::GameState()
 
 void GameState::ApplyMove(Move move)
 {
-    net.AccumulatorPush();
     previousStates.push_back(previousStates.back());
-    MutableBoard().ApplyMove(move, net);
+    MutableBoard().ApplyMove(move);
+    net.Recalculate(Board());
+    assert(net.Verify(Board()));
 }
 
 void GameState::ApplyMove(std::string_view strmove)
@@ -51,7 +52,8 @@ void GameState::RevertMove()
     assert(previousStates.size() > 0);
 
     previousStates.pop_back();
-    net.AccumulatorPop();
+    net.Recalculate(Board());
+    assert(net.Verify(Board()));
 }
 
 void GameState::ApplyNullMove()

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -31,9 +31,6 @@ public:
     bool InitialiseFromFen(std::array<std::string_view, 6> fen);
     bool InitialiseFromFen(std::string_view fen);
 
-    // TODO: is this needed?
-    void Reset();
-
     Score GetEvaluation() const;
 
     bool CheckForRep(int distanceFromRoot, int maxReps) const;

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,8 +3,8 @@ LLVM_PROFDATA := llvm-profdata
 BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
-EVALURL = https://github.com/KierenP/Halogen-Networks/blob/8aec7df412aa8d755a7c711b48fd875b538090d8/c61a0069.nn?raw=true
-EVALFILE = $(BUILD_DIR)/c61a0069.nn
+EVALURL = https://github.com/KierenP/Halogen-Networks/blob/a9a8169954e73712c6013b22e37f5ecf8c3b565d/e9c3f4f5.nn?raw=true
+EVALFILE = $(BUILD_DIR)/e9c3f4f5.nn
 
 SRCS := \
 	BitBoardDefine.cpp \

--- a/src/Network.h
+++ b/src/Network.h
@@ -21,6 +21,11 @@ struct HalfAccumulator
     {
         return side == rhs.side;
     }
+
+    void AddInput(Square w_king, Square b_king, Square sq, Pieces piece);
+    void SubInput(Square w_king, Square b_king, Square sq, Pieces piece);
+
+    void Recalculate(const BoardState& board);
 };
 
 class Network
@@ -34,8 +39,8 @@ public:
     // calculates starting from the first hidden layer and skips input -> hidden
     Score Eval(const BoardState& board) const;
 
-    // void ApplyMove(const BoardState& board, Move move);
-    // void UndoMove(const BoardState& board);
+    void ApplyMove(const BoardState& prev_move_board, const BoardState& post_move_board, Move move);
+    void UndoMove();
 
 private:
     std::vector<HalfAccumulator> AccumulatorStack;

--- a/src/Network.h
+++ b/src/Network.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "BitBoardDefine.h"
+#include "Move.h"
 #include "Score.h"
 
 constexpr size_t INPUT_NEURONS = 12 * 64;
@@ -33,17 +34,9 @@ public:
     // calculates starting from the first hidden layer and skips input -> hidden
     Score Eval(const BoardState& board) const;
 
-    // call and then update inputs as required
-    void AccumulatorPush();
-
-    void AddInput(Square square, Pieces piece);
-    void RemoveInput(Square square, Pieces piece);
-
-    // do undo the last move
-    void AccumulatorPop();
+    // void ApplyMove(const BoardState& board, Move move);
+    // void UndoMove(const BoardState& board);
 
 private:
-    static int index(Square square, Pieces piece, Players view);
-
     std::vector<HalfAccumulator> AccumulatorStack;
 };


### PR DESCRIPTION
Trained using 1.35B positions (datagen 3 + 4 + 5 + 6), filtered to remove captures and promotions. Non-mirrored 8 king bucket architecture.

```
File Path      : ...
Threads        : 20
WDL Proportion : start 0.3 end 0.3
Max Epochs     : 50
Save Rate      : 10
Batch Size     : 16384
Net Name       : bullet_r19_768x8-512x2-1x8
LR Scheduler   : start 0.001 gamma 0.95 drop every 1 epochs
Scale          : 160
Positions      : 1116214793
```
```
Elo   | 7.49 +- 4.70 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6588 W: 1805 L: 1663 D: 3120
Penta | [59, 711, 1628, 821, 75]
http://chess.grantnet.us/test/37573/
```
```
Elo   | 5.74 +- 4.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11268 W: 3329 L: 3143 D: 4796
Penta | [245, 1253, 2479, 1385, 272]
http://chess.grantnet.us/test/37571/
```