### PR TITLE
Update default network to 87b3ca62.nn

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,8 +3,8 @@ LLVM_PROFDATA := llvm-profdata
 BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
-EVALURL = https://github.com/KierenP/Halogen-Networks/blob/feefcc3817f7e9b0fd8a94dbb9756ce8b805a73a/6913d330.nn?raw=true
-EVALFILE = $(BUILD_DIR)/6913d330.nn
+EVALURL = https://github.com/KierenP/Halogen-Networks/blob/bf5d52a57e22f5f3d0b7736039e705458a029c1a/87b3ca62.nn?raw=true
+EVALFILE = $(BUILD_DIR)/87b3ca62.nn
 
 SRCS := \
 	BoardState.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.21.1";
+constexpr std::string_view version = "12.22.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
The datasets used were as follows:

| File       | Origin                                        | Fens |
|------------|-----------------------------------------------|------|
| datagen3+4 | 11.24.0 + 768-512x2-1_r18_g2771316.nn         | 0.6B |
| datagen5+6 | 11.30.0 + bullet_r10_768-512x2-1-epoch100.bin | 0.7B |
| datagen7..13| 12.0.0                                        | 4.0B |

The combined dataset was [filtered](https://github.com/KierenP/Halogen/blob/e49385f990a750a6bbbaf7320a0b47d010be116e/src/datagen/filter.h) to remove positions where the best move is a capture, promotion, or positions in check. The dataset was then shuffled, and finally [rescored](https://github.com/KierenP/Halogen/blob/e49385f990a750a6bbbaf7320a0b47d010be116e/src/datagen/syzygy_rescore.h)

The bullet trainer was used with [config](https://github.com/KierenP/bullet/blob/4378221194b7e08187ab9e37f9c4b3d1100b34cf/examples/halogen.rs).

-----------------------------

```
Elo   | 1.84 +- 1.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.80 (-2.94, 2.94) [0.00, 3.00]
Games | N: 65126 W: 16964 L: 16619 D: 31543
Penta | [604, 7905, 15285, 8080, 689]
http://chess.grantnet.us/test/39154/
```



















