### PR TITLE
Tune history values

### DIFF
--- a/src/History.h
+++ b/src/History.h
@@ -36,24 +36,24 @@ struct HistoryTable
 
 struct ButterflyHistory : HistoryTable<ButterflyHistory>
 {
-    static constexpr int max_value = 17662;
-    static constexpr int scale = 67;
+    static constexpr int max_value = 15145;
+    static constexpr int scale = 71;
     int16_t table[N_PLAYERS][N_SQUARES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CountermoveHistory : HistoryTable<CountermoveHistory>
 {
-    static constexpr int max_value = 15230;
-    static constexpr int scale = 53;
+    static constexpr int max_value = 15683;
+    static constexpr int scale = 55;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
-    static constexpr int max_value = 19065;
-    static constexpr int scale = 31;
+    static constexpr int max_value = 18795;
+    static constexpr int scale = 40;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };

--- a/src/History.h
+++ b/src/History.h
@@ -36,24 +36,24 @@ struct HistoryTable
 
 struct ButterflyHistory : HistoryTable<ButterflyHistory>
 {
-    static constexpr int max_value = 24441;
-    static constexpr int scale = 70;
+    static constexpr int max_value = 17662;
+    static constexpr int scale = 67;
     int16_t table[N_PLAYERS][N_SQUARES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CountermoveHistory : HistoryTable<CountermoveHistory>
 {
-    static constexpr int max_value = 14681;
-    static constexpr int scale = 41;
+    static constexpr int max_value = 15230;
+    static constexpr int scale = 53;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
-    static constexpr int max_value = 15317;
-    static constexpr int scale = 26;
+    static constexpr int max_value = 19065;
+    static constexpr int scale = 31;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };

--- a/src/History.h
+++ b/src/History.h
@@ -53,7 +53,7 @@ struct CountermoveHistory : HistoryTable<CountermoveHistory>
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
     static constexpr int max_value = 16384;
-    static constexpr int scale = 32;
+    static constexpr int scale = 64;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
@@ -75,8 +75,7 @@ public:
             return value ? *value : 0;
         };
 
-        return std::apply([&](auto&... table) { return (get_value(table) + ...); }, tables_)
-            / (int)std::tuple_size_v<decltype(tables_)>;
+        return std::apply([&](auto&... table) { return (get_value(table) + ...); }, tables_);
     }
 
     void add(const GameState& position, const SearchStackState* ss, Move move, int change)

--- a/src/History.h
+++ b/src/History.h
@@ -36,24 +36,24 @@ struct HistoryTable
 
 struct ButterflyHistory : HistoryTable<ButterflyHistory>
 {
-    static constexpr int max_value = 16384;
-    static constexpr int scale = 32;
+    static constexpr int max_value = 24441;
+    static constexpr int scale = 70;
     int16_t table[N_PLAYERS][N_SQUARES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CountermoveHistory : HistoryTable<CountermoveHistory>
 {
-    static constexpr int max_value = 16384;
-    static constexpr int scale = 64;
+    static constexpr int max_value = 14681;
+    static constexpr int scale = 41;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
-    static constexpr int max_value = 16384;
-    static constexpr int scale = 64;
+    static constexpr int max_value = 15317;
+    static constexpr int scale = 26;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -527,7 +527,7 @@ int reduction(int depth, int seen_moves, int history)
     if constexpr (pv_node)
         r--;
 
-    r -= history / 3922;
+    r -= history / 7844;
 
     return std::max(0, r);
 }

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -207,8 +207,8 @@ void StagedMoveGenerator::OrderQuietMoves(ExtendedMoveList& moves)
         else
         {
             int history = local.quiet_history.get(position, ss, moves[i].move);
-            moves[i].score = std::clamp<int>(history, std::numeric_limits<decltype(moves[i].score)>::min(),
-                std::numeric_limits<decltype(moves[i].score)>::max());
+            moves[i].score
+                = std::clamp<int>(history, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max());
         }
     }
 
@@ -245,7 +245,9 @@ void StagedMoveGenerator::OrderLoudMoves(ExtendedMoveList& moves)
         // Captures
         else
         {
-            moves[i].score = local.loud_history.get(position, ss, moves[i].move);
+            int history = local.loud_history.get(position, ss, moves[i].move);
+            moves[i].score
+                = std::clamp<int>(history, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max());
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.8.2";
+constexpr std::string_view version = "12.9.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 1.90 +- 1.50 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 53372 W: 12617 L: 12325 D: 28430
Penta | [147, 6198, 13703, 6492, 146]
http://chess.grantnet.us/test/38182/
```
```
Elo   | 1.66 +- 1.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 79194 W: 19555 L: 19177 D: 40462
Penta | [624, 9421, 19136, 9785, 631]
http://chess.grantnet.us/test/38177/
```