### PR TITLE
Implement smart SEE for inequality checks

### DIFF
--- a/src/MoveList.h
+++ b/src/MoveList.h
@@ -5,21 +5,18 @@
 #include "Move.h"
 #include "StaticVector.h"
 
-// For move ordering we need to bundle the 'score' and SEE values
-// with the move objects
+// For move ordering we need to bundle the 'score' with the move objects
 struct ExtendedMove
 {
     ExtendedMove() = default;
     ExtendedMove(const Move _move)
         : move(_move)
         , score(0)
-        , SEE(0)
     {
     }
     ExtendedMove(Square from, Square to, MoveFlag flag)
         : move(from, to, flag)
         , score(0)
-        , SEE(0)
     {
     }
 
@@ -35,7 +32,6 @@ struct ExtendedMove
 
     Move move;
     int16_t score;
-    int16_t SEE;
 };
 
 using ExtendedMoveList = StaticVector<ExtendedMove, 256>;

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "BitBoardDefine.h"
+#include "BoardState.h"
 #include "EGTB.h"
 #include "Evaluate.h"
 #include "GameState.h"
@@ -22,6 +23,7 @@
 #include "SearchConstants.h"
 #include "SearchData.h"
 #include "StagedMoveGenerator.h"
+#include "StaticExchangeEvaluation.h"
 #include "TTEntry.h"
 #include "TimeManager.h"
 #include "TranspositionTable.h"
@@ -927,10 +929,26 @@ SearchResult Quiescence(GameState& position, SearchStackState* ss, SearchLocalSt
 
     while (gen.Next(move))
     {
-        int SEE = gen.GetSEE(move);
-
-        // delta pruning
-        if (eval + SEE + 280 < alpha)
+        // delta pruning (This looks pretty strange, but it was to maintain the legacy behaviour. It will be simplified
+        // away)
+        if (move.IsPromotion())
+        {
+            if (move.GetFlag() == QUEEN_PROMOTION || move.GetFlag() == QUEEN_PROMOTION_CAPTURE)
+            {
+                if (eval + PieceValues[QUEEN] + 280 < alpha)
+                {
+                    break;
+                }
+            }
+            else
+            {
+                if (eval + 280 < alpha)
+                {
+                    break;
+                }
+            }
+        }
+        else if (!see_ge(position.Board(), move, alpha - eval - 280))
         {
             break;
         }

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -30,8 +30,6 @@ StagedMoveGenerator::StagedMoveGenerator(
 
 bool StagedMoveGenerator::Next(Move& move)
 {
-    moveSEE = std::nullopt;
-
     if (stage == Stage::TT_MOVE)
     {
         stage = Stage::GEN_LOUD;
@@ -55,26 +53,9 @@ bool StagedMoveGenerator::Next(Move& move)
     {
         while (current != loudMoves.end())
         {
-            if (current->move.IsPromotion())
-            {
-                if (current->move.GetFlag() == QUEEN_PROMOTION || current->move.GetFlag() == QUEEN_PROMOTION_CAPTURE)
-                {
-                    current->SEE = PieceValues[QUEEN];
-                }
-                else
-                {
-                    current->SEE = 0;
-                }
-            }
-            else
-            {
-                current->SEE = see(position.Board(), current->move);
-            }
-
-            if (current->SEE >= 0)
+            if (current->move.IsPromotion() || see_ge(position.Board(), current->move, 0))
             {
                 move = current->move;
-                moveSEE = current->SEE;
                 ++current;
                 return true;
             }
@@ -121,7 +102,6 @@ bool StagedMoveGenerator::Next(Move& move)
         if (current != bad_loudMoves.end())
         {
             move = current->move;
-            moveSEE = current->SEE;
             ++current;
             return true;
         }
@@ -147,7 +127,6 @@ bool StagedMoveGenerator::Next(Move& move)
         if (current != quietMoves.end())
         {
             move = current->move;
-            moveSEE = current->SEE;
             ++current;
             return true;
         }
@@ -180,11 +159,6 @@ void selection_sort(ExtendedMoveList& v)
     {
         std::iter_swap(it, std::max_element(it, v.end()));
     }
-}
-
-int16_t StagedMoveGenerator::GetSEE(Move) const
-{
-    return *moveSEE;
 }
 
 void StagedMoveGenerator::OrderQuietMoves(ExtendedMoveList& moves)

--- a/src/StagedMoveGenerator.h
+++ b/src/StagedMoveGenerator.h
@@ -39,11 +39,6 @@ public:
     // Returns false if no more legal moves
     bool Next(Move& move);
 
-    // Get the static exchange evaluation of the given move
-    // Optimized to return the SEE without calculation if it
-    // was already calculated and used in move ordering
-    int16_t GetSEE(Move move) const;
-
     // Signal the generator that a fail high has occured, and history tables need to be updated
     void AdjustHistory(const Move& move, int positive_adjustment, int negative_adjustment) const;
 
@@ -77,10 +72,6 @@ private:
     // Data uses for keeping track of internal values
     Stage stage;
     ExtendedMoveList::iterator current;
-
-    // We use SEE for ordering the moves, but SEE is also used in QS.
-    // See the body of GetSEE for usage.
-    std::optional<int16_t> moveSEE;
 
     const Move TTmove = Move::Uninitialized;
     Move Killer1 = Move::Uninitialized;

--- a/src/StaticExchangeEvaluation.h
+++ b/src/StaticExchangeEvaluation.h
@@ -2,7 +2,9 @@
 
 class BoardState;
 class Move;
+class Score;
 
 constexpr int PieceValues[] = { 91, 532, 568, 715, 1279, 5000, 91, 532, 568, 715, 1279, 5000 };
 
 int see(const BoardState& board, Move move);
+bool see_ge(const BoardState& board, Move move, Score threshold);

--- a/src/test/StaticExchangeEvaluation.cpp
+++ b/src/test/StaticExchangeEvaluation.cpp
@@ -2,11 +2,21 @@
 
 #include "../GameState.h"
 
+#include <cassert>
+
+auto test_see
+    = []([[maybe_unused]] const GameState& position, [[maybe_unused]] Move move, [[maybe_unused]] Score expected_value)
+{
+    assert(see(position.Board(), move) == expected_value.value());
+    assert(see_ge(position.Board(), move, expected_value));
+    assert(!see_ge(position.Board(), move, expected_value + 1));
+};
+
 auto test1 = []()
 {
     GameState position;
     position.InitialiseFromFen("rnbqk1nr/pp1p1ppp/8/4p3/1b2P3/2P4P/PP1P1PP1/RNBQKBNR w KQkq - 0 4");
-    assert(see(position.Board(), Move(SQ_C3, SQ_B4, CAPTURE)) == PieceValues[BISHOP]);
+    test_see(position, Move(SQ_C3, SQ_B4, CAPTURE), PieceValues[BISHOP]);
     return true;
 }();
 
@@ -14,7 +24,7 @@ auto test2 = []()
 {
     GameState position;
     position.InitialiseFromFen("rnbqk1nr/pp1p1ppp/8/2p1p3/1b2P3/2P4P/PP1P1PP1/RNBQKBNR w KQkq - 0 4");
-    assert(see(position.Board(), Move(SQ_C3, SQ_B4, CAPTURE)) == PieceValues[BISHOP] - PieceValues[PAWN]);
+    test_see(position, Move(SQ_C3, SQ_B4, CAPTURE), PieceValues[BISHOP] - PieceValues[PAWN]);
     return true;
 }();
 
@@ -22,7 +32,7 @@ auto test3 = []()
 {
     GameState position;
     position.InitialiseFromFen("rnbqk1nr/pp1p1ppp/8/2p1p3/1b2P3/2Q4P/PP1P1PP1/RNBQKBNR w KQkq - 0 4");
-    assert(see(position.Board(), Move(SQ_C3, SQ_B4, CAPTURE)) == PieceValues[BISHOP] - PieceValues[QUEEN]);
+    test_see(position, Move(SQ_C3, SQ_B4, CAPTURE), PieceValues[BISHOP] - PieceValues[QUEEN]);
     return true;
 }();
 
@@ -30,7 +40,7 @@ auto test4 = []()
 {
     GameState position;
     position.InitialiseFromFen("1k1r3q/1ppn3p/p4b2/4p3/8/P2N2P1/1PP1R1BP/2K1Q3 w - -");
-    assert(see(position.Board(), Move(SQ_D3, SQ_E5, CAPTURE)) == PieceValues[PAWN] - PieceValues[KNIGHT]);
+    test_see(position, Move(SQ_D3, SQ_E5, CAPTURE), PieceValues[PAWN] - PieceValues[KNIGHT]);
     return true;
 }();
 
@@ -38,8 +48,8 @@ auto test5 = []()
 {
     GameState position;
     position.InitialiseFromFen("1k1r4/1pp4p/p2b1b2/4q3/8/P3R1P1/1PP1R1BP/2K1Q3 w - - 0 1");
-    assert(see(position.Board(), Move(SQ_E3, SQ_E5, CAPTURE))
-        == PieceValues[QUEEN] - PieceValues[ROOK] + PieceValues[BISHOP] - PieceValues[ROOK] + PieceValues[BISHOP]);
+    test_see(position, Move(SQ_E3, SQ_E5, CAPTURE),
+        PieceValues[QUEEN] - PieceValues[ROOK] + PieceValues[BISHOP] - PieceValues[ROOK] + PieceValues[BISHOP]);
     return true;
 }();
 
@@ -49,8 +59,8 @@ auto test6 = []()
 {
     GameState position;
     position.InitialiseFromFen("1k6/8/4R3/6B1/2n1Pp2/8/8/1K6 b - e3 0 1");
-    assert(see(position.Board(), Move(SQ_F4, SQ_E3, EN_PASSANT))
-        == PieceValues[PAWN] - PieceValues[PAWN] + PieceValues[BISHOP] - PieceValues[KNIGHT]);
+    test_see(position, Move(SQ_F4, SQ_E3, EN_PASSANT),
+        PieceValues[PAWN] - PieceValues[PAWN] + PieceValues[BISHOP] - PieceValues[KNIGHT]);
     return true;
 }();
 
@@ -60,7 +70,7 @@ auto test7 = []()
 {
     GameState position;
     position.InitialiseFromFen("1k6/4r3/8/8/8/4P3/3K4/8 b - - 0 1");
-    assert(see(position.Board(), Move(SQ_E7, SQ_E3, CAPTURE)) == PieceValues[PAWN] - PieceValues[ROOK]);
+    test_see(position, Move(SQ_E7, SQ_E3, CAPTURE), PieceValues[PAWN] - PieceValues[ROOK]);
     return true;
 }();
 
@@ -68,7 +78,7 @@ auto test8 = []()
 {
     GameState position;
     position.InitialiseFromFen("1k2r3/4r3/8/8/8/4P3/3K4/8 b - - 0 1");
-    assert(see(position.Board(), Move(SQ_E7, SQ_E3, CAPTURE)) == PieceValues[PAWN]);
+    test_see(position, Move(SQ_E7, SQ_E3, CAPTURE), PieceValues[PAWN]);
     return true;
 }();
 
@@ -76,7 +86,7 @@ auto test9 = []()
 {
     GameState position;
     position.InitialiseFromFen("4r3/8/8/8/3k4/4P3/3K4/8 b - - 0 1");
-    assert(see(position.Board(), Move(SQ_E8, SQ_E3, CAPTURE)) == PieceValues[PAWN]);
+    test_see(position, Move(SQ_E8, SQ_E3, CAPTURE), PieceValues[PAWN]);
     return true;
 }();
 
@@ -86,8 +96,8 @@ auto test10 = []()
 {
     GameState position;
     position.InitialiseFromFen("1k6/8/8/3n2B1/4Pp2/8/3K4/8 b - e3 0 1");
-    assert(see(position.Board(), Move(SQ_F4, SQ_E3, EN_PASSANT))
-        == PieceValues[PAWN] - PieceValues[PAWN] + PieceValues[BISHOP] - PieceValues[KNIGHT]);
+    test_see(position, Move(SQ_F4, SQ_E3, EN_PASSANT),
+        PieceValues[PAWN] - PieceValues[PAWN] + PieceValues[BISHOP] - PieceValues[KNIGHT]);
     return true;
 }();
 
@@ -95,6 +105,6 @@ auto test11 = []()
 {
     GameState position;
     position.InitialiseFromFen("1k2r3/8/8/3n2B1/4Pp2/8/3K4/8 b - e3 0 1");
-    assert(see(position.Board(), Move(SQ_F4, SQ_E3, EN_PASSANT)) == PieceValues[PAWN]);
+    test_see(position, Move(SQ_F4, SQ_E3, EN_PASSANT), PieceValues[PAWN]);
     return true;
 }();


### PR DESCRIPTION
```
Elo   | 4.84 +- 2.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 15866 W: 3977 L: 3756 D: 8133
Penta | [101, 1760, 4010, 1941, 121]
http://chess.grantnet.us/test/38094/
```