### PR TITLE
Use partial selection sort to speedup StagedMoveGeneration

### DIFF
--- a/src/StagedMoveGenerator.h
+++ b/src/StagedMoveGenerator.h
@@ -56,8 +56,8 @@ public:
     }
 
 private:
-    void OrderQuietMoves(ExtendedMoveList& moves);
-    void OrderLoudMoves(ExtendedMoveList& moves);
+    void ScoreQuietMoves(ExtendedMoveList& moves);
+    void ScoreLoudMoves(ExtendedMoveList& moves);
 
     // Data needed for use in ordering or generating moves
     const GameState& position;
@@ -71,6 +71,7 @@ private:
     // Data uses for keeping track of internal values
     Stage stage;
     ExtendedMoveList::iterator current;
+    ExtendedMoveList::iterator sorted_end;
 
     const Move TTmove = Move::Uninitialized;
     Move Killer1 = Move::Uninitialized;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.19.4";
+constexpr std::string_view version = "12.20.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 4.04 +- 3.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.05 (-2.94, 2.94) [0.00, 3.00]
Games | N: 13320 W: 3291 L: 3136 D: 6893
Penta | [73, 1461, 3454, 1582, 90]
http://chess.grantnet.us/test/39133/
```