### PR TITLE
Correctly cap adjusted eval

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -653,8 +653,7 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
     {
         // rescale and skew the raw eval based on the 50 move rule. We need to reclamp the score to ensure we don't
         // return false mate scores
-        auto adjusted = eval.value() * (288 - (int)position.Board().fifty_move_count) / 256;
-        return std::clamp<Score>(adjusted, Score::Limits::EVAL_MIN, Score::Limits::EVAL_MAX);
+        return eval.value() * (288 - (int)position.Board().fifty_move_count) / 256;
     };
 
     auto eval_corr_history = [&](Score eval) { return eval + local.pawn_corr_hist.get_correction_score(position); };
@@ -691,6 +690,7 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
             position.Board().half_turn_count, distance_from_root, SearchResultType::EMPTY, raw_eval);
     }
 
+    adjusted_eval = std::clamp<Score>(adjusted_eval, Score::Limits::EVAL_MIN, Score::Limits::EVAL_MAX);
     return { raw_eval, adjusted_eval };
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.19.0";
+constexpr std::string_view version = "12.19.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | -0.63 +- 1.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 54440 W: 13157 L: 13255 D: 28028
Penta | [363, 6109, 14325, 6109, 314]
http://chess.grantnet.us/test/39110/
```