### PR TITLE
Avoid calculating static eval when in check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.4.2";
+constexpr std::string_view version = "12.4.3";
 
 void PrintVersion()
 {

--- a/src/test/tsan.supp
+++ b/src/test/tsan.supp
@@ -1,3 +1,4 @@
 # Using atomics in TT is a slowdown, so we silence the data race warnings
 race:TranspositionTable::GetEntry
 race:TranspositionTable::AddEntry
+race:get_search_eval


### PR DESCRIPTION
Every pruning / reduction / extension technique that uses the static eval is not applied when in check, so this change is non-functional. Speedup is `0.466 %  +/-  0.085 %`