### PR TITLE
Simplify q-search delta prune

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -937,26 +937,7 @@ SearchResult Quiescence(GameState& position, SearchStackState* ss, SearchLocalSt
 
     while (gen.Next(move))
     {
-        // delta pruning (This looks pretty strange, but it was to maintain the legacy behaviour. It will be simplified
-        // away)
-        if (move.IsPromotion())
-        {
-            if (move.GetFlag() == QUEEN_PROMOTION || move.GetFlag() == QUEEN_PROMOTION_CAPTURE)
-            {
-                if (eval + PieceValues[QUEEN] + 280 < alpha)
-                {
-                    break;
-                }
-            }
-            else
-            {
-                if (eval + 280 < alpha)
-                {
-                    continue;
-                }
-            }
-        }
-        else if (!see_ge(position.Board(), move, alpha - eval - 280))
+        if (!move.IsPromotion() && !see_ge(position.Board(), move, alpha - eval - 280))
         {
             continue;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.7.0";
+constexpr std::string_view version = "12.7.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | -0.48 +- 1.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 47302 W: 10996 L: 11062 D: 25244
Penta | [133, 5243, 12969, 5169, 137]
http://chess.grantnet.us/test/38123/
```
```
Elo   | 0.32 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 23136 W: 5753 L: 5732 D: 11651
Penta | [186, 2634, 5896, 2677, 175]
http://chess.grantnet.us/test/38122/
```