### PR TITLE
Fix 50 move rule edge case handling

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -282,10 +282,24 @@ std::optional<Score> init_search_node(const GameState& position, const int dista
         return 0;
     }
 
-    // Draw randomness as in https://github.com/Luecx/Koivisto/commit/c8f01211c290a582b69e4299400b667a7731a9f7 with
-    // permission from Koivisto authors. The condition > 100 is used because the 100th move could give checkmate.
-    if (position.is_repitition(distance_from_root) || position.Board().fifty_move_count > 100)
+    // Draw randomness as in https://github.com/Luecx/Koivisto/commit/c8f01211c290a582b69e4299400b667a7731a9f7
+    if (position.is_repitition(distance_from_root))
     {
+        return 8 - (local.nodes & 0b1111);
+    }
+
+    if (position.Board().fifty_move_count >= 100)
+    {
+        if (IsInCheck(position.Board()))
+        {
+            BasicMoveList moves;
+            LegalMoves(position.Board(), moves);
+            if (moves.empty())
+            {
+                return Score::mated_in(distance_from_root);
+            }
+        }
+
         return 8 - (local.nodes & 0b1111);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.21.0";
+constexpr std::string_view version = "12.21.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 0.01 +- 2.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 28940 W: 6967 L: 6966 D: 15007
Penta | [176, 3285, 7542, 3296, 171]
http://chess.grantnet.us/test/39153/
```