### PR TITLE
Add pawn hash indexed history tables for ordering quiet moves

### DIFF
--- a/src/BoardState.cpp
+++ b/src/BoardState.cpp
@@ -26,6 +26,7 @@ void BoardState::Reset()
 
     RecalculateWhiteBlackBoards();
     key.Recalculate(*this);
+    pawn_key.recalculate(*this);
 }
 
 bool BoardState::InitialiseFromFen(const std::array<std::string_view, 6>& fen)
@@ -138,6 +139,7 @@ bool BoardState::InitialiseFromFen(const std::array<std::string_view, 6>& fen)
 
     RecalculateWhiteBlackBoards();
     key.Recalculate(*this);
+    pawn_key.recalculate(*this);
     return true;
 }
 
@@ -160,6 +162,11 @@ uint64_t BoardState::GetPiecesColour(Players colour) const
 uint64_t BoardState::GetZobristKey() const
 {
     return key.Key();
+}
+
+uint64_t BoardState::GetPawnKey() const
+{
+    return pawn_key;
 }
 
 void BoardState::AddPiece(Square square, Pieces piece)
@@ -481,12 +488,20 @@ void BoardState::ApplyNullMove()
 void BoardState::AddPieceAndUpdate(Square square, Pieces piece)
 {
     key.TogglePieceSquare(piece, square);
+    if (piece == WHITE_PAWN || piece == BLACK_PAWN)
+    {
+        pawn_key.toggle_piece_square(piece, square);
+    }
     AddPiece(square, piece);
 }
 
 void BoardState::RemovePieceAndUpdate(Square square, Pieces piece)
 {
     key.TogglePieceSquare(piece, square);
+    if (piece == WHITE_PAWN || piece == BLACK_PAWN)
+    {
+        pawn_key.toggle_piece_square(piece, square);
+    }
     RemovePiece(square, piece);
 }
 
@@ -494,6 +509,10 @@ void BoardState::ClearSquareAndUpdate(Square square)
 {
     Pieces piece = GetSquare(square);
     key.TogglePieceSquare(piece, square);
+    if (piece == WHITE_PAWN || piece == BLACK_PAWN)
+    {
+        pawn_key.toggle_piece_square(piece, square);
+    }
     ClearSquare(square);
 }
 

--- a/src/BoardState.h
+++ b/src/BoardState.h
@@ -66,6 +66,7 @@ public:
     }
 
     uint64_t GetZobristKey() const;
+    uint64_t GetPawnKey() const;
 
     void AddPiece(Square square, Pieces piece);
     void RemovePiece(Square square, Pieces piece);
@@ -90,6 +91,7 @@ private:
     void RecalculateWhiteBlackBoards();
 
     Zobrist key;
+    PawnKey pawn_key;
 
     std::array<uint64_t, N_PIECES> board = {};
     std::array<uint64_t, 2> side_bb;

--- a/src/History.cpp
+++ b/src/History.cpp
@@ -41,6 +41,15 @@ int16_t* FollowmoveHistory::get(const GameState& position, const SearchStackStat
     return &table[stm][counter_piece][counter.GetTo()][curr_piece][move.GetTo()];
 }
 
+int16_t* PawnHistory::get(const GameState& position, const SearchStackState*, Move move)
+{
+    const auto& stm = position.Board().stm;
+    const auto pawn_hash = position.Board().GetPawnKey() % pawn_states;
+    const auto piece = GetPieceType(position.Board().GetSquare(move.GetFrom()));
+
+    return &table[stm][pawn_hash][piece][move.GetTo()];
+}
+
 int16_t* CaptureHistory::get(const GameState& position, const SearchStackState*, Move move)
 {
     const auto& stm = position.Board().stm;

--- a/src/History.h
+++ b/src/History.h
@@ -36,32 +36,32 @@ struct HistoryTable
 
 struct ButterflyHistory : HistoryTable<ButterflyHistory>
 {
-    static constexpr int max_value = 12116;
-    static constexpr int scale = 57;
+    static constexpr int max_value = 9692;
+    static constexpr int scale = 45;
     int16_t table[N_PLAYERS][N_SQUARES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CountermoveHistory : HistoryTable<CountermoveHistory>
 {
-    static constexpr int max_value = 12546;
-    static constexpr int scale = 44;
+    static constexpr int max_value = 10036;
+    static constexpr int scale = 35;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct FollowmoveHistory : HistoryTable<FollowmoveHistory>
 {
-    static constexpr int max_value = 12546;
-    static constexpr int scale = 44;
+    static constexpr int max_value = 10036;
+    static constexpr int scale = 35;
     int16_t table[N_PLAYERS][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct PawnHistory : HistoryTable<PawnHistory>
 {
-    static constexpr int max_value = 12546;
-    static constexpr int scale = 44;
+    static constexpr int max_value = 10036;
+    static constexpr int scale = 35;
     static constexpr size_t pawn_states = 512;
     int16_t table[N_PLAYERS][pawn_states][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);

--- a/src/History.h
+++ b/src/History.h
@@ -58,6 +58,15 @@ struct FollowmoveHistory : HistoryTable<FollowmoveHistory>
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
+struct PawnHistory : HistoryTable<PawnHistory>
+{
+    static constexpr int max_value = 12546;
+    static constexpr int scale = 44;
+    static constexpr size_t pawn_states = 512;
+    int16_t table[N_PLAYERS][pawn_states][N_PIECE_TYPES][N_SQUARES] = {};
+    int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
+};
+
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
     static constexpr int max_value = 18795;
@@ -95,5 +104,5 @@ private:
     std::tuple<tables...> tables_;
 };
 
-using QuietHistory = History<ButterflyHistory, CountermoveHistory, FollowmoveHistory>;
+using QuietHistory = History<ButterflyHistory, CountermoveHistory, FollowmoveHistory, PawnHistory>;
 using LoudHistory = History<CaptureHistory>;

--- a/src/Zobrist.cpp
+++ b/src/Zobrist.cpp
@@ -21,6 +21,21 @@ const std::array<uint64_t, 12 * 64 + 1 + 16 + 8> Zobrist::ZobristTable = []
     return table;
 }();
 
+const std::array<uint64_t, 2 * 64> PawnKey::table = []
+{
+    std::array<uint64_t, 2 * 64> table;
+
+    std::mt19937_64 gen(0);
+    std::uniform_int_distribution<uint64_t> dist(0, UINT64_MAX);
+
+    for (size_t i = 0; i < table.size(); i++)
+    {
+        table[i] = dist(gen);
+    }
+
+    return table;
+}();
+
 void Zobrist::ToggleCastle(Square sq)
 {
     assert(GetRank(sq) == RANK_1 || GetRank(sq) == RANK_8);
@@ -59,4 +74,23 @@ uint64_t Zobrist::Generate(const BoardState& board)
     }
 
     return Key.Key();
+}
+
+uint64_t PawnKey::generate(const BoardState& board)
+{
+    PawnKey Key;
+
+    uint64_t white = board.GetPieceBB<WHITE_PAWN>();
+    while (white != 0)
+    {
+        Key.toggle_piece_square(WHITE_PAWN, LSBpop(white));
+    }
+
+    uint64_t black = board.GetPieceBB<BLACK_PAWN>();
+    while (black != 0)
+    {
+        Key.toggle_piece_square(BLACK_PAWN, LSBpop(black));
+    }
+
+    return Key;
 }

--- a/src/Zobrist.h
+++ b/src/Zobrist.h
@@ -49,3 +49,34 @@ private:
 
     uint64_t key = EMPTY;
 };
+
+class PawnKey
+{
+public:
+    void recalculate(const BoardState& board)
+    {
+        key = generate(board);
+    }
+
+    operator uint64_t() const
+    {
+        return key;
+    }
+
+    void toggle_piece_square(Pieces piece, Square square)
+    {
+        key ^= table[((piece == WHITE_PAWN) ? 0 : 64) + square];
+    }
+
+    bool verify(const BoardState& board) const
+    {
+        return generate(board) == key;
+    }
+
+private:
+    static uint64_t generate(const BoardState& board);
+
+    // 2 pieces * 64 squares
+    const static std::array<uint64_t, 2 * 64> table;
+    uint64_t key = EMPTY;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.9.4";
+constexpr std::string_view version = "12.10.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 1.70 +- 1.36 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 64644 W: 15243 L: 14927 D: 34474
Penta | [162, 7572, 16539, 7886, 163]
http://chess.grantnet.us/test/38215/
```
```
Elo   | 1.51 +- 1.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 93398 W: 22809 L: 22403 D: 48186
Penta | [601, 11170, 22811, 11456, 661]
http://chess.grantnet.us/test/38213/
```
