### PR TITLE
Limit the 50 move rule eval adjustment

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.6.0";
+constexpr std::string_view version = "12.6.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | -0.50 +- 1.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 45046 W: 11060 L: 11125 D: 22861
Penta | [348, 5290, 11328, 5193, 364]
http://chess.grantnet.us/test/38115/
```