### PR TITLE
Improve repetition detection algorithm

### DIFF
--- a/src/BoardState.h
+++ b/src/BoardState.h
@@ -3,6 +3,8 @@
 #include <array>
 #include <cstdint>
 #include <iosfwd>
+#include <limits>
+#include <optional>
 #include <string_view>
 
 #include "BitBoardDefine.h"
@@ -27,6 +29,10 @@ public:
 
     Players stm = N_PLAYERS;
     uint64_t castle_squares;
+
+    // number of plys since last repitition
+    std::optional<int> repitition;
+    bool three_fold_rep = false;
 
     Pieces GetSquare(Square square) const;
 

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -141,8 +141,7 @@ BoardState& GameState::MutableBoard()
 bool GameState::is_repitition(int distance_from_root) const
 {
     return Board().three_fold_rep
-        || (Board().repitition.has_value()
-            && Board().repitition.value() < distance_from_root - 1); // -1 is to match behaviour of old bug
+        || (Board().repitition.has_value() && Board().repitition.value() < distance_from_root);
 }
 
 bool GameState::is_two_fold_repitition() const

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -17,20 +17,7 @@ GameState::GameState()
 void GameState::ApplyMove(Move move)
 {
     previousStates.emplace_back(previousStates.back()).ApplyMove(move);
-
-    const int i = previousStates.size() - 1;
-    previousStates[i].three_fold_rep = false;
-    previousStates[i].repitition = std::nullopt;
-
-    for (int ply = 4; ply < (int)previousStates[i].fifty_move_count; ply += 2)
-    {
-        if (previousStates[i].GetZobristKey() == previousStates[i - ply].GetZobristKey())
-        {
-            previousStates[i].repitition = ply;
-            previousStates[i].three_fold_rep = (bool)previousStates[i - ply].repitition;
-            break;
-        }
-    }
+    update_current_position_repitition();
 }
 
 void GameState::ApplyMove(std::string_view strmove)
@@ -82,10 +69,7 @@ void GameState::ApplyNullMove()
 {
     previousStates.push_back(previousStates.back());
     MutableBoard().ApplyNullMove();
-
-    const int i = previousStates.size() - 1;
-    previousStates[i].three_fold_rep = false;
-    previousStates[i].repitition = std::nullopt;
+    update_current_position_repitition();
 }
 
 void GameState::RevertNullMove()
@@ -157,10 +141,32 @@ BoardState& GameState::MutableBoard()
 bool GameState::is_repitition(int distance_from_root) const
 {
     return Board().three_fold_rep
-        || (Board().repitition.has_value() && Board().repitition.value() < distance_from_root);
+        || (Board().repitition.has_value()
+            && Board().repitition.value() < distance_from_root - 1); // -1 is to match behaviour of old bug
 }
 
 bool GameState::is_two_fold_repitition() const
 {
     return Board().repitition.has_value();
+}
+
+void GameState::update_current_position_repitition()
+{
+    assert(previousStates.size() >= 1);
+
+    const int i = previousStates.size() - 1;
+    previousStates[i].three_fold_rep = false;
+    previousStates[i].repitition = std::nullopt;
+
+    const int max_ply = std::min<int>(previousStates.size() - 1, previousStates[i].fifty_move_count);
+
+    for (int ply = 4; ply <= max_ply; ply += 2)
+    {
+        if (previousStates[i].GetZobristKey() == previousStates[i - ply].GetZobristKey())
+        {
+            previousStates[i].repitition = ply;
+            previousStates[i].three_fold_rep = (bool)previousStates[i - ply].repitition;
+            break;
+        }
+    }
 }

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -81,8 +81,11 @@ void GameState::RevertMove()
 void GameState::ApplyNullMove()
 {
     previousStates.push_back(previousStates.back());
-
     MutableBoard().ApplyNullMove();
+
+    const int i = previousStates.size() - 1;
+    previousStates[i].three_fold_rep = false;
+    previousStates[i].repitition = std::nullopt;
 }
 
 void GameState::RevertNullMove()

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -17,6 +17,20 @@ GameState::GameState()
 void GameState::ApplyMove(Move move)
 {
     previousStates.emplace_back(previousStates.back()).ApplyMove(move);
+
+    const int i = previousStates.size() - 1;
+    previousStates[i].three_fold_rep = false;
+    previousStates[i].repitition = std::nullopt;
+
+    for (int ply = 4; ply < (int)previousStates[i].fifty_move_count; ply += 2)
+    {
+        if (previousStates[i].GetZobristKey() == previousStates[i - ply].GetZobristKey())
+        {
+            previousStates[i].repitition = ply;
+            previousStates[i].three_fold_rep = (bool)previousStates[i - ply].repitition;
+            break;
+        }
+    }
 }
 
 void GameState::ApplyMove(std::string_view strmove)
@@ -119,31 +133,6 @@ bool GameState::InitialiseFromFen(std::string_view fen)
     return InitialiseFromFen(splitFen);
 }
 
-bool GameState::CheckForRep(int distanceFromRoot, int maxReps) const
-{
-    int totalRep = 1;
-    uint64_t current = Board().GetZobristKey();
-
-    // check every second key from the back, skipping the last (current) key
-    for (int i = static_cast<int>(previousStates.size()) - 3; i >= 0; i -= 2)
-    {
-        if (previousStates[i].GetZobristKey() == current)
-            totalRep++;
-
-        if (totalRep == maxReps)
-            return true; // maxReps (usually 3) reps is always a draw
-        if (totalRep == 2 && static_cast<int>(previousStates.size() - i) < distanceFromRoot)
-            return true; // Don't allow 2 reps if its in the local search history (not part of the actual played game)
-
-        // the fifty move count is reset when a irreversible move is made. As such, we can stop here
-        // and know no repitition has taken place. Becuase we move by two at a time, we stop at 0 or 1.
-        if (previousStates[i].fifty_move_count <= 1)
-            break;
-    }
-
-    return false;
-}
-
 const BoardState& GameState::Board() const
 {
     assert(previousStates.size() >= 1);
@@ -160,4 +149,15 @@ BoardState& GameState::MutableBoard()
 {
     assert(previousStates.size() >= 1);
     return previousStates.back();
+}
+
+bool GameState::is_repitition(int distance_from_root) const
+{
+    return Board().three_fold_rep
+        || (Board().repitition.has_value() && Board().repitition.value() < distance_from_root);
+}
+
+bool GameState::is_two_fold_repitition() const
+{
+    return Board().repitition.has_value();
 }

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -41,4 +41,6 @@ private:
     BoardState& MutableBoard();
 
     std::vector<BoardState> previousStates;
+
+    void update_current_position_repitition();
 };

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -31,7 +31,8 @@ public:
     bool InitialiseFromFen(std::array<std::string_view, 6> fen);
     bool InitialiseFromFen(std::string_view fen);
 
-    bool CheckForRep(int distanceFromRoot, int maxReps) const;
+    bool is_repitition(int distance_from_root) const;
+    bool is_two_fold_repitition() const;
 
     const BoardState& Board() const;
     const BoardState& PrevBoard() const;

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -283,7 +283,7 @@ std::optional<Score> init_search_node(const GameState& position, const int dista
 
     // Draw randomness as in https://github.com/Luecx/Koivisto/commit/c8f01211c290a582b69e4299400b667a7731a9f7 with
     // permission from Koivisto authors. The condition > 100 is used because the 100th move could give checkmate.
-    if (position.CheckForRep(distance_from_root, 3) || position.Board().fifty_move_count > 100)
+    if (position.is_repitition(distance_from_root) || position.Board().fifty_move_count > 100)
     {
         return 8 - (local.nodes & 0b1111);
     }
@@ -408,11 +408,11 @@ std::tuple<TTEntry*, Score, int, SearchResultType, Move, Score> probe_tt(
     return { tt_entry, tt_score, tt_depth, tt_cutoff, tt_move, tt_eval };
 }
 
-std::optional<Score> tt_cutoff_node(const GameState& position, const int distance_from_root, const Score tt_score,
-    const SearchResultType tt_cutoff, const Score alpha, const Score beta)
+std::optional<Score> tt_cutoff_node(const GameState& position, const Score tt_score, const SearchResultType tt_cutoff,
+    const Score alpha, const Score beta)
 {
     // Don't take scores from the TT if there's a two-fold repitition
-    if (position.CheckForRep(distance_from_root, 2))
+    if (position.is_two_fold_repitition())
     {
         return std::nullopt;
     }
@@ -740,7 +740,7 @@ Score NegaScout(GameState& position, SearchStackState* ss, SearchLocalState& loc
     if (!pv_node && ss->singular_exclusion == Move::Uninitialized && tt_depth >= depth
         && tt_cutoff != SearchResultType::EMPTY && tt_score != SCORE_UNDEFINED)
     {
-        if (auto value = tt_cutoff_node(position, distance_from_root, tt_score, tt_cutoff, alpha, beta))
+        if (auto value = tt_cutoff_node(position, tt_score, tt_cutoff, alpha, beta))
         {
             return *value;
         }
@@ -951,7 +951,7 @@ Score Quiescence(GameState& position, SearchStackState* ss, SearchLocalState& lo
     if (!pv_node && ss->singular_exclusion == Move::Uninitialized && tt_depth >= depth
         && tt_cutoff != SearchResultType::EMPTY && tt_score != SCORE_UNDEFINED)
     {
-        if (auto value = tt_cutoff_node(position, distance_from_root, tt_score, tt_cutoff, alpha, beta))
+        if (auto value = tt_cutoff_node(position, tt_score, tt_cutoff, alpha, beta))
         {
             return *value;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.16.0";
+constexpr std::string_view version = "12.17.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 5.76 +- 3.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8500 W: 2161 L: 2020 D: 4319
Penta | [41, 931, 2190, 1022, 66]
http://chess.grantnet.us/test/39073/
```
```
Elo   | 5.55 +- 7.04 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.55 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2252 W: 544 L: 508 D: 1200
Penta | [2, 241, 608, 269, 6]
http://chess.grantnet.us/test/39074/
```