### PR TITLE
Allow exact search results to replace lower-bound results even when the score is lower

### DIFF
--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -171,11 +171,34 @@ void SearchSharedState::report_search_result(
 
     // Update the best search result. We want to pick the highest depth result, and using the higher score for
     // tie-breaks. It adds elo to also include LOWER_BOUND search results as potential best result candidates.
-    if ((result_data.type == SearchResultType::EXACT || result_data.type == SearchResultType::LOWER_BOUND)
-        && (!best_search_result_ || (best_search_result_->depth < result_data.depth)
-            || (best_search_result_->depth == result_data.depth && best_search_result_->score < result_data.score)))
+    if (result_data.type == SearchResultType::EXACT || result_data.type == SearchResultType::LOWER_BOUND)
     {
-        best_search_result_ = result_data;
+        // no best result, so use this one
+        if (!best_search_result_)
+        {
+            best_search_result_ = result_data;
+        }
+
+        // higher depth results are always preferred
+        else if (result_data.depth > best_search_result_->depth)
+        {
+            best_search_result_ = result_data;
+        }
+
+        // it's possible for this to be false in multi-threaded searches
+        else if (result_data.depth == best_search_result_->depth)
+        {
+            if (result_data.score > best_search_result_->score)
+            {
+                best_search_result_ = result_data;
+            }
+            // if the best search result is a lower bound, and this is an exact result, we want to use this one
+            else if (best_search_result_->type == SearchResultType::LOWER_BOUND
+                && result_data.type == SearchResultType::EXACT)
+            {
+                best_search_result_ = result_data;
+            }
+        }
     }
 
     // Only the main thread prints info output. We limit lowerbound/upperbound info results to after the first 5 seconds

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -192,6 +192,7 @@ void SearchSharedState::report_search_result(
             {
                 best_search_result_ = result_data;
             }
+
             // if the best search result is a lower bound, and this is an exact result, we want to use this one
             else if (best_search_result_->type == SearchResultType::LOWER_BOUND
                 && result_data.type == SearchResultType::EXACT)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.14.0";
+constexpr std::string_view version = "12.15.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 3.29 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 25990 W: 6528 L: 6282 D: 13180
Penta | [176, 2930, 6566, 3118, 205]
```
```
Elo   | 1.54 +- 1.56 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 1.87 (-2.94, 2.94) [0.00, 3.00]
Games | N: 50438 W: 11744 L: 11521 D: 27173
Penta | [156, 5896, 12914, 6075, 178]
```