### PR TITLE
Add quiet move threat history

### DIFF
--- a/src/History.cpp
+++ b/src/History.cpp
@@ -51,10 +51,10 @@ int16_t* PawnHistory::get(const GameState& position, const SearchStackState*, Mo
     return &table[stm][pawn_hash][piece][move.GetTo()];
 }
 
-int16_t* ThreatHistory::get(const GameState& position, const SearchStackState*, Move move)
+int16_t* ThreatHistory::get(const GameState& position, const SearchStackState* ss, Move move)
 {
     const auto& stm = position.Board().stm;
-    uint64_t threat_mask = ThreatMask(position.Board(), !stm);
+    const uint64_t& threat_mask = ss->threat_mask;
     const bool from_square_threat = threat_mask & SquareBB[move.GetFrom()];
 
     return &table[stm][from_square_threat][move.GetFrom()][move.GetTo()];

--- a/src/History.cpp
+++ b/src/History.cpp
@@ -4,12 +4,6 @@
 #include "MoveGeneration.h"
 #include "SearchData.h"
 
-int16_t* ButterflyHistory::get(const GameState& position, const SearchStackState*, Move move)
-{
-    const auto& stm = position.Board().stm;
-    return &table[stm][move.GetFrom()][move.GetTo()];
-}
-
 int16_t* CountermoveHistory::get(const GameState& position, const SearchStackState* ss, Move move)
 {
     const auto& counter = (ss - 1)->move;

--- a/src/History.cpp
+++ b/src/History.cpp
@@ -1,6 +1,7 @@
 #include "History.h"
 #include "BitBoardDefine.h"
 #include "Move.h"
+#include "MoveGeneration.h"
 #include "SearchData.h"
 
 int16_t* ButterflyHistory::get(const GameState& position, const SearchStackState*, Move move)
@@ -48,6 +49,15 @@ int16_t* PawnHistory::get(const GameState& position, const SearchStackState*, Mo
     const auto piece = GetPieceType(position.Board().GetSquare(move.GetFrom()));
 
     return &table[stm][pawn_hash][piece][move.GetTo()];
+}
+
+int16_t* ThreatHistory::get(const GameState& position, const SearchStackState*, Move move)
+{
+    const auto& stm = position.Board().stm;
+    uint64_t threat_mask = ThreatMask(position.Board(), !stm);
+    const bool from_square_threat = threat_mask & SquareBB[move.GetFrom()];
+
+    return &table[stm][from_square_threat][move.GetFrom()][move.GetTo()];
 }
 
 int16_t* CaptureHistory::get(const GameState& position, const SearchStackState*, Move move)

--- a/src/History.h
+++ b/src/History.h
@@ -34,14 +34,6 @@ struct HistoryTable
     }
 };
 
-struct ButterflyHistory : HistoryTable<ButterflyHistory>
-{
-    static constexpr int max_value = 9692;
-    static constexpr int scale = 45;
-    int16_t table[N_PLAYERS][N_SQUARES][N_SQUARES] = {};
-    int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
-};
-
 struct CountermoveHistory : HistoryTable<CountermoveHistory>
 {
     static constexpr int max_value = 10036;
@@ -112,5 +104,5 @@ private:
     std::tuple<tables...> tables_;
 };
 
-using QuietHistory = History<ButterflyHistory, CountermoveHistory, FollowmoveHistory, PawnHistory, ThreatHistory>;
+using QuietHistory = History<CountermoveHistory, FollowmoveHistory, PawnHistory, ThreatHistory>;
 using LoudHistory = History<CaptureHistory>;

--- a/src/History.h
+++ b/src/History.h
@@ -67,6 +67,14 @@ struct PawnHistory : HistoryTable<PawnHistory>
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
+struct ThreatHistory : HistoryTable<ThreatHistory>
+{
+    static constexpr int max_value = 9692;
+    static constexpr int scale = 45;
+    int16_t table[N_PLAYERS][2][N_SQUARES][N_SQUARES] = {};
+    int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
+};
+
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
     static constexpr int max_value = 18795;
@@ -104,5 +112,5 @@ private:
     std::tuple<tables...> tables_;
 };
 
-using QuietHistory = History<ButterflyHistory, CountermoveHistory, FollowmoveHistory, PawnHistory>;
+using QuietHistory = History<ButterflyHistory, CountermoveHistory, FollowmoveHistory, PawnHistory, ThreatHistory>;
 using LoudHistory = History<CaptureHistory>;

--- a/src/MoveGeneration.h
+++ b/src/MoveGeneration.h
@@ -22,6 +22,9 @@ bool MoveIsLegal(const BoardState& board, const Move& move);
 // This function does not work for casteling moves. They are tested for legality their creation.
 bool MovePutsSelfInCheck(const BoardState& board, const Move& move);
 
+// Returns a threat mask that only contains winning captures (RxQ, B/NxR/Q, Px!P)
+uint64_t ThreatMask(const BoardState& board, Players colour);
+
 // Returns the attack bitboard for a piece of piecetype on square sq
 template <PieceTypes pieceType>
 uint64_t AttackBB(Square sq, uint64_t occupied = EMPTY);

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -779,6 +779,7 @@ SearchResult NegaScout(GameState& position, SearchStackState* ss, SearchLocalSta
     auto original_alpha = alpha;
     int seen_moves = 0;
     bool noLegalMoves = true;
+    ss->threat_mask = ThreatMask(position.Board(), !position.Board().stm);
 
     // Step 9: Rebel style IID
     //

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -25,6 +25,7 @@ void SearchStackState::reset()
     killers = {};
     move = Move::Uninitialized;
     moved_piece = N_PIECES;
+    threat_mask = EMPTY;
     singular_exclusion = Move::Uninitialized;
     multiple_extensions = 0;
     acc = {};

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -42,10 +42,14 @@ struct SearchStackState
 
     Move move = Move::Uninitialized;
     Pieces moved_piece = N_PIECES;
+    uint64_t threat_mask = EMPTY;
+
     Move singular_exclusion = Move::Uninitialized;
     int multiple_extensions = 0;
+
     int nmp_verification_depth = 0;
     bool nmp_verification_root = false;
+
     const int distance_from_root;
 
     Accumulator acc;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.10.0";
+constexpr std::string_view version = "12.11.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 1.51 +- 1.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 81408 W: 19347 L: 18994 D: 43067
Penta | [232, 9435, 21033, 9756, 248]
http://chess.grantnet.us/test/38220/
```
```
Elo   | 2.92 +- 2.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 30842 W: 7652 L: 7393 D: 15797
Penta | [204, 3614, 7566, 3793, 244]
http://chess.grantnet.us/test/38219/
```