### PR TITLE
Fix potential blunder where a fail-low score overwrites the best move

### DIFF
--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -110,7 +110,7 @@ void SearchSharedState::ResetNewSearch()
         }
     }
 
-    best_search_result_ = nullptr;
+    best_search_result_ = {};
     search_timer.reset();
     std::for_each(search_local_states_.begin(), search_local_states_.end(), [](auto& data) { data->ResetNewSearch(); });
 }
@@ -147,7 +147,11 @@ void SearchSharedState::set_threads(int threads)
 SearchResults SearchSharedState::get_best_search_result() const
 {
     std::scoped_lock lock(lock_);
-    return *best_search_result_;
+    if (!best_search_result_)
+    {
+        uci_handler.print_error("Could not find best move");
+    }
+    return best_search_result_.value_or(SearchResults {});
 }
 
 void SearchSharedState::report_search_result(
@@ -166,7 +170,7 @@ void SearchSharedState::report_search_result(
         && (!best_search_result_ || (best_search_result_->depth < result_data.depth)
             || (best_search_result_->depth == result_data.depth && best_search_result_->score < result_data.score)))
     {
-        best_search_result_ = &result_data;
+        best_search_result_ = result_data;
     }
 
     // Only the main thread prints info output. We limit lowerbound/upperbound info results to after the first 5 seconds

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -178,7 +178,7 @@ private:
     // [thread_id][multi_pv][depth]
     std::vector<std::vector<std::array<SearchResults, MAX_DEPTH>>> search_results_;
 
-    SearchResults* best_search_result_ = nullptr;
+    std::optional<SearchResults> best_search_result_;
 
     // We persist the SearchLocalStates for each thread we have, so that they don't need to be reconstructed each time
     // we start a search.

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -550,6 +550,11 @@ void Uci::print_bestmove(Move move)
     }
 }
 
+void Uci::print_error(const std::string& error_str)
+{
+    std::cout << "info string Error: " << error_str << std::endl;
+}
+
 void Uci::handle_print()
 {
     std::cout << position.Board() << std::endl;

--- a/src/uci/uci.h
+++ b/src/uci/uci.h
@@ -27,6 +27,7 @@ public:
 
     void print_search_info(const SearchResults& data, bool final = false);
     void print_bestmove(Move move);
+    void print_error(const std::string& error_str);
 
     struct go_ctx
     {


### PR DESCRIPTION
In the old logic, a fail high followed by a fail low could cause the fail low to overwrite the data pointed to by `best_search_result_`. Fail low results have no PV and usually a nonsensical best move. 

This caused the blunder [here](https://www.chess.com/computer-chess-championship#event=ccc23-bullet-qualifier-1&game=552).  Event logs clearly show a `upperbound` score made it's way into the bestmove:
![image](https://github.com/user-attachments/assets/ade1c037-6818-4209-9883-96d77dfba439)

------------------

Details:

A fail high can result in the best move being updated. This is intentional and increases strength.
```
    if ((result_data.type == SearchResultType::EXACT || result_data.type == SearchResultType::LOWER_BOUND)
        && (!best_search_result_ || (best_search_result_->depth < result_data.depth)
            || (best_search_result_->depth == result_data.depth && best_search_result_->score < result_data.score)))
    {
        best_search_result_ = &result_data;
    }
```
The issue is, we simply point the best_search_result_ to the result_data entry to avoid a copy. This is wrong, as the thread may follow the fail high with a fail low and overwrite this entry:
```
    auto& result_data = search_results_[local.thread_id][local.curr_multi_pv - 1][local.curr_depth];
    result_data
        = { local.curr_depth, local.sel_septh, local.curr_multi_pv, result.GetMove(), result.GetScore(), ss->pv, type };
```

-------------------------

```
Elo   | -2.70 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 27400 W: 6527 L: 6740 D: 14133
Penta | [197, 3175, 7134, 3032, 162]
http://chess.grantnet.us/test/38305/
```
A small regression, likely because there's some positive elo from allowing a exact entry to overwrite a fail high entry even when the exact entry has a lower score? More investigation needed.
