### PR TITLE
Update default network to b425ef8d.nn

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,8 +3,8 @@ LLVM_PROFDATA := llvm-profdata
 BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
-EVALURL = https://github.com/KierenP/Halogen-Networks/blob/bf5d52a57e22f5f3d0b7736039e705458a029c1a/87b3ca62.nn?raw=true
-EVALFILE = $(BUILD_DIR)/87b3ca62.nn
+EVALURL = https://github.com/KierenP/Halogen-Networks/blob/f9832830c55ee68cf0c4a0663b9af58ef668ea4f/b425ef8d.nn?raw=true
+EVALFILE = $(BUILD_DIR)/b425ef8d.nn
 
 SRCS := \
 	BoardState.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.23.0";
+constexpr std::string_view version = "12.24.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
Exactly the same training procedure as r46 (previous master) but with 1000 SBs rather than 400 SBs.

----------------------------

The datasets used were as follows:

| File       | Origin                                        | Fens |
|------------|-----------------------------------------------|------|
| datagen3+4 | 11.24.0 + 768-512x2-1_r18_g2771316.nn         | 0.6B |
| datagen5+6 | 11.30.0 + bullet_r10_768-512x2-1-epoch100.bin | 0.7B |
| datagen7..13| 12.0.0                                        | 4.0B |

The combined dataset was [filtered](https://github.com/KierenP/Halogen/blob/e49385f990a750a6bbbaf7320a0b47d010be116e/src/datagen/filter.h) to remove positions where the best move is a capture, promotion, or positions in check. The dataset was then shuffled, and finally [rescored](https://github.com/KierenP/Halogen/blob/e49385f990a750a6bbbaf7320a0b47d010be116e/src/datagen/syzygy_rescore.h)

The bullet trainer was used with [config](https://github.com/KierenP/bullet/blob/dd916f6a77ab40a2ab00e2bd4ebe909908815281/examples/halogen.rs).

-----------------------------

```
Elo   | 4.38 +- 2.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 17074 W: 4293 L: 4078 D: 8703
Penta | [56, 1941, 4334, 2144, 62]
http://chess.grantnet.us/test/39385/
```

```
Elo   | 9.81 +- 4.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 7476 W: 1987 L: 1776 D: 3713
Penta | [52, 849, 1752, 1006, 79]
http://chess.grantnet.us/test/39384/
```