### PR TITLE
Bugfix: Fix illegal move and empty PV in TB win root node

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "Network.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.12.3";
+constexpr std::string_view version = "12.13.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 52.30 +- 13.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 830 W: 254 L: 130 D: 446
Penta | [1, 57, 201, 129, 27]
```