### PR TITLE
Fix overflow in calculating TT entry score

### DIFF
--- a/src/TranspositionTable.cpp
+++ b/src/TranspositionTable.cpp
@@ -26,7 +26,7 @@ void TranspositionTable::AddEntry(const Move& best, uint64_t ZobristKey, Score s
     score = convert_to_tt_score(score, distanceFromRoot);
     auto key16 = uint16_t(ZobristKey);
     auto current_generation = get_generation(Turncount, distanceFromRoot);
-    std::array<int8_t, TTBucket::size> scores = {};
+    std::array<int16_t, TTBucket::size> scores = {};
     auto& bucket = GetBucket(ZobristKey);
 
     const auto write_to_entry = [&](auto& entry)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.0.3";
+constexpr std::string_view version = "12.0.4";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 1.92 +- 3.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 11762 W: 2889 L: 2824 D: 6049
Penta | [69, 1357, 2993, 1364, 98]
http://chess.grantnet.us/test/37752/
```