### PR TITLE
Add Pawn Correction History

### DIFF
--- a/src/History.h
+++ b/src/History.h
@@ -5,10 +5,12 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <tuple>
 
 #include "BitBoardDefine.h"
 #include "Move.h"
+#include "Score.h"
 
 class GameState;
 struct SearchStackState;
@@ -89,6 +91,29 @@ struct ContinuationHistory
     {
         memset(table, 0, sizeof(table));
     }
+};
+
+struct PawnCorrHistory
+{
+    // must be a power of 2, for fast hash lookup
+    static constexpr size_t pawn_hash_table_size = 16384;
+    static constexpr int correction_max = 16;
+
+    int16_t table[N_PLAYERS][pawn_hash_table_size] = {};
+
+    int16_t* get(const GameState& position);
+    const int16_t* get(const GameState& position) const;
+
+    void add(const GameState& position, int depth, int eval_diff);
+    Score get_correction_score(const GameState& position) const;
+
+    constexpr void reset()
+    {
+        memset(table, 0, sizeof(table));
+    }
+
+private:
+    static constexpr int eval_scale = 16384 / correction_max;
 };
 
 template <typename... tables>

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -299,20 +299,6 @@ std::optional<Score> init_search_node(const GameState& position, const int dista
     return std::nullopt;
 }
 
-void AddScoreToTable(Score score, Score alphaOriginal, const BoardState& board, int depthRemaining,
-    int distanceFromRoot, Score beta, Move bestMove, Score static_eval)
-{
-    if (score <= alphaOriginal)
-        tTable.AddEntry(bestMove, board.GetZobristKey(), score, depthRemaining, board.half_turn_count, distanceFromRoot,
-            SearchResultType::UPPER_BOUND, static_eval);
-    else if (score >= beta)
-        tTable.AddEntry(bestMove, board.GetZobristKey(), score, depthRemaining, board.half_turn_count, distanceFromRoot,
-            SearchResultType::LOWER_BOUND, static_eval);
-    else
-        tTable.AddEntry(bestMove, board.GetZobristKey(), score, depthRemaining, board.half_turn_count, distanceFromRoot,
-            SearchResultType::EXACT, static_eval);
-}
-
 template <bool root_node, bool pv_node>
 std::optional<Score> probe_egtb(const GameState& position, const int distance_from_root, SearchLocalState& local,
     SearchStackState* ss, Score& alpha, Score& beta, Score& min_score, Score& max_score, const int depth)
@@ -344,8 +330,8 @@ std::optional<Score> probe_egtb(const GameState& position, const int distance_fr
             if (bound == SearchResultType::EXACT || (bound == SearchResultType::LOWER_BOUND && tb_score >= beta)
                 || (bound == SearchResultType::UPPER_BOUND && tb_score <= alpha))
             {
-                AddScoreToTable(tb_score, alpha, position.Board(), depth, distance_from_root, beta, Move::Uninitialized,
-                    SCORE_UNDEFINED);
+                tTable.AddEntry(Move::Uninitialized, position.Board().GetZobristKey(), tb_score, depth,
+                    position.Board().half_turn_count, distance_from_root, bound, SCORE_UNDEFINED);
                 return tb_score;
             }
         }
@@ -671,6 +657,8 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
         return std::clamp<Score>(adjusted, Score::Limits::EVAL_MIN, Score::Limits::EVAL_MAX);
     };
 
+    auto eval_corr_history = [&](Score eval) { return eval + local.pawn_corr_hist.get_correction_score(position); };
+
     if (tt_entry)
     {
         if (tt_eval != SCORE_UNDEFINED)
@@ -683,6 +671,7 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
         }
 
         adjusted_eval = scale_eval_50_move(raw_eval);
+        adjusted_eval = eval_corr_history(adjusted_eval);
 
         // Use the tt_score to improve the static eval if possible. Avoid returning unproved mate scores in q-search
         if (tt_score != SCORE_UNDEFINED && (!is_qsearch || std::abs(tt_score) < Score::tb_win_in(MAX_DEPTH))
@@ -697,6 +686,7 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
     {
         raw_eval = Evaluate(position.Board(), ss, local.net);
         adjusted_eval = scale_eval_50_move(raw_eval);
+        adjusted_eval = eval_corr_history(adjusted_eval);
         tTable.AddEntry(Move::Uninitialized, position.Board().GetZobristKey(), SCORE_UNDEFINED, depth,
             position.Board().half_turn_count, distance_from_root, SearchResultType::EMPTY, raw_eval);
     }
@@ -963,11 +953,27 @@ Score NegaScout(GameState& position, SearchStackState* ss, SearchLocalState& loc
 
     score = std::clamp(score, min_score, max_score);
 
-    // Step 19: Update transposition table
-    if (!local.aborting_search && ss->singular_exclusion == Move::Uninitialized)
+    // Step 19: Return early when in a singular extension root search
+    if (local.aborting_search || ss->singular_exclusion != Move::Uninitialized)
     {
-        AddScoreToTable(score, original_alpha, position.Board(), depth, distance_from_root, beta, bestMove, raw_eval);
+        return score;
     }
+
+    const auto bound = score <= original_alpha ? SearchResultType::UPPER_BOUND
+        : score >= beta                        ? SearchResultType::LOWER_BOUND
+                                               : SearchResultType::EXACT;
+
+    // Step 20: Adjust eval correction history
+    if (!InCheck && (bestMove != Move::Uninitialized || (!bestMove.IsCapture() && !bestMove.IsPromotion()))
+        && !(bound == SearchResultType::LOWER_BOUND && score <= raw_eval)
+        && !(bound == SearchResultType::UPPER_BOUND && score >= raw_eval))
+    {
+        local.pawn_corr_hist.add(position, depth, score.value() - raw_eval.value());
+    }
+
+    // Step 21: Update transposition table
+    tTable.AddEntry(bestMove, position.Board().GetZobristKey(), score, depth, position.Board().half_turn_count,
+        distance_from_root, bound, raw_eval);
 
     return score;
 }
@@ -1062,11 +1068,19 @@ Score Quiescence(GameState& position, SearchStackState* ss, SearchLocalState& lo
         }
     }
 
-    // Step 6: Update transposition table
-    if (!local.aborting_search && ss->singular_exclusion == Move::Uninitialized)
+    // Step 6: Return early when in a singular extension root search
+    if (local.aborting_search || ss->singular_exclusion != Move::Uninitialized)
     {
-        AddScoreToTable(score, original_alpha, position.Board(), depth, distance_from_root, beta, bestmove, raw_eval);
+        return score;
     }
+
+    const auto bound = score <= original_alpha ? SearchResultType::UPPER_BOUND
+        : score >= beta                        ? SearchResultType::LOWER_BOUND
+                                               : SearchResultType::EXACT;
+
+    // Step 7: Update transposition table
+    tTable.AddEntry(bestmove, position.Board().GetZobristKey(), score, depth, position.Board().half_turn_count,
+        distance_from_root, bound, raw_eval);
 
     return score;
 }

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -99,6 +99,7 @@ void SearchLocalState::ResetNewGame()
     quiet_history.reset();
     loud_history.reset();
     cont_hist.reset();
+    pawn_corr_hist.reset();
 }
 
 SearchSharedState::SearchSharedState(Uci& uci)

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -117,6 +117,7 @@ public:
     QuietHistory quiet_history;
     LoudHistory loud_history;
     ContinuationHistory cont_hist;
+    PawnCorrHistory pawn_corr_hist;
     int sel_septh = 0;
     atomic_relaxed<int64_t> tb_hits = 0;
     atomic_relaxed<int64_t> nodes = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.18.2";
+constexpr std::string_view version = "12.19.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
https://www.chessprogramming.org/Static_Evaluation_Correction_History

```
Elo   | 3.34 +- 2.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 25450 W: 6343 L: 6098 D: 13009
Penta | [167, 2947, 6250, 3196, 165]
http://chess.grantnet.us/test/39100/
```