### PR TITLE
Optimize PGO flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -86,12 +86,12 @@ endif
 # Detect if CXX is g++ or clang++, in this order.
 ifeq ($(findstring clang++, $(CXX)),)
 	PGOGEN = -fprofile-generate
-	PGOUSE = -fprofile-use
+	PGOUSE = -fprofile-use -fprofile-partial-training
 	CXXFLAGS += -Wno-interference-size
   	$(info detected compiler is [g++])
 else
 	PGOGEN = -fprofile-instr-generate=$(BUILD_DIR)/default.profraw
-	PGOMERGE = $(LLVM_PROFDATA) merge -output=$(BUILD_DIR)/merged.profdata $(BUILD_DIR)/default.profraw
+	PGOMERGE = $(LLVM_PROFDATA) merge -output=$(BUILD_DIR)/merged.profdata $(BUILD_DIR)/default.profraw --sparse=true
 	PGOUSE = -fprofile-instr-use=$(BUILD_DIR)/merged.profdata
   	$(info detected compiler is [clang++])
 endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.8.1";
+constexpr std::string_view version = "12.8.2";
 
 void PrintVersion()
 {


### PR DESCRIPTION
`-fprofile-partial-training` and `--sparse=true` omit PGO information for functions that aren't called during the profiling pass. Without these flags, the unused functions are optimized for space rather than speed. This is not ideal, because there are parts of the hot-path that are not ran during the PGO build (Syzygy TB e.g)