### PR TITLE
Adjust static evaluation based on 50 move rule

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -651,7 +651,7 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
             tt_entry->static_eval = raw_eval = Evaluate(position.Board(), ss, local.net);
         }
 
-        adjusted_eval = raw_eval.value() * (128 - position.Board().fifty_move_count) / 128;
+        adjusted_eval = raw_eval.value() * (128 - (int)position.Board().fifty_move_count) / 128;
 
         // Use the tt_score to improve the static eval if possible. Avoid returning unproved mate scores in q-search
         if (tt_score != SCORE_UNDEFINED && (!is_qsearch || std::abs(tt_score) < Score::tb_win_in(MAX_DEPTH))
@@ -665,7 +665,7 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
     else
     {
         raw_eval = Evaluate(position.Board(), ss, local.net);
-        adjusted_eval = raw_eval.value() * (128 - position.Board().fifty_move_count) / 128;
+        adjusted_eval = raw_eval.value() * (128 - (int)position.Board().fifty_move_count) / 128;
         tTable.AddEntry(Move::Uninitialized, position.Board().GetZobristKey(), SCORE_UNDEFINED, depth,
             position.Board().half_turn_count, distance_from_root, SearchResultType::EMPTY, raw_eval);
     }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -651,7 +651,7 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
             tt_entry->static_eval = raw_eval = Evaluate(position.Board(), ss, local.net);
         }
 
-        adjusted_eval = raw_eval.value() * (128 - (int)position.Board().fifty_move_count) / 128;
+        adjusted_eval = raw_eval.value() * (256 - (int)position.Board().fifty_move_count) / 256;
 
         // Use the tt_score to improve the static eval if possible. Avoid returning unproved mate scores in q-search
         if (tt_score != SCORE_UNDEFINED && (!is_qsearch || std::abs(tt_score) < Score::tb_win_in(MAX_DEPTH))
@@ -665,7 +665,7 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
     else
     {
         raw_eval = Evaluate(position.Board(), ss, local.net);
-        adjusted_eval = raw_eval.value() * (128 - (int)position.Board().fifty_move_count) / 128;
+        adjusted_eval = raw_eval.value() * (256 - (int)position.Board().fifty_move_count) / 256;
         tTable.AddEntry(Move::Uninitialized, position.Board().GetZobristKey(), SCORE_UNDEFINED, depth,
             position.Board().half_turn_count, distance_from_root, SearchResultType::EMPTY, raw_eval);
     }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -637,41 +637,40 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
     TTEntry* const tt_entry, const Score tt_eval, const Score tt_score, const SearchResultType tt_cutoff, int depth,
     int distance_from_root)
 {
+    Score raw_eval;
+    Score adjusted_eval;
+
     if (tt_entry)
     {
-        const auto static_eval = [&]
+        if (tt_eval != SCORE_UNDEFINED)
         {
-            if (tt_eval != SCORE_UNDEFINED)
-            {
-                return tt_eval;
-            }
-            {
-                const auto eval = Evaluate(position.Board(), ss, local.net);
-                tt_entry->static_eval = eval;
-                return eval;
-            }
-        }();
+            raw_eval = tt_eval;
+        }
+        else
+        {
+            tt_entry->static_eval = raw_eval = Evaluate(position.Board(), ss, local.net);
+        }
+
+        adjusted_eval = raw_eval.value() * (128 - position.Board().fifty_move_count) / 128;
 
         // Use the tt_score to improve the static eval if possible. Avoid returning unproved mate scores in q-search
         if (tt_score != SCORE_UNDEFINED && (!is_qsearch || std::abs(tt_score) < Score::tb_win_in(MAX_DEPTH))
             && (tt_cutoff == SearchResultType::EXACT
-                || (tt_cutoff == SearchResultType::LOWER_BOUND && tt_score >= static_eval)
-                || (tt_cutoff == SearchResultType::UPPER_BOUND && tt_score <= static_eval)))
+                || (tt_cutoff == SearchResultType::LOWER_BOUND && tt_score >= adjusted_eval)
+                || (tt_cutoff == SearchResultType::UPPER_BOUND && tt_score <= adjusted_eval)))
         {
-            return { static_eval, tt_score };
-        }
-        else
-        {
-            return { static_eval, static_eval };
+            adjusted_eval = tt_score;
         }
     }
     else
     {
-        const auto static_eval = Evaluate(position.Board(), ss, local.net);
+        raw_eval = Evaluate(position.Board(), ss, local.net);
+        adjusted_eval = raw_eval.value() * (128 - position.Board().fifty_move_count) / 128;
         tTable.AddEntry(Move::Uninitialized, position.Board().GetZobristKey(), SCORE_UNDEFINED, depth,
-            position.Board().half_turn_count, distance_from_root, SearchResultType::EMPTY, static_eval);
-        return { static_eval, static_eval };
+            position.Board().half_turn_count, distance_from_root, SearchResultType::EMPTY, raw_eval);
     }
+
+    return { raw_eval, adjusted_eval };
 }
 
 template <SearchType search_type>

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -651,7 +651,7 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
             tt_entry->static_eval = raw_eval = Evaluate(position.Board(), ss, local.net);
         }
 
-        adjusted_eval = raw_eval.value() * (256 - (int)position.Board().fifty_move_count) / 256;
+        adjusted_eval = raw_eval.value() * (288 - (int)position.Board().fifty_move_count) / 256;
 
         // Use the tt_score to improve the static eval if possible. Avoid returning unproved mate scores in q-search
         if (tt_score != SCORE_UNDEFINED && (!is_qsearch || std::abs(tt_score) < Score::tb_win_in(MAX_DEPTH))
@@ -665,7 +665,7 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
     else
     {
         raw_eval = Evaluate(position.Board(), ss, local.net);
-        adjusted_eval = raw_eval.value() * (256 - (int)position.Board().fifty_move_count) / 256;
+        adjusted_eval = raw_eval.value() * (288 - (int)position.Board().fifty_move_count) / 256;
         tTable.AddEntry(Move::Uninitialized, position.Board().GetZobristKey(), SCORE_UNDEFINED, depth,
             position.Board().half_turn_count, distance_from_root, SearchResultType::EMPTY, raw_eval);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.4.1";
+constexpr std::string_view version = "12.5.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 5.36 +- 3.03 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 13350 W: 3259 L: 3053 D: 7038
Penta | [45, 1483, 3416, 1683, 48]
http://chess.grantnet.us/test/38088/
```
```
Elo   | 1.37 +- 1.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 124142 W: 30527 L: 30039 D: 63576
Penta | [1030, 14795, 29924, 15301, 1021]
http://chess.grantnet.us/test/38080/
```