### PR TITLE
Fix SEE function for en passant

### DIFF
--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -192,8 +192,8 @@ int see(const BoardState& board, Move move)
     int index = 0;
 
     auto capturing = board.GetSquare(from);
-    auto captured = board.GetSquare(to);
     auto attacker = ColourOfPiece(capturing);
+    auto captured = move.GetFlag() == EN_PASSANT ? Piece(PAWN, !attacker) : board.GetSquare(to);
 
     uint64_t from_set = (1ull << from);
     uint64_t occ = board.GetAllPieces(), bishops = 0, rooks = 0;
@@ -201,6 +201,11 @@ int see(const BoardState& board, Move move)
     bishops = rooks = board.GetPieceBB<QUEEN>();
     bishops |= board.GetPieceBB<BISHOP>();
     rooks |= board.GetPieceBB<ROOK>();
+
+    if (move.GetFlag() == EN_PASSANT)
+    {
+        occ ^= SquareBB[GetPosition(GetFile(move.GetTo()), GetRank(move.GetFrom()))];
+    }
 
     uint64_t attack_def = AttackersToSq(board, to);
     scores[index] = PieceValues[captured];
@@ -280,13 +285,7 @@ void StagedMoveGenerator::OrderMoves(ExtendedMoveList& moves)
         // Captures
         else if (moves[i].move.IsCapture())
         {
-            int SEE = 0;
-
-            if (moves[i].move.GetFlag() != EN_PASSANT)
-            {
-                SEE = see(position.Board(), moves[i].move);
-            }
-
+            int SEE = see(position.Board(), moves[i].move);
             moves[i].score = SCORE_CAPTURE + SEE;
             moves[i].SEE = SEE;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.0.0";
+constexpr std::string_view version = "12.0.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | -0.13 +- 2.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 31602 W: 7744 L: 7756 D: 16102
Penta | [300, 3708, 7799, 3692, 302]
http://chess.grantnet.us/test/37713/
```