### PR TITLE
Update default network to 46f749a2.nn

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,8 +3,8 @@ LLVM_PROFDATA := llvm-profdata
 BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
-EVALURL = https://github.com/KierenP/Halogen-Networks/blob/8aaaffab345bf683af734de3875ae50866ded661/9819aa87.nn?raw=true
-EVALFILE = $(BUILD_DIR)/9819aa87.nn
+EVALURL = https://github.com/KierenP/Halogen-Networks/blob/fb19d1823c259e0d1735de94c8b6890557fafd96/46f749a2.nn?raw=true
+EVALFILE = $(BUILD_DIR)/46f749a2.nn
 
 SRCS := \
 	BitBoardDefine.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.1.0";
+constexpr std::string_view version = "12.2.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
The datasets used were as follows:

| File       | Origin                                        | Fens |
|------------|-----------------------------------------------|------|
| datagen3+4 | 11.24.0 + 768-512x2-1_r18_g2771316.nn         | 0.6B |
| datagen5+6 | 11.30.0 + bullet_r10_768-512x2-1-epoch100.bin | 0.7B |
| datagen7+8+9 | 12.0.0                                        | 1.9B |

The combined dataset was [filtered](https://github.com/KierenP/Halogen/blob/e49385f990a750a6bbbaf7320a0b47d010be116e/src/datagen/filter.h) to remove positions where the best move is a capture, promotion, or positions in check. The dataset was then shuffled.

The bullet trainer was used with [config](https://github.com/jw1912/bullet/blob/b27b9bab0c23715d1c5b768a2211f9c19a02ce9c/examples/halogen.rs).

-----------------------------

```
Elo   | 22.80 +- 8.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1770 W: 490 L: 374 D: 906
Penta | [4, 170, 430, 268, 13]
http://chess.grantnet.us/test/37786/
```

```
Elo   | 18.95 +- 7.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.08 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2422 W: 696 L: 564 D: 1162
Penta | [17, 245, 568, 351, 30]
http://chess.grantnet.us/test/37785/
```