### PR TITLE
Add upcoming cycle detection to qsearch

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -987,6 +987,15 @@ Score Quiescence(GameState& position, SearchStackState* ss, SearchLocalState& lo
         return *value;
     }
 
+    if (alpha < 0 && position.upcoming_rep(distance_from_root))
+    {
+        alpha = 0;
+        if (alpha >= beta)
+        {
+            return alpha;
+        }
+    }
+
     // Step 2: Probe transposition table
     const auto [tt_entry, tt_score, tt_depth, tt_cutoff, tt_move, tt_eval] = probe_tt(position, distance_from_root);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.18.0";
+constexpr std::string_view version = "12.18.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 0.42 +- 0.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.69 (-2.94, 2.94) [0.00, 3.00]
Games | N: 148296 W: 35847 L: 35668 D: 76781
Penta | [1047, 17678, 36486, 17923, 1014]
http://chess.grantnet.us/test/39081/
```