### PR TITLE
Fix continuation history heuristic

### DIFF
--- a/src/History.cpp
+++ b/src/History.cpp
@@ -20,7 +20,7 @@ int16_t* CountermoveHistory::get(const GameState& position, const SearchStackSta
 
     const auto& stm = position.Board().stm;
     const auto curr_piece = GetPieceType(position.Board().GetSquare(move.GetFrom()));
-    const auto counter_piece = GetPieceType(position.Board().GetSquare(counter.GetTo()));
+    const auto counter_piece = GetPieceType((ss - 1)->moved_piece);
 
     return &table[stm][counter_piece][counter.GetTo()][curr_piece][move.GetTo()];
 }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -430,6 +430,7 @@ std::optional<Score> null_move_pruning(GameState& position, SearchStackState* ss
     const int reduction = 4 + depth / 6 + std::min(3, (static_score - beta).value() / 245);
 
     ss->move = Move::Uninitialized;
+    ss->moved_piece = N_PIECES;
     position.ApplyNullMove();
     local.net.StoreLazyUpdates(position.PrevBoard(), position.Board(), (ss + 1)->acc, Move::Uninitialized);
     auto null_move_score
@@ -849,6 +850,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
         int history = move.IsCapture() || move.IsPromotion() ? local.loud_history.get(position, ss, move)
                                                              : local.quiet_history.get(position, ss, move);
         ss->move = move;
+        ss->moved_piece = position.Board().GetSquare(move.GetFrom());
         position.ApplyMove(move);
         tTable.PreFetch(position.Board().GetZobristKey()); // load the transposition into l1 cache. ~5% speedup
         local.net.StoreLazyUpdates(position.PrevBoard(), position.Board(), (ss + 1)->acc, move);
@@ -955,6 +957,7 @@ SearchResult Quiescence(GameState& position, SearchStackState* ss, SearchLocalSt
         }
 
         ss->move = move;
+        ss->moved_piece = position.Board().GetSquare(move.GetFrom());
         position.ApplyMove(move);
         // TODO: prefetch
         local.net.StoreLazyUpdates(position.PrevBoard(), position.Board(), (ss + 1)->acc, move);

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -24,6 +24,7 @@ void SearchStackState::reset()
     pv = {};
     killers = {};
     move = Move::Uninitialized;
+    moved_piece = N_PIECES;
     singular_exclusion = Move::Uninitialized;
     multiple_extensions = 0;
     acc = {};

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -41,6 +41,7 @@ struct SearchStackState
     std::array<Move, 2> killers = {};
 
     Move move = Move::Uninitialized;
+    Pieces moved_piece = N_PIECES;
     Move singular_exclusion = Move::Uninitialized;
     int multiple_extensions = 0;
     int nmp_verification_depth = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.9.0";
+constexpr std::string_view version = "12.9.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | -0.02 +- 1.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 81378 W: 19696 L: 19701 D: 41981
Penta | [574, 9789, 19952, 9816, 558]
http://chess.grantnet.us/test/38190/
```