### PR TITLE
Speedup movegen functions

### DIFF
--- a/src/MoveList.h
+++ b/src/MoveList.h
@@ -34,5 +34,5 @@ struct ExtendedMove
     int16_t score;
 };
 
-using ExtendedMoveList = StaticVector<ExtendedMove, 256>;
-using BasicMoveList = StaticVector<Move, 256>;
+using ExtendedMoveList = StaticVector<ExtendedMove, 218>;
+using BasicMoveList = StaticVector<Move, 218>;

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -37,7 +37,7 @@ struct SearchStackState
     SearchStackState(int distance_from_root_);
     void reset();
 
-    BasicMoveList pv = {};
+    StaticVector<Move, MAX_DEPTH> pv = {};
     std::array<Move, 2> killers = {};
 
     Move move = Move::Uninitialized;
@@ -120,7 +120,7 @@ struct SearchResults
     int multi_pv = 0;
     Move best_move = Move::Uninitialized;
     Score score = SCORE_UNDEFINED;
-    BasicMoveList pv = {};
+    StaticVector<Move, MAX_DEPTH> pv = {};
     SearchResultType type = SearchResultType::EMPTY;
 };
 
@@ -170,7 +170,7 @@ private:
     int threads_setting {};
 
     // [thread_id][multi_pv][depth]
-    std::vector<std::vector<std::array<SearchResults, MAX_DEPTH + 1>>> search_results_;
+    std::vector<std::vector<std::array<SearchResults, MAX_DEPTH>>> search_results_;
 
     SearchResults* best_search_result_ = nullptr;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.8.0";
+constexpr std::string_view version = "12.8.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
Seeing a +3% speedup for non-pgo builds. PGO builds are even.

```
Elo   | 0.06 +- 2.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -0.87 (-2.94, 2.94) [0.00, 3.00]
Games | N: 25036 W: 6081 L: 6077 D: 12878
Penta | [166, 2928, 6342, 2900, 182]
http://chess.grantnet.us/test/38160/
```