### PR TITLE
Trim previousStates vector

### DIFF
--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -49,6 +49,12 @@ void GameState::ApplyMove(std::string_view strmove)
     }
 
     ApplyMove(Move(from, to, flag));
+
+    // trim all moves before a 50 move reset
+    if (Board().fifty_move_count == 0)
+    {
+        previousStates.erase(previousStates.begin(), previousStates.end() - 1);
+    }
 }
 
 void GameState::RevertMove()
@@ -140,15 +146,18 @@ bool GameState::CheckForRep(int distanceFromRoot, int maxReps) const
 
 const BoardState& GameState::Board() const
 {
+    assert(previousStates.size() >= 1);
     return previousStates.back();
 }
 
 const BoardState& GameState::PrevBoard() const
 {
+    assert(previousStates.size() >= 2);
     return previousStates[previousStates.size() - 2];
 }
 
 BoardState& GameState::MutableBoard()
 {
+    assert(previousStates.size() >= 1);
     return previousStates.back();
 }

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -39,6 +39,12 @@ class Uci;
 struct SearchStackState
 {
     SearchStackState(int distance_from_root_);
+
+    SearchStackState(const SearchStackState&) = delete;
+    SearchStackState& operator=(const SearchStackState&) = delete;
+    SearchStackState(SearchStackState&&) = delete;
+    SearchStackState& operator=(SearchStackState&&) = delete;
+
     void reset();
 
     StaticVector<Move, MAX_DEPTH> pv = {};
@@ -74,6 +80,13 @@ public:
     SearchStackState* root();
     void reset();
 
+    SearchStack() = default;
+
+    SearchStack(const SearchStack&) = delete;
+    SearchStack& operator=(const SearchStack&) = delete;
+    SearchStack(SearchStack&&) = delete;
+    SearchStack& operator=(SearchStack&&) = delete;
+
 private:
     std::array<SearchStackState, size> search_stack_array_ { generate(std::make_integer_sequence<int, size>()) };
 
@@ -89,6 +102,11 @@ struct alignas(hardware_destructive_interference_size) SearchLocalState
 {
 public:
     SearchLocalState(int thread_id);
+
+    SearchLocalState(const SearchLocalState&) = delete;
+    SearchLocalState& operator=(const SearchLocalState&) = delete;
+    SearchLocalState(SearchLocalState&&) = delete;
+    SearchLocalState& operator=(SearchLocalState&&) = delete;
 
     bool RootExcludeMove(Move move);
     void ResetNewSearch();
@@ -142,6 +160,11 @@ class SearchSharedState
 {
 public:
     SearchSharedState(Uci& uci);
+
+    SearchSharedState(const SearchSharedState&) = delete;
+    SearchSharedState& operator=(const SearchSharedState&) = delete;
+    SearchSharedState(SearchSharedState&&) = delete;
+    SearchSharedState& operator=(SearchSharedState&&) = delete;
 
     // Below functions are not thread-safe and should not be called during search
     // ------------------------------------

--- a/src/StaticVector.h
+++ b/src/StaticVector.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cassert>
 #include <iterator>
 
 // Stack allocated fixed capacity vector. Should be a drop-in replacement for std::vector, with some lesser
@@ -25,41 +26,49 @@ public:
 
     reference at(size_t pos)
     {
+        assert(pos < size_);
         return elems_[pos];
     }
 
     const_reference at(size_t pos) const
     {
+        assert(pos < size_);
         return elems_[pos];
     }
 
     reference operator[](size_t pos)
     {
+        assert(pos < size_);
         return elems_[pos];
     }
 
     const_reference operator[](size_t pos) const
     {
+        assert(pos < size_);
         return elems_[pos];
     }
 
     reference front()
     {
+        assert(size_ > 0);
         return elems_[0];
     }
 
     const_reference front() const
     {
+        assert(size_ > 0);
         return elems_[0];
     }
 
     reference back()
     {
+        assert(size_ > 0);
         return elems_[size_ - 1];
     }
 
     const_reference back() const
     {
+        assert(size_ > 0);
         return elems_[size_ - 1];
     }
 
@@ -166,6 +175,7 @@ public:
 
     iterator insert(const_iterator pos, const T& value)
     {
+        assert(size_ < N);
         std::move_backward(pos, end(), std::next(end()));
         *pos = value;
         size_++;
@@ -174,6 +184,7 @@ public:
 
     iterator insert(const_iterator pos, T&& value)
     {
+        assert(size_ < N);
         std::move_backward(pos, end(), std::next(end()));
         *pos = std::move(value);
         size_++;
@@ -183,6 +194,7 @@ public:
     template <class InputIt>
     iterator insert(const_iterator pos, InputIt first, InputIt last)
     {
+        assert(size_ + (last - first) <= N);
         auto mutable_it = begin() + std::distance(cbegin(), pos);
         std::move_backward(mutable_it, end(), end() + (last - first));
         std::copy(first, last, mutable_it);
@@ -193,6 +205,7 @@ public:
     template <class... Args>
     iterator emplace(const_iterator pos, Args&&... args)
     {
+        assert(size_ < N);
         auto mutable_it = begin() + std::distance(cbegin(), pos);
         std::move_backward(mutable_it, end(), std::next(end()));
         *mutable_it = T { std::forward<Args>(args)... };
@@ -202,31 +215,45 @@ public:
 
     iterator erase(const_iterator pos)
     {
+        assert(size_ > 0);
         auto mutable_it = begin() + std::distance(cbegin(), pos);
         std::move(std::next(mutable_it), end(), mutable_it);
         size_--;
         return mutable_it;
     }
 
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        assert((int)size_ > (last - first));
+        auto mutable_first = begin() + std::distance(cbegin(), first);
+        std::move(last, cend(), mutable_first);
+        size_ -= last - first;
+        return mutable_first;
+    }
+
     void push_back(const T& value)
     {
+        assert(size_ < N);
         elems_[size_++] = value;
     }
 
     void push_back(T&& value)
     {
+        assert(size_ < N);
         elems_[size_++] = std::move(value);
     }
 
     template <class... Args>
     reference emplace_back(Args&&... args)
     {
+        assert(size_ < N);
         elems_[size_++] = T { std::forward<Args>(args)... };
         return back();
     }
 
     void pop_back()
     {
+        assert(size_ > 0);
         size_--;
     }
 };


### PR DESCRIPTION
```
Elo   | -0.07 +- 1.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 88024 W: 21755 L: 21774 D: 44495
Penta | [649, 9706, 23244, 9841, 572]
http://chess.grantnet.us/test/38961/
```