### PR TITLE
Implement enhanced SCReLU trick from Lizard engine

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,8 +3,8 @@ LLVM_PROFDATA := llvm-profdata
 BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
-EVALURL = https://github.com/KierenP/Halogen-Networks/blob/1502bf9b41c65dba8c7f1e5c1fe1a822f3822d7c/6faaebee.nn?raw=true
-EVALFILE = $(BUILD_DIR)/6faaebee.nn
+EVALURL = https://github.com/KierenP/Halogen-Networks/blob/2808843de59b258977826fbb4ec8b453fbaf3853/f359d888.nn?raw=true
+EVALFILE = $(BUILD_DIR)/f359d888.nn
 
 SRCS := \
 	BitBoardDefine.cpp \

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -24,7 +24,7 @@ struct alignas(64) network
     return true;
 }();
 
-constexpr int16_t L1_SCALE = 181;
+constexpr int16_t L1_SCALE = 255;
 constexpr int16_t L2_SCALE = 64;
 constexpr double SCALE_FACTOR = 160;
 
@@ -65,17 +65,23 @@ template <typename T, size_t SIZE>
 }
 
 template <typename T_out, typename T_in, size_t SIZE>
-void DotProductHalves(const std::array<T_in, SIZE>& stm, const std::array<T_in, SIZE>& other,
+void DotProductSCReLU(const std::array<T_in, SIZE>& stm, const std::array<T_in, SIZE>& other,
     const std::array<T_in, SIZE * 2>& weights, T_out& output)
 {
+    // This uses the lizard-SCReLU trick: Given stm[i] < 255, and weights[i] < 126, we want to compute stm[i] * stm[i] *
+    // weights[i] to do the SCReLU dot product. By first doing stm[i] * weights[i], the result fits within the int16_t
+    // type. Then multiply by stm[i] and accumulate.
+
     for (size_t i = 0; i < SIZE; i++)
     {
-        output += stm[i] * weights[i];
+        int16_t partial = stm[i] * weights[i];
+        output += partial * stm[i];
     }
 
     for (size_t i = 0; i < SIZE; i++)
     {
-        output += other[i] * weights[i + SIZE];
+        int16_t partial = other[i] * weights[i + SIZE];
+        output += partial * other[i];
     }
 }
 
@@ -572,10 +578,8 @@ Score Network::Eval(const BoardState& board, const Accumulator& acc)
     auto output_bucket = calculate_output_bucket(GetBitCount(board.GetAllPieces()));
 
     int32_t output = net.outputBias[output_bucket];
-    DotProductHalves(SCReLU(acc.side[stm]), SCReLU(acc.side[!stm]), net.outputWeights[output_bucket], output);
-    output *= SCALE_FACTOR;
-    output /= L1_SCALE * L2_SCALE;
-    return output;
+    DotProductSCReLU(CReLU(acc.side[stm]), CReLU(acc.side[!stm]), net.outputWeights[output_bucket], output);
+    return int64_t(output) * SCALE_FACTOR / L1_SCALE / L1_SCALE / L2_SCALE;
 }
 
 Score Network::SlowEval(const BoardState& board)

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -577,9 +577,10 @@ Score Network::Eval(const BoardState& board, const Accumulator& acc)
     auto stm = board.stm;
     auto output_bucket = calculate_output_bucket(GetBitCount(board.GetAllPieces()));
 
-    int32_t output = net.outputBias[output_bucket];
+    int32_t output = 0;
     DotProductSCReLU(CReLU(acc.side[stm]), CReLU(acc.side[!stm]), net.outputWeights[output_bucket], output);
-    return int64_t(output) * SCALE_FACTOR / L1_SCALE / L1_SCALE / L2_SCALE;
+    return (int64_t(output) + int64_t(net.outputBias[output_bucket]) * L1_SCALE) * SCALE_FACTOR / L1_SCALE / L1_SCALE
+        / L2_SCALE;
 }
 
 Score Network::SlowEval(const BoardState& board)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "11.41.0";
+constexpr std::string_view version = "11.42.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 16.09 +- 7.10 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2614 W: 675 L: 554 D: 1385
Penta | [9, 266, 648, 363, 21]
http://chess.grantnet.us/test/37671/
```
```
Elo   | 13.95 +- 6.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3388 W: 932 L: 796 D: 1660
Penta | [36, 353, 793, 463, 49]
http://chess.grantnet.us/test/37670/
```