### PR TITLE
Add Follow move history heuristic

### DIFF
--- a/src/History.cpp
+++ b/src/History.cpp
@@ -25,6 +25,22 @@ int16_t* CountermoveHistory::get(const GameState& position, const SearchStackSta
     return &table[stm][counter_piece][counter.GetTo()][curr_piece][move.GetTo()];
 }
 
+int16_t* FollowmoveHistory::get(const GameState& position, const SearchStackState* ss, Move move)
+{
+    const auto& counter = (ss - 2)->move;
+
+    if (counter == Move::Uninitialized)
+    {
+        return nullptr;
+    }
+
+    const auto& stm = position.Board().stm;
+    const auto curr_piece = GetPieceType(position.Board().GetSquare(move.GetFrom()));
+    const auto counter_piece = GetPieceType((ss - 2)->moved_piece);
+
+    return &table[stm][counter_piece][counter.GetTo()][curr_piece][move.GetTo()];
+}
+
 int16_t* CaptureHistory::get(const GameState& position, const SearchStackState*, Move move)
 {
     const auto& stm = position.Board().stm;

--- a/src/History.h
+++ b/src/History.h
@@ -50,6 +50,14 @@ struct CountermoveHistory : HistoryTable<CountermoveHistory>
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
+struct FollowmoveHistory : HistoryTable<FollowmoveHistory>
+{
+    static constexpr int max_value = 15683;
+    static constexpr int scale = 55;
+    int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES][N_SQUARES] = {};
+    int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
+};
+
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
     static constexpr int max_value = 18795;
@@ -87,5 +95,5 @@ private:
     std::tuple<tables...> tables_;
 };
 
-using QuietHistory = History<ButterflyHistory, CountermoveHistory>;
+using QuietHistory = History<ButterflyHistory, CountermoveHistory, FollowmoveHistory>;
 using LoudHistory = History<CaptureHistory>;

--- a/src/History.h
+++ b/src/History.h
@@ -36,24 +36,24 @@ struct HistoryTable
 
 struct ButterflyHistory : HistoryTable<ButterflyHistory>
 {
-    static constexpr int max_value = 15145;
-    static constexpr int scale = 71;
+    static constexpr int max_value = 12116;
+    static constexpr int scale = 57;
     int16_t table[N_PLAYERS][N_SQUARES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CountermoveHistory : HistoryTable<CountermoveHistory>
 {
-    static constexpr int max_value = 15683;
-    static constexpr int scale = 55;
+    static constexpr int max_value = 12546;
+    static constexpr int scale = 44;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct FollowmoveHistory : HistoryTable<FollowmoveHistory>
 {
-    static constexpr int max_value = 15683;
-    static constexpr int scale = 55;
+    static constexpr int max_value = 12546;
+    static constexpr int scale = 44;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -53,8 +53,8 @@ struct SearchStackState
 
 class SearchStack
 {
-    // The search accesses [ss-1, ss+1]
-    constexpr static int min_access = -1;
+    // The search accesses [ss-2, ss+1]
+    constexpr static int min_access = -2;
     constexpr static int max_access = 1;
     constexpr static size_t size = MAX_DEPTH + max_access - min_access;
 


### PR DESCRIPTION
```
Elo   | 1.56 +- 1.26 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 75972 W: 17859 L: 17518 D: 40595
Penta | [200, 8846, 19577, 9139, 224]
http://chess.grantnet.us/test/38211/
```
```
Elo   | 1.60 +- 1.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 84696 W: 20763 L: 20372 D: 43561
Penta | [640, 10057, 20643, 10288, 720]
http://chess.grantnet.us/test/38208/
```