### PR TITLE
Update default network to 6913d330.nn

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,8 +3,8 @@ LLVM_PROFDATA := llvm-profdata
 BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
-EVALURL = https://github.com/KierenP/Halogen-Networks/blob/f7f182c776dce3cac71a2fae258f3e3037bd4016/2cc25bae.nn?raw=true
-EVALFILE = $(BUILD_DIR)/2cc25bae.nn
+EVALURL = https://github.com/KierenP/Halogen-Networks/blob/feefcc3817f7e9b0fd8a94dbb9756ce8b805a73a/6913d330.nn?raw=true
+EVALFILE = $(BUILD_DIR)6913d330.nn
 
 SRCS := \
 	BitBoardDefine.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.3.0";
+constexpr std::string_view version = "12.4.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
The datasets used were as follows:

| File       | Origin                                        | Fens |
|------------|-----------------------------------------------|------|
| datagen3+4 | 11.24.0 + 768-512x2-1_r18_g2771316.nn         | 0.6B |
| datagen5+6 | 11.30.0 + bullet_r10_768-512x2-1-epoch100.bin | 0.7B |
| datagen7..13| 12.0.0                                        | 4.0B |

The combined dataset was [filtered](https://github.com/KierenP/Halogen/blob/e49385f990a750a6bbbaf7320a0b47d010be116e/src/datagen/filter.h) to remove positions where the best move is a capture, promotion, or positions in check. The dataset was then shuffled.

The bullet trainer was used with [config](https://github.com/KierenP/bullet/blob/24921649e13656603941339b0a42ef84f1c319d4/examples/halogen.rs).

-----------------------------

```
Elo   | 9.56 +- 5.30 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4506 W: 1168 L: 1044 D: 2294
Penta | [18, 472, 1160, 574, 29]
http://chess.grantnet.us/test/37896/
```
```
Elo   | 5.44 +- 3.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10094 W: 2643 L: 2485 D: 4966
Penta | [86, 1176, 2379, 1306, 100]
http://chess.grantnet.us/test/37889/
```