### PR TITLE
Apply negative extensions for non-singular cut nodes

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -526,7 +526,7 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
     // might decide to reduce the TT move search. The TT move doesn't have LMR applied, to heuristically this
     // reduction can be thought of as evening out the search depth between the moves and not favouring the TT
     // move as heavily.
-    else if (tt_score >= beta)
+    else if (tt_score >= beta || cut_node)
     {
         extensions += -1;
     }


### PR DESCRIPTION
```
Elo   | 7.12 +- 4.13 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.21 (-2.94, 2.94) [0.00, 3.00]
Games | N: 7170 W: 1753 L: 1606 D: 3811
Penta | [14, 808, 1802, 939, 22]
http://chess.grantnet.us/test/39439/
```
```
Elo   | 5.40 +- 3.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 14018 W: 3462 L: 3244 D: 7312
Penta | [86, 1546, 3534, 1750, 93]
http://chess.grantnet.us/test/39431/
```