### PR TITLE
Update default network to 9819aa87.nn

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,8 +3,8 @@ LLVM_PROFDATA := llvm-profdata
 BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
-EVALURL = https://github.com/KierenP/Halogen-Networks/blob/414f007e25168fab573c9b938acb198e4e1b66d4/0a11ed39.nn?raw=true
-EVALFILE = $(BUILD_DIR)/0a11ed39.nn
+EVALURL = https://github.com/KierenP/Halogen-Networks/blob/8aaaffab345bf683af734de3875ae50866ded661/9819aa87.nn?raw=true
+EVALFILE = $(BUILD_DIR)/9819aa87.nn
 
 SRCS := \
 	BitBoardDefine.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.0.5";
+constexpr std::string_view version = "12.1.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
The datasets used were as follows:

| File       | Origin                                        | Fens |
|------------|-----------------------------------------------|------|
| datagen3+4 | 11.24.0 + 768-512x2-1_r18_g2771316.nn         | 0.6B |
| datagen5+6 | 11.30.0 + bullet_r10_768-512x2-1-epoch100.bin | 0.7B |
| datagen7+8 | 12.0.0                                        | 0.7B |

The combined dataset was [filtered](https://github.com/KierenP/Halogen/blob/e49385f990a750a6bbbaf7320a0b47d010be116e/src/datagen/filter.h) to remove positions where the best move is a capture, promotion, or positions in check. The dataset was then shuffled.

The bullet trainer was used with [config](https://github.com/jw1912/bullet/blob/d4033b515f17bafa596c714ac969269217ab6a53/examples/halogen.rs).

-----------------------------

```
Elo   | 25.97 +- 3.56 (95%)
Conf  | 40.0+0.40s Threads=1 Hash=64MB
Games | N: 10000 W: 2812 L: 2066 D: 5122
Penta | [26, 900, 2433, 1584, 57]
http://chess.grantnet.us/test/37780/
```

```
Elo   | 27.81 +- 3.99 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=8MB
Games | N: 10002 W: 3030 L: 2231 D: 4741
Penta | [85, 933, 2246, 1572, 165]
http://chess.grantnet.us/test/37779/
```
