### PR TITLE
Speedup Bitboard representation

### DIFF
--- a/src/BoardState.h
+++ b/src/BoardState.h
@@ -67,7 +67,8 @@ public:
 
     uint64_t GetZobristKey() const;
 
-    void SetSquare(Square square, Pieces piece);
+    void AddPiece(Square square, Pieces piece);
+    void RemovePiece(Square square, Pieces piece);
     void ClearSquare(Square square);
 
     void Reset();
@@ -83,7 +84,8 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const BoardState& b);
 
 private:
-    void SetSquareAndUpdate(Square square, Pieces piece);
+    void AddPieceAndUpdate(Square square, Pieces piece);
+    void RemovePieceAndUpdate(Square square, Pieces piece);
     void ClearSquareAndUpdate(Square square);
     void RecalculateWhiteBlackBoards();
 

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -40,6 +40,16 @@ void GameState::ApplyMove(std::string_view strmove)
             flag = (flag == CAPTURE ? BISHOP_PROMOTION_CAPTURE : BISHOP_PROMOTION);
     }
 
+    // Correction for castle moves (encode as KxR)
+    if (flag == A_SIDE_CASTLE)
+    {
+        to = LSB(Board().castle_squares & RankBB[Board().stm == WHITE ? RANK_1 : RANK_8]);
+    }
+    else if (flag == H_SIDE_CASTLE)
+    {
+        to = MSB(Board().castle_squares & RankBB[Board().stm == WHITE ? RANK_1 : RANK_8]);
+    }
+
     ApplyMove(Move(from, to, flag));
 }
 

--- a/src/MoveGeneration.cpp
+++ b/src/MoveGeneration.cpp
@@ -800,6 +800,18 @@ bool MoveIsLegal(const BoardState& board, const Move& move)
     return true;
 }
 
+bool MovePutsSelfInCheck(const BoardState& board, const Move& move)
+{
+    if (board.stm == WHITE)
+    {
+        return MovePutsSelfInCheck<WHITE>(board, move);
+    }
+    else
+    {
+        return MovePutsSelfInCheck<BLACK>(board, move);
+    }
+}
+
 /*
 This function does not work for casteling moves. They are tested for legality their creation.
 */

--- a/src/MoveGeneration.h
+++ b/src/MoveGeneration.h
@@ -19,6 +19,9 @@ bool IsInCheck(const BoardState& board);
 
 bool MoveIsLegal(const BoardState& board, const Move& move);
 
+// This function does not work for casteling moves. They are tested for legality their creation.
+bool MovePutsSelfInCheck(const BoardState& board, const Move& move);
+
 // Returns the attack bitboard for a piece of piecetype on square sq
 template <PieceTypes pieceType>
 uint64_t AttackBB(Square sq, uint64_t occupied = EMPTY);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.9.3";
+constexpr std::string_view version = "12.9.4";
 
 void PrintVersion()
 {


### PR DESCRIPTION
Tested `perft 6` from startpos:

Old perft speed: `301565844 nps`
new perft speed: `320797869 nps`

```
Elo   | 0.61 +- 2.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 19322 W: 4631 L: 4597 D: 10094
Penta | [95, 2161, 5120, 2185, 100]
http://chess.grantnet.us/test/38207/
```