### PR TITLE
Use TT move in q-search where possible

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -1024,7 +1024,7 @@ Score Quiescence(GameState& position, SearchStackState* ss, SearchLocalState& lo
     auto score = eval;
     auto original_alpha = alpha;
 
-    StagedMoveGenerator gen(position, ss, local, Move::Uninitialized, true);
+    StagedMoveGenerator gen(position, ss, local, tt_move, true);
     Move move;
 
     while (gen.Next(move))

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -31,7 +31,7 @@ bool StagedMoveGenerator::Next(Move& move)
     {
         stage = Stage::GEN_LOUD;
 
-        if ((!quiescence || move.IsCapture() || move.IsPromotion()) && MoveIsLegal(position.Board(), TTmove))
+        if ((!quiescence || TTmove.IsCapture() || TTmove.IsPromotion()) && MoveIsLegal(position.Board(), TTmove))
         {
             move = TTmove;
             return true;

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -20,12 +20,9 @@ StagedMoveGenerator::StagedMoveGenerator(
     , local(Local)
     , ss(SS)
     , quiescence(Quiescence)
+    , stage(Stage::TT_MOVE)
     , TTmove(tt_move)
 {
-    if (quiescence)
-        stage = Stage::GEN_LOUD;
-    else
-        stage = Stage::TT_MOVE;
 }
 
 bool StagedMoveGenerator::Next(Move& move)

--- a/src/StagedMoveGenerator.cpp
+++ b/src/StagedMoveGenerator.cpp
@@ -34,7 +34,7 @@ bool StagedMoveGenerator::Next(Move& move)
     {
         stage = Stage::GEN_LOUD;
 
-        if (MoveIsLegal(position.Board(), TTmove))
+        if ((!quiescence || move.IsCapture() || move.IsPromotion()) && MoveIsLegal(position.Board(), TTmove))
         {
             move = TTmove;
             return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.18.1";
+constexpr std::string_view version = "12.18.2";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 0.73 +- 1.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -0.47 (-2.94, 2.94) [0.00, 3.00]
Games | N: 126908 W: 30809 L: 30541 D: 65558
Penta | [830, 15248, 31072, 15432, 872]
http://chess.grantnet.us/test/39095/
```