### PR TITLE
Use fail-medium for RFP fail-high cutoffs

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -829,7 +829,7 @@ Score NegaScout(GameState& position, SearchStackState* ss, SearchLocalState& loc
     // If the static score is far above beta we fail high.
     if (!pv_node && !InCheck && ss->singular_exclusion == Move::Uninitialized && depth < 8 && eval - 93 * depth >= beta)
     {
-        return beta;
+        return (beta.value() + eval.value()) / 2;
     }
 
     // Step 7: Null move pruning

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.28.0";
+constexpr std::string_view version = "12.29.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 7.79 +- 3.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 9416 W: 2382 L: 2171 D: 4863
Penta | [60, 1060, 2272, 1241, 75]
http://chess.grantnet.us/test/39470/
```
```
Elo   | 7.84 +- 3.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 8552 W: 2086 L: 1893 D: 4573
Penta | [19, 942, 2159, 1139, 17]
http://chess.grantnet.us/test/39491/
```