### PR TITLE
Adjust eval correction condition

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -964,7 +964,7 @@ Score NegaScout(GameState& position, SearchStackState* ss, SearchLocalState& loc
                                                : SearchResultType::EXACT;
 
     // Step 20: Adjust eval correction history
-    if (!InCheck && (bestMove != Move::Uninitialized || (!bestMove.IsCapture() && !bestMove.IsPromotion()))
+    if (!InCheck && !(bestMove.IsCapture() || bestMove.IsPromotion())
         && !(bound == SearchResultType::LOWER_BOUND && score <= raw_eval)
         && !(bound == SearchResultType::UPPER_BOUND && score >= raw_eval))
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.19.2";
+constexpr std::string_view version = "12.19.3";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | -0.32 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 56782 W: 13630 L: 13683 D: 29469
Penta | [391, 6858, 13952, 6793, 397]
```