### PR TITLE
Speedup movegen by 6%

### DIFF
--- a/src/BoardState.cpp
+++ b/src/BoardState.cpp
@@ -365,7 +365,7 @@ void BoardState::ApplyMove(Move move)
         while (potentialAttackers)
         {
             stm = !stm;
-            bool legal = !MovePutsSelfInCheck(*this, Move(LSBpop(potentialAttackers), ep_sq, EN_PASSANT));
+            bool legal = EnPassantIsLegal(*this, Move(LSBpop(potentialAttackers), ep_sq, EN_PASSANT));
             stm = !stm;
             if (legal)
             {

--- a/src/Move.cpp
+++ b/src/Move.cpp
@@ -11,14 +11,10 @@ constexpr int TO_MASK = 0b111111 << 6; // 0 0 0 0 1 1 1 1 1 1 0 0 0 0 0 0
 constexpr int FLAG_MASK = 0b1111 << 12; // 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0
 
 Move::Move(Square from, Square to, MoveFlag flag)
-    : data(0)
+    : data(from | (to << 6) | (flag << 12))
 {
     assert(from < 64);
     assert(to < 64);
-
-    SetFrom(from);
-    SetTo(to);
-    SetFlag(flag);
 }
 
 Move::Move(uint16_t data_)
@@ -89,24 +85,6 @@ std::ostream& operator<<(std::ostream& os, Move m)
     }
 
     return os << buffer;
-}
-
-void Move::SetFrom(Square from)
-{
-    data &= ~FROM_MASK;
-    data |= from;
-}
-
-void Move::SetTo(Square to)
-{
-    data &= ~TO_MASK;
-    data |= to << 6;
-}
-
-void Move::SetFlag(MoveFlag flag)
-{
-    data &= ~FLAG_MASK;
-    data |= flag << 12;
 }
 
 std::ostream& operator<<(std::ostream& os, format_chess960 f)

--- a/src/Move.h
+++ b/src/Move.h
@@ -57,10 +57,6 @@ public:
     friend std::ostream& operator<<(std::ostream& os, Move m);
 
 private:
-    void SetFrom(Square from);
-    void SetTo(Square to);
-    void SetFlag(MoveFlag flag);
-
     // 6 bits for 'from square', 6 bits for 'to square' and 4 bits for the 'move flag'
     uint16_t data;
 };

--- a/src/MoveGeneration.h
+++ b/src/MoveGeneration.h
@@ -17,9 +17,7 @@ bool IsInCheck(const BoardState& board, Players colour);
 bool IsInCheck(const BoardState& board);
 
 bool MoveIsLegal(const BoardState& board, const Move& move);
-
-// This function does not work for casteling moves. They are tested for legality their creation.
-bool MovePutsSelfInCheck(const BoardState& board, const Move& move);
+bool EnPassantIsLegal(const BoardState& board, const Move& move);
 
 // Returns a threat mask that only contains winning captures (RxQ, B/NxR/Q, Px!P)
 uint64_t ThreatMask(const BoardState& board, Players colour);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.15.0";
+constexpr std::string_view version = "12.15.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
Perft speed calculated by
```
taskset -c 1 ../bin/Halogen-native "position fen r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - " "perft 7"
```
Baseline:
`Nodes searched: 374190009323 in 1065.81 seconds (351085914 nps)`
Dev: 
`Nodes searched: 374190009323 in 1001.54 seconds (373615407 nps)`