### PR TITLE
Static exchange pruning for quiet moves

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -843,6 +843,17 @@ Score NegaScout(GameState& position, SearchStackState* ss, SearchLocalState& loc
             }
         }
 
+        bool is_loud_move = move.IsCapture() || move.IsPromotion();
+        int history = is_loud_move
+            ? local.loud_history.get(position, ss, move)
+            : (local.quiet_history.get(position, ss, move) + local.cont_hist.get(position, ss, move));
+
+        if (score > Score::tb_loss_in(MAX_DEPTH) && !is_loud_move && depth <= 10
+            && !see_ge(position.Board(), move, -64 * depth - history / 128))
+        {
+            continue;
+        }
+
         int extensions = 0;
 
         // Step 13: Singular extensions.
@@ -863,9 +874,6 @@ Score NegaScout(GameState& position, SearchStackState* ss, SearchLocalState& loc
             }
         }
 
-        int history = move.IsCapture() || move.IsPromotion()
-            ? local.loud_history.get(position, ss, move)
-            : (local.quiet_history.get(position, ss, move) + local.cont_hist.get(position, ss, move));
         ss->move = move;
         ss->moved_piece = position.Board().GetSquare(move.GetFrom());
         ss->cont_hist_subtable

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -848,8 +848,8 @@ Score NegaScout(GameState& position, SearchStackState* ss, SearchLocalState& loc
             ? local.loud_history.get(position, ss, move)
             : (local.quiet_history.get(position, ss, move) + local.cont_hist.get(position, ss, move));
 
-        if (score > Score::tb_loss_in(MAX_DEPTH) && !is_loud_move && depth <= 10
-            && !see_ge(position.Board(), move, -64 * depth - history / 128))
+        if (score > Score::tb_loss_in(MAX_DEPTH) && !is_loud_move && depth <= 6
+            && !see_ge(position.Board(), move, -111 * depth - history / 168))
         {
             continue;
         }

--- a/src/StaticExchangeEvaluation.h
+++ b/src/StaticExchangeEvaluation.h
@@ -4,7 +4,7 @@ class BoardState;
 class Move;
 class Score;
 
-constexpr int PieceValues[] = { 91, 532, 568, 715, 1279, 5000, 91, 532, 568, 715, 1279, 5000 };
+constexpr int PieceValues[] = { 91, 532, 568, 715, 1279, 5000, 91, 532, 568, 715, 1279, 5000, 0 };
 
 int see(const BoardState& board, Move move);
 bool see_ge(const BoardState& board, Move move, Score threshold);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.15.1";
+constexpr std::string_view version = "12.16.0";
 
 void PrintVersion()
 {

--- a/src/test/StaticExchangeEvaluation.cpp
+++ b/src/test/StaticExchangeEvaluation.cpp
@@ -110,3 +110,33 @@ auto test11 = []()
     test_see(position, Move(SQ_F4, SQ_E3, EN_PASSANT), PieceValues[PAWN]);
     return true;
 }();
+
+// quiet moves (no capture)
+
+auto test12 = []()
+{
+    GameState position;
+    position.InitialiseFromFen("3k4/8/1B6/8/8/8/8/3K4 w - - 0 1");
+    test_see(position, Move(SQ_B6, SQ_E3, QUIET), 0);
+    return true;
+}();
+
+// quiet moves (recapture)
+
+auto test13 = []()
+{
+    GameState position;
+    position.InitialiseFromFen("3k4/8/1B6/5n2/8/8/8/3K4 w - - 0 1");
+    test_see(position, Move(SQ_B6, SQ_E3, QUIET), -PieceValues[BISHOP]);
+    return true;
+}();
+
+// quiet moves (complex recapture)
+
+auto test14 = []()
+{
+    GameState position;
+    position.InitialiseFromFen("3k4/8/1B6/5n2/8/8/5P2/3K4 w - - 0 1");
+    test_see(position, Move(SQ_B6, SQ_E3, QUIET), -PieceValues[BISHOP] + PieceValues[KNIGHT]);
+    return true;
+}();


### PR DESCRIPTION
```
Elo   | 3.43 +- 2.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 25550 W: 6447 L: 6195 D: 12908
Penta | [202, 2993, 6166, 3179, 235]
```

```
Elo   | 1.43 +- 1.15 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 91800 W: 22101 L: 21722 D: 47977
Penta | [310, 10685, 23511, 11104, 290]
```