### PR TITLE
Use fail-medium for q-search fail-high cutoffs

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -1104,6 +1104,11 @@ Score Quiescence(GameState& position, SearchStackState* ss, SearchLocalState& lo
         return score;
     }
 
+    if (score >= beta)
+    {
+        score = (score.value() + beta.value()) / 2;
+    }
+
     const auto bound = score <= original_alpha ? SearchResultType::UPPER_BOUND
         : score >= beta                        ? SearchResultType::LOWER_BOUND
                                                : SearchResultType::EXACT;


### PR DESCRIPTION
```
Elo   | 1.12 +- 0.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 207212 W: 50246 L: 49578 D: 107388
Penta | [1247, 24771, 51046, 25151, 1391]
http://chess.grantnet.us/test/39471/
```