### PR TITLE
Add capture history heuristic

### DIFF
--- a/src/History.cpp
+++ b/src/History.cpp
@@ -1,5 +1,6 @@
 #include "History.h"
 #include "BitBoardDefine.h"
+#include "Move.h"
 #include "SearchData.h"
 
 int16_t* ButterflyHistory::get(const GameState& position, const SearchStackState*, Move move)
@@ -24,24 +25,11 @@ int16_t* CountermoveHistory::get(const GameState& position, const SearchStackSta
     return &table[stm][counter_piece][counter.GetTo()][curr_piece][move.GetTo()];
 }
 
-void History::reset()
+int16_t* CaptureHistory::get(const GameState& position, const SearchStackState*, Move move)
 {
-    std::apply([](auto&... table) { (table.reset(), ...); }, tables_);
-}
+    const auto& stm = position.Board().stm;
+    const auto curr_piece = GetPieceType(position.Board().GetSquare(move.GetFrom()));
+    const auto cap_piece = move.GetFlag() == EN_PASSANT ? PAWN : GetPieceType(position.Board().GetSquare(move.GetTo()));
 
-int History::get(const GameState& position, const SearchStackState* ss, Move move)
-{
-    auto get_value = [&](auto& table)
-    {
-        auto* value = table.get(position, ss, move);
-        return value ? *value : 0;
-    };
-
-    return std::apply([&](auto&... table) { return (get_value(table) + ...); }, tables_)
-        / (int)std::tuple_size_v<decltype(tables_)>;
-}
-
-void History::add(const GameState& position, const SearchStackState* ss, Move move, int change)
-{
-    std::apply([&](auto&... table) { (table.add(position, ss, move, change), ...); }, tables_);
+    return &table[stm][curr_piece][move.GetTo()][cap_piece];
 }

--- a/src/History.h
+++ b/src/History.h
@@ -53,7 +53,7 @@ struct CountermoveHistory : HistoryTable<CountermoveHistory>
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
     static constexpr int max_value = 16384;
-    static constexpr int scale = 64;
+    static constexpr int scale = 32;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };

--- a/src/History.h
+++ b/src/History.h
@@ -50,13 +50,43 @@ struct CountermoveHistory : HistoryTable<CountermoveHistory>
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
+struct CaptureHistory : HistoryTable<CaptureHistory>
+{
+    static constexpr int max_value = 16384;
+    static constexpr int scale = 64;
+    int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
+    int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
+};
+
+template <typename... tables>
 class History
 {
 public:
-    void reset();
-    int get(const GameState& position, const SearchStackState* ss, Move move);
-    void add(const GameState& position, const SearchStackState* ss, Move move, int change);
+    void reset()
+    {
+        std::apply([](auto&... table) { (table.reset(), ...); }, tables_);
+    }
+
+    int get(const GameState& position, const SearchStackState* ss, Move move)
+    {
+        auto get_value = [&](auto& table)
+        {
+            auto* value = table.get(position, ss, move);
+            return value ? *value : 0;
+        };
+
+        return std::apply([&](auto&... table) { return (get_value(table) + ...); }, tables_)
+            / (int)std::tuple_size_v<decltype(tables_)>;
+    }
+
+    void add(const GameState& position, const SearchStackState* ss, Move move, int change)
+    {
+        std::apply([&](auto&... table) { (table.add(position, ss, move, change), ...); }, tables_);
+    }
 
 private:
-    std::tuple<ButterflyHistory, CountermoveHistory> tables_;
+    std::tuple<tables...> tables_;
 };
+
+using QuietHistory = History<ButterflyHistory, CountermoveHistory>;
+using LoudHistory = History<CaptureHistory>;

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -551,8 +551,13 @@ void AddKiller(Move move, std::array<Move, 2>& killers)
 void AddHistory(const StagedMoveGenerator& gen, const Move& move, int depthRemaining)
 {
     if (move.IsCapture() || move.IsPromotion())
-        return;
-    gen.AdjustHistory(move, depthRemaining * depthRemaining, -depthRemaining * depthRemaining);
+    {
+        gen.AdjustLoudHistory(move, depthRemaining * depthRemaining, -depthRemaining * depthRemaining);
+    }
+    else
+    {
+        gen.AdjustQuietHistory(move, depthRemaining * depthRemaining, -depthRemaining * depthRemaining);
+    }
 }
 
 template <bool pv_node>
@@ -841,7 +846,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
             }
         }
 
-        int history = local.history.get(position, ss, move);
+        int history = local.quiet_history.get(position, ss, move);
         ss->move = move;
         position.ApplyMove(move);
         tTable.PreFetch(position.Board().GetZobristKey()); // load the transposition into l1 cache. ~5% speedup

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -846,7 +846,8 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
             }
         }
 
-        int history = local.quiet_history.get(position, ss, move);
+        int history = move.IsCapture() || move.IsPromotion() ? local.loud_history.get(position, ss, move)
+                                                             : local.quiet_history.get(position, ss, move);
         ss->move = move;
         position.ApplyMove(move);
         tTable.PreFetch(position.Board().GetZobristKey()); // load the transposition into l1 cache. ~5% speedup

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -89,7 +89,8 @@ void SearchLocalState::ResetNewSearch()
 void SearchLocalState::ResetNewGame()
 {
     ResetNewSearch();
-    history.reset();
+    quiet_history.reset();
+    loud_history.reset();
 }
 
 SearchSharedState::SearchSharedState(Uci& uci)

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -84,7 +84,8 @@ public:
 
     const int thread_id;
     SearchStack search_stack;
-    History history;
+    QuietHistory quiet_history;
+    LoudHistory loud_history;
     int sel_septh = 0;
     atomic_relaxed<int64_t> tb_hits = 0;
     atomic_relaxed<int64_t> nodes = 0;

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -237,15 +237,13 @@ void StagedMoveGenerator::OrderLoudMoves(ExtendedMoveList& moves)
         // Handle en passant separate to MVV_LVA
         else if (moves[i].move.GetFlag() == EN_PASSANT)
         {
-            moves[i].score = SCORE_CAPTURE + MVV_LVA[PAWN][PAWN];
+            moves[i].score = 0;
         }
 
         // Captures
         else
         {
-            moves[i].score = SCORE_CAPTURE
-                + MVV_LVA[GetPieceType(position.Board().GetSquare(moves[i].move.GetTo()))]
-                         [GetPieceType(position.Board().GetSquare(moves[i].move.GetFrom()))];
+            moves[i].score = 0;
         }
     }
 

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -220,15 +220,6 @@ void StagedMoveGenerator::OrderLoudMoves(ExtendedMoveList& moves)
     static constexpr int16_t SCORE_QUEEN_PROMOTION = 30000;
     static constexpr int16_t SCORE_UNDER_PROMOTION = -30000;
 
-    static constexpr std::array MVV_LVA = {
-        std::array { 15, 14, 13, 12, 11, 10 },
-        std::array { 25, 24, 23, 22, 21, 20 },
-        std::array { 35, 34, 33, 32, 31, 30 },
-        std::array { 45, 44, 43, 42, 41, 40 },
-        std::array { 55, 54, 53, 52, 51, 50 },
-        std::array { 0, 0, 0, 0, 0, 0 },
-    };
-
     for (size_t i = 0; i < moves.size(); i++)
     {
         // Hash move
@@ -236,11 +227,10 @@ void StagedMoveGenerator::OrderLoudMoves(ExtendedMoveList& moves)
         {
             moves.erase(moves.begin() + i);
             i--;
-            continue;
         }
 
         // Promotions
-        if (moves[i].move.IsPromotion())
+        else if (moves[i].move.IsPromotion())
         {
             if (moves[i].move.GetFlag() == QUEEN_PROMOTION || moves[i].move.GetFlag() == QUEEN_PROMOTION_CAPTURE)
             {
@@ -250,14 +240,6 @@ void StagedMoveGenerator::OrderLoudMoves(ExtendedMoveList& moves)
             {
                 moves[i].score = SCORE_UNDER_PROMOTION;
             }
-
-            continue;
-        }
-
-        // Handle en passant separate to MVV_LVA
-        if (moves[i].move.GetFlag() == EN_PASSANT)
-        {
-            moves[i].score = local.loud_history.get(position, ss, moves[i].move);
         }
 
         // Captures

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -146,6 +146,11 @@ void StagedMoveGenerator::AdjustQuietHistory(const Move& move, int positive_adju
 
         local.quiet_history.add(position, ss, m.move, negative_adjustment);
     }
+
+    for (auto const& m : loudMoves)
+    {
+        local.loud_history.add(position, ss, m.move, negative_adjustment);
+    }
 }
 
 void StagedMoveGenerator::AdjustLoudHistory(const Move& move, int positive_adjustment, int negative_adjustment) const

--- a/src/StagedMoveGenerator.h
+++ b/src/StagedMoveGenerator.h
@@ -40,7 +40,8 @@ public:
     bool Next(Move& move);
 
     // Signal the generator that a fail high has occured, and history tables need to be updated
-    void AdjustHistory(const Move& move, int positive_adjustment, int negative_adjustment) const;
+    void AdjustQuietHistory(const Move& move, int positive_adjustment, int negative_adjustment) const;
+    void AdjustLoudHistory(const Move& move, int positive_adjustment, int negative_adjustment) const;
 
     // Signal the MoveGenerator that the LMP condition is satisfied and it should skip quiet moves
     void SkipQuiets();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.7.1";
+constexpr std::string_view version = "12.8.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 3.33 +- 2.26 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 23672 W: 5635 L: 5408 D: 12629
Penta | [82, 2670, 6083, 2941, 60]
http://chess.grantnet.us/test/38157/
```
```
Elo   | 3.41 +- 2.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 25232 W: 6327 L: 6079 D: 12826
Penta | [173, 2979, 6099, 3157, 208]
http://chess.grantnet.us/test/38155/
```