### PR TITLE
Non pawn correction history

### DIFF
--- a/src/BoardState.cpp
+++ b/src/BoardState.cpp
@@ -121,6 +121,10 @@ bool BoardState::InitialiseFromFen(const std::array<std::string_view, 6>& fen)
     RecalculateWhiteBlackBoards();
     key = Zobrist::key(*this);
     pawn_key = Zobrist::pawn_key(*this);
+    non_pawn_key[WHITE] = Zobrist::non_pawn_key(*this, WHITE);
+    non_pawn_key[BLACK] = Zobrist::non_pawn_key(*this, BLACK);
+    minor_key = Zobrist::minor_key(*this);
+    major_key = Zobrist::major_key(*this);
     return true;
 }
 
@@ -311,6 +315,8 @@ std::ostream& operator<<(std::ostream& os, const BoardState& b)
 
 void BoardState::ApplyMove(Move move)
 {
+    // std::cout << *this << std::endl;
+
     key ^= Zobrist::stm();
 
     // undo the previous ep square
@@ -338,6 +344,21 @@ void BoardState::ApplyMove(Move move)
         {
             pawn_key ^= Zobrist::piece_square(piece, move.GetFrom());
             pawn_key ^= Zobrist::piece_square(piece, move.GetTo());
+        }
+        else
+        {
+            non_pawn_key[stm] ^= Zobrist::piece_square(piece, move.GetFrom());
+            non_pawn_key[stm] ^= Zobrist::piece_square(piece, move.GetTo());
+            if (GetPieceType(piece) == KNIGHT || GetPieceType(piece) == BISHOP)
+            {
+                minor_key ^= Zobrist::piece_square(piece, move.GetFrom());
+                minor_key ^= Zobrist::piece_square(piece, move.GetTo());
+            }
+            else if (GetPieceType(piece) == ROOK || GetPieceType(piece) == QUEEN)
+            {
+                major_key ^= Zobrist::piece_square(piece, move.GetFrom());
+                major_key ^= Zobrist::piece_square(piece, move.GetTo());
+            }
         }
 
         break;
@@ -392,6 +413,12 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(Piece(KING, stm), king_end);
         key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
         key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
+        non_pawn_key[stm] ^= Zobrist::piece_square(Piece(KING, stm), king_start);
+        non_pawn_key[stm] ^= Zobrist::piece_square(Piece(KING, stm), king_end);
+        non_pawn_key[stm] ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
+        non_pawn_key[stm] ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
+        major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
+        major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
 
         break;
     }
@@ -411,6 +438,12 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(Piece(KING, stm), king_end);
         key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
         key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
+        non_pawn_key[stm] ^= Zobrist::piece_square(Piece(KING, stm), king_start);
+        non_pawn_key[stm] ^= Zobrist::piece_square(Piece(KING, stm), king_end);
+        non_pawn_key[stm] ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
+        non_pawn_key[stm] ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
+        major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
+        major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
 
         break;
     }
@@ -423,7 +456,6 @@ void BoardState::ApplyMove(Move move)
         AddPiece(move.GetTo(), piece);
         RemovePiece(move.GetFrom(), piece);
 
-        key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         key ^= Zobrist::piece_square(piece, move.GetFrom());
         key ^= Zobrist::piece_square(piece, move.GetTo());
         if (GetPieceType(piece) == PAWN)
@@ -431,9 +463,37 @@ void BoardState::ApplyMove(Move move)
             pawn_key ^= Zobrist::piece_square(piece, move.GetFrom());
             pawn_key ^= Zobrist::piece_square(piece, move.GetTo());
         }
+        else
+        {
+            non_pawn_key[stm] ^= Zobrist::piece_square(piece, move.GetFrom());
+            non_pawn_key[stm] ^= Zobrist::piece_square(piece, move.GetTo());
+            if (GetPieceType(piece) == KNIGHT || GetPieceType(piece) == BISHOP)
+            {
+                minor_key ^= Zobrist::piece_square(piece, move.GetFrom());
+                minor_key ^= Zobrist::piece_square(piece, move.GetTo());
+            }
+            else if (GetPieceType(piece) == ROOK || GetPieceType(piece) == QUEEN)
+            {
+                major_key ^= Zobrist::piece_square(piece, move.GetFrom());
+                major_key ^= Zobrist::piece_square(piece, move.GetTo());
+            }
+        }
+        key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         if (GetPieceType(cap_piece) == PAWN)
         {
             pawn_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        }
+        else
+        {
+            non_pawn_key[!stm] ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            if (GetPieceType(cap_piece) == KNIGHT || GetPieceType(cap_piece) == BISHOP)
+            {
+                minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            }
+            else if (GetPieceType(cap_piece) == ROOK || GetPieceType(cap_piece) == QUEEN)
+            {
+                major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            }
         }
 
         break;
@@ -469,6 +529,8 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
+        non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
 
         break;
     }
@@ -483,6 +545,8 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
+        non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
 
         break;
     }
@@ -497,6 +561,8 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
+        non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
 
         break;
     }
@@ -511,6 +577,8 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
+        non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
 
         break;
     }
@@ -526,8 +594,19 @@ void BoardState::ApplyMove(Move move)
 
         key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
+        non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        non_pawn_key[!stm] ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        if (GetPieceType(cap_piece) == KNIGHT || GetPieceType(cap_piece) == BISHOP)
+        {
+            minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        }
+        else if (GetPieceType(cap_piece) == ROOK || GetPieceType(cap_piece) == QUEEN)
+        {
+            major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        }
 
         break;
     }
@@ -543,8 +622,19 @@ void BoardState::ApplyMove(Move move)
 
         key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
+        non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        non_pawn_key[!stm] ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        if (GetPieceType(cap_piece) == KNIGHT || GetPieceType(cap_piece) == BISHOP)
+        {
+            minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        }
+        else if (GetPieceType(cap_piece) == ROOK || GetPieceType(cap_piece) == QUEEN)
+        {
+            major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        }
 
         break;
     }
@@ -560,8 +650,19 @@ void BoardState::ApplyMove(Move move)
 
         key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
+        non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        non_pawn_key[!stm] ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        if (GetPieceType(cap_piece) == KNIGHT || GetPieceType(cap_piece) == BISHOP)
+        {
+            minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        }
+        else if (GetPieceType(cap_piece) == ROOK || GetPieceType(cap_piece) == QUEEN)
+        {
+            major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        }
 
         break;
     }
@@ -577,8 +678,19 @@ void BoardState::ApplyMove(Move move)
 
         key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
+        non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        non_pawn_key[!stm] ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        if (GetPieceType(cap_piece) == KNIGHT || GetPieceType(cap_piece) == BISHOP)
+        {
+            minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        }
+        else if (GetPieceType(cap_piece) == ROOK || GetPieceType(cap_piece) == QUEEN)
+        {
+            major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+        }
 
         break;
     }
@@ -594,8 +706,15 @@ void BoardState::ApplyMove(Move move)
     half_turn_count += 1;
     stm = !stm;
 
+    // std::cout << *this << std::endl;
+    // std::cout << move << std::endl;
+
     assert(key == Zobrist::key(*this));
     assert(pawn_key == Zobrist::pawn_key(*this));
+    assert(non_pawn_key[WHITE] == Zobrist::non_pawn_key(*this, WHITE));
+    assert(non_pawn_key[BLACK] == Zobrist::non_pawn_key(*this, BLACK));
+    assert(minor_key == Zobrist::minor_key(*this));
+    assert(major_key == Zobrist::major_key(*this));
 }
 
 void BoardState::ApplyNullMove()
@@ -615,6 +734,10 @@ void BoardState::ApplyNullMove()
 
     assert(key == Zobrist::key(*this));
     assert(pawn_key == Zobrist::pawn_key(*this));
+    assert(non_pawn_key[WHITE] == Zobrist::non_pawn_key(*this, WHITE));
+    assert(non_pawn_key[BLACK] == Zobrist::non_pawn_key(*this, BLACK));
+    assert(minor_key == Zobrist::minor_key(*this));
+    assert(major_key == Zobrist::major_key(*this));
 }
 
 MoveFlag BoardState::GetMoveFlag(Square from, Square to) const

--- a/src/BoardState.cpp
+++ b/src/BoardState.cpp
@@ -123,8 +123,8 @@ bool BoardState::InitialiseFromFen(const std::array<std::string_view, 6>& fen)
     pawn_key = Zobrist::pawn_key(*this);
     non_pawn_key[WHITE] = Zobrist::non_pawn_key(*this, WHITE);
     non_pawn_key[BLACK] = Zobrist::non_pawn_key(*this, BLACK);
-    minor_key = Zobrist::minor_key(*this);
-    major_key = Zobrist::major_key(*this);
+    // minor_key = Zobrist::minor_key(*this);
+    // major_key = Zobrist::major_key(*this);
     return true;
 }
 
@@ -351,13 +351,13 @@ void BoardState::ApplyMove(Move move)
             non_pawn_key[stm] ^= Zobrist::piece_square(piece, move.GetTo());
             if (GetPieceType(piece) == KNIGHT || GetPieceType(piece) == BISHOP)
             {
-                minor_key ^= Zobrist::piece_square(piece, move.GetFrom());
-                minor_key ^= Zobrist::piece_square(piece, move.GetTo());
+                // minor_key ^= Zobrist::piece_square(piece, move.GetFrom());
+                // minor_key ^= Zobrist::piece_square(piece, move.GetTo());
             }
             else if (GetPieceType(piece) == ROOK || GetPieceType(piece) == QUEEN)
             {
-                major_key ^= Zobrist::piece_square(piece, move.GetFrom());
-                major_key ^= Zobrist::piece_square(piece, move.GetTo());
+                // major_key ^= Zobrist::piece_square(piece, move.GetFrom());
+                // major_key ^= Zobrist::piece_square(piece, move.GetTo());
             }
         }
 
@@ -417,8 +417,8 @@ void BoardState::ApplyMove(Move move)
         non_pawn_key[stm] ^= Zobrist::piece_square(Piece(KING, stm), king_end);
         non_pawn_key[stm] ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
         non_pawn_key[stm] ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
-        major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
-        major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
+        // major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
+        // major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
 
         break;
     }
@@ -442,8 +442,8 @@ void BoardState::ApplyMove(Move move)
         non_pawn_key[stm] ^= Zobrist::piece_square(Piece(KING, stm), king_end);
         non_pawn_key[stm] ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
         non_pawn_key[stm] ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
-        major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
-        major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
+        // major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_start);
+        // major_key ^= Zobrist::piece_square(Piece(ROOK, stm), rook_end);
 
         break;
     }
@@ -469,13 +469,13 @@ void BoardState::ApplyMove(Move move)
             non_pawn_key[stm] ^= Zobrist::piece_square(piece, move.GetTo());
             if (GetPieceType(piece) == KNIGHT || GetPieceType(piece) == BISHOP)
             {
-                minor_key ^= Zobrist::piece_square(piece, move.GetFrom());
-                minor_key ^= Zobrist::piece_square(piece, move.GetTo());
+                // minor_key ^= Zobrist::piece_square(piece, move.GetFrom());
+                // minor_key ^= Zobrist::piece_square(piece, move.GetTo());
             }
             else if (GetPieceType(piece) == ROOK || GetPieceType(piece) == QUEEN)
             {
-                major_key ^= Zobrist::piece_square(piece, move.GetFrom());
-                major_key ^= Zobrist::piece_square(piece, move.GetTo());
+                // major_key ^= Zobrist::piece_square(piece, move.GetFrom());
+                // major_key ^= Zobrist::piece_square(piece, move.GetTo());
             }
         }
         key ^= Zobrist::piece_square(cap_piece, move.GetTo());
@@ -488,11 +488,11 @@ void BoardState::ApplyMove(Move move)
             non_pawn_key[!stm] ^= Zobrist::piece_square(cap_piece, move.GetTo());
             if (GetPieceType(cap_piece) == KNIGHT || GetPieceType(cap_piece) == BISHOP)
             {
-                minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+                // minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
             }
             else if (GetPieceType(cap_piece) == ROOK || GetPieceType(cap_piece) == QUEEN)
             {
-                major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+                // major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
             }
         }
 
@@ -530,7 +530,7 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        // minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
 
         break;
     }
@@ -546,7 +546,7 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        // minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
 
         break;
     }
@@ -562,7 +562,7 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        // major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
 
         break;
     }
@@ -578,7 +578,7 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        // major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
 
         break;
     }
@@ -596,16 +596,16 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        // minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         non_pawn_key[!stm] ^= Zobrist::piece_square(cap_piece, move.GetTo());
         if (GetPieceType(cap_piece) == KNIGHT || GetPieceType(cap_piece) == BISHOP)
         {
-            minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            // minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         }
         else if (GetPieceType(cap_piece) == ROOK || GetPieceType(cap_piece) == QUEEN)
         {
-            major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            // major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         }
 
         break;
@@ -624,16 +624,16 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        // minor_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         non_pawn_key[!stm] ^= Zobrist::piece_square(cap_piece, move.GetTo());
         if (GetPieceType(cap_piece) == KNIGHT || GetPieceType(cap_piece) == BISHOP)
         {
-            minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            // minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         }
         else if (GetPieceType(cap_piece) == ROOK || GetPieceType(cap_piece) == QUEEN)
         {
-            major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            // major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         }
 
         break;
@@ -652,16 +652,16 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        // major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         non_pawn_key[!stm] ^= Zobrist::piece_square(cap_piece, move.GetTo());
         if (GetPieceType(cap_piece) == KNIGHT || GetPieceType(cap_piece) == BISHOP)
         {
-            minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            // minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         }
         else if (GetPieceType(cap_piece) == ROOK || GetPieceType(cap_piece) == QUEEN)
         {
-            major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            // major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         }
 
         break;
@@ -680,16 +680,16 @@ void BoardState::ApplyMove(Move move)
         key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         pawn_key ^= Zobrist::piece_square(pawn_piece, move.GetFrom());
         non_pawn_key[stm] ^= Zobrist::piece_square(promo_piece, move.GetTo());
-        major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
+        // major_key ^= Zobrist::piece_square(promo_piece, move.GetTo());
         key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         non_pawn_key[!stm] ^= Zobrist::piece_square(cap_piece, move.GetTo());
         if (GetPieceType(cap_piece) == KNIGHT || GetPieceType(cap_piece) == BISHOP)
         {
-            minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            // minor_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         }
         else if (GetPieceType(cap_piece) == ROOK || GetPieceType(cap_piece) == QUEEN)
         {
-            major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
+            // major_key ^= Zobrist::piece_square(cap_piece, move.GetTo());
         }
 
         break;
@@ -713,8 +713,8 @@ void BoardState::ApplyMove(Move move)
     assert(pawn_key == Zobrist::pawn_key(*this));
     assert(non_pawn_key[WHITE] == Zobrist::non_pawn_key(*this, WHITE));
     assert(non_pawn_key[BLACK] == Zobrist::non_pawn_key(*this, BLACK));
-    assert(minor_key == Zobrist::minor_key(*this));
-    assert(major_key == Zobrist::major_key(*this));
+    // assert(minor_key == Zobrist::minor_key(*this));
+    // assert(major_key == Zobrist::major_key(*this));
 }
 
 void BoardState::ApplyNullMove()
@@ -736,8 +736,8 @@ void BoardState::ApplyNullMove()
     assert(pawn_key == Zobrist::pawn_key(*this));
     assert(non_pawn_key[WHITE] == Zobrist::non_pawn_key(*this, WHITE));
     assert(non_pawn_key[BLACK] == Zobrist::non_pawn_key(*this, BLACK));
-    assert(minor_key == Zobrist::minor_key(*this));
-    assert(major_key == Zobrist::major_key(*this));
+    // assert(minor_key == Zobrist::minor_key(*this));
+    // assert(major_key == Zobrist::major_key(*this));
 }
 
 MoveFlag BoardState::GetMoveFlag(Square from, Square to) const

--- a/src/BoardState.h
+++ b/src/BoardState.h
@@ -89,12 +89,13 @@ public:
 private:
     void RecalculateWhiteBlackBoards();
 
+public:
     uint64_t key = 0;
     uint64_t pawn_key = 0;
     std::array<uint64_t, 2> non_pawn_key {};
-    uint64_t minor_key = 0;
-    uint64_t major_key = 0;
-
+    // uint64_t minor_key = 0;
+    // uint64_t major_key = 0;
+private:
     std::array<uint64_t, N_PIECES> board = {};
     std::array<uint64_t, 2> side_bb = {};
 };

--- a/src/BoardState.h
+++ b/src/BoardState.h
@@ -91,6 +91,9 @@ private:
 
     uint64_t key = 0;
     uint64_t pawn_key = 0;
+    std::array<uint64_t, 2> non_pawn_key {};
+    uint64_t minor_key = 0;
+    uint64_t major_key = 0;
 
     std::array<uint64_t, N_PIECES> board = {};
     std::array<uint64_t, 2> side_bb = {};

--- a/src/History.cpp
+++ b/src/History.cpp
@@ -110,3 +110,23 @@ Score PawnCorrHistory::get_correction_score(const GameState& position) const
 {
     return *get(position) / eval_scale;
 }
+
+int16_t* NonPawnCorrHistory::get(const GameState& position, Players side)
+{
+    const auto& stm = position.Board().stm;
+    const auto hash = position.Board().non_pawn_key[side];
+    return &table[stm][hash % hash_table_size];
+}
+
+void NonPawnCorrHistory::add(const GameState& position, Players side, int depth, int eval_diff)
+{
+    auto* entry = get(position, side);
+
+    int change = std::clamp(eval_diff * depth / 8, -correction_max * eval_scale / 4, correction_max * eval_scale / 4);
+    *entry += change - *entry * abs(change) / (correction_max * eval_scale);
+}
+
+Score NonPawnCorrHistory::get_correction_score(const GameState& position, Players side)
+{
+    return *get(position, side) / eval_scale;
+}

--- a/src/History.h
+++ b/src/History.h
@@ -115,6 +115,27 @@ private:
     static constexpr int eval_scale = 16384 / correction_max;
 };
 
+struct NonPawnCorrHistory
+{
+    // must be a power of 2, for fast hash lookup
+    static constexpr size_t hash_table_size = 16384;
+    static constexpr int correction_max = 16;
+
+    int16_t table[N_PLAYERS][hash_table_size] = {};
+
+    int16_t* get(const GameState& position, Players side);
+    void add(const GameState& position, Players side, int depth, int eval_diff);
+    Score get_correction_score(const GameState& position, Players side);
+
+    constexpr void reset()
+    {
+        memset(table, 0, sizeof(table));
+    }
+
+private:
+    static constexpr int eval_scale = 16384 / correction_max;
+};
+
 template <typename... tables>
 class History
 {

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -681,7 +681,12 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
         return eval.value() * (288 - (int)position.Board().fifty_move_count) / 256;
     };
 
-    auto eval_corr_history = [&](Score eval) { return eval + local.pawn_corr_hist.get_correction_score(position); };
+    auto eval_corr_history = [&](Score eval)
+    {
+        return eval + local.pawn_corr_hist.get_correction_score(position)
+            + local.non_pawn_corr[WHITE].get_correction_score(position, WHITE)
+            + local.non_pawn_corr[BLACK].get_correction_score(position, BLACK);
+    };
 
     if (tt_entry)
     {
@@ -996,7 +1001,10 @@ Score NegaScout(GameState& position, SearchStackState* ss, SearchLocalState& loc
         && !(bound == SearchResultType::LOWER_BOUND && score <= raw_eval)
         && !(bound == SearchResultType::UPPER_BOUND && score >= raw_eval))
     {
-        local.pawn_corr_hist.add(position, depth, score.value() - raw_eval.value());
+        const auto adj = score.value() - raw_eval.value();
+        local.pawn_corr_hist.add(position, depth, adj);
+        local.non_pawn_corr[WHITE].add(position, WHITE, depth, adj);
+        local.non_pawn_corr[BLACK].add(position, BLACK, depth, adj);
     }
 
     // Step 21: Update transposition table

--- a/src/SearchData.cpp
+++ b/src/SearchData.cpp
@@ -100,6 +100,8 @@ void SearchLocalState::ResetNewGame()
     loud_history.reset();
     cont_hist.reset();
     pawn_corr_hist.reset();
+    non_pawn_corr[WHITE].reset();
+    non_pawn_corr[BLACK].reset();
 }
 
 SearchSharedState::SearchSharedState(Uci& uci)

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -118,6 +118,7 @@ public:
     LoudHistory loud_history;
     ContinuationHistory cont_hist;
     PawnCorrHistory pawn_corr_hist;
+    std::array<NonPawnCorrHistory, 2> non_pawn_corr;
     int sel_septh = 0;
     atomic_relaxed<int64_t> tb_hits = 0;
     atomic_relaxed<int64_t> nodes = 0;

--- a/src/Zobrist.cpp
+++ b/src/Zobrist.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <random>
 
 #include "BitBoardDefine.h"
@@ -96,6 +97,63 @@ uint64_t pawn_key(const BoardState& board)
     while (black != 0)
     {
         key ^= piece_square(BLACK_PAWN, LSBpop(black));
+    }
+
+    return key;
+}
+
+uint64_t non_pawn_key(const BoardState& board, Players side)
+{
+    uint64_t key = 0;
+
+    for (int i = KNIGHT; i <= KING; i++)
+    {
+        const auto piece = Piece(static_cast<PieceTypes>(i), side);
+        uint64_t bitboard = board.GetPieceBB(piece);
+        while (bitboard != 0)
+        {
+            key ^= piece_square(piece, LSBpop(bitboard));
+        }
+    }
+
+    return key;
+}
+
+uint64_t minor_key(const BoardState& board)
+{
+    uint64_t key = 0;
+
+    for (const auto side : { WHITE, BLACK })
+    {
+        for (const auto piece_type : { KNIGHT, BISHOP })
+        {
+            const auto piece = Piece(piece_type, side);
+            uint64_t bitboard = board.GetPieceBB(piece);
+            while (bitboard != 0)
+            {
+                key ^= piece_square(piece, LSBpop(bitboard));
+            }
+        }
+    }
+
+    return key;
+}
+
+uint64_t major_key(const BoardState& board)
+{
+    uint64_t key = 0;
+
+    for (const auto side : { WHITE, BLACK })
+    {
+        for (const auto piece_type : { ROOK, QUEEN })
+        {
+            const auto piece = Piece(piece_type, side);
+            uint64_t bitboard = board.GetPieceBB(piece);
+            while (bitboard != 0)
+            {
+                key ^= piece_square(piece, LSBpop(bitboard));
+            }
+        }
     }
 
     return key;

--- a/src/Zobrist.h
+++ b/src/Zobrist.h
@@ -14,6 +14,9 @@ uint64_t castle(Square square);
 
 uint64_t key(const BoardState& board);
 uint64_t pawn_key(const BoardState& board);
+uint64_t non_pawn_key(const BoardState& board, Players side);
+uint64_t minor_key(const BoardState& board);
+uint64_t major_key(const BoardState& board);
 
 uint64_t get_fifty_move_adj_key(const BoardState& board);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.27.1";
+constexpr std::string_view version = "12.28.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 1.58 +- 1.42 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.39 (-2.94, 2.94) [0.00, 3.00]
Games | N: 59048 W: 14006 L: 13737 D: 31305
Penta | [134, 6884, 15231, 7129, 146]
http://chess.grantnet.us/test/39458/
```
```
Elo   | -2.70 +- 2.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 18530 W: 4419 L: 4563 D: 9548
Penta | [130, 2279, 4588, 2141, 127]
http://chess.grantnet.us/test/39457/
```