### PR TITLE
Use 'improving' heuristic to more optimistically apply RFP

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -831,7 +831,8 @@ Score NegaScout(GameState& position, SearchStackState* ss, SearchLocalState& loc
     // Step 6: Static null move pruning (a.k.a reverse futility pruning)
     //
     // If the static score is far above beta we fail high.
-    if (!pv_node && !InCheck && ss->singular_exclusion == Move::Uninitialized && depth < 8 && eval - 93 * depth >= beta)
+    if (!pv_node && !InCheck && ss->singular_exclusion == Move::Uninitialized && depth < 8
+        && eval - 93 * (depth - improving) >= beta)
     {
         return (beta.value() + eval.value()) / 2;
     }
@@ -894,7 +895,7 @@ Score NegaScout(GameState& position, SearchStackState* ss, SearchLocalState& loc
         //
         // At low depths, we limit the number of candidate quiet moves. This is a more aggressive form of futility
         // pruning
-        if (depth < 6 && seen_moves >= 3 + 3 * depth * (1 + improving) && score > Score::tb_loss_in(MAX_DEPTH))
+        if (depth < 6 && seen_moves >= 3 + 3 * depth && score > Score::tb_loss_in(MAX_DEPTH))
         {
             gen.SkipQuiets();
         }

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -66,6 +66,8 @@ struct SearchStackState
     std::array<PieceMoveHistory*, ContinuationHistory::cont_hist_depth> cont_hist_subtables = {};
 
     Accumulator acc;
+
+    Score adjusted_eval = 0;
 };
 
 class SearchStack

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.30.0";
+constexpr std::string_view version = "12.31.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 10.23 +- 4.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 6656 W: 1655 L: 1459 D: 3542
Penta | [27, 690, 1726, 830, 55]
http://chess.grantnet.us/test/39496/
```
```
Elo   | 12.48 +- 4.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 5012 W: 1226 L: 1046 D: 2740
Penta | [6, 498, 1324, 666, 12]
http://chess.grantnet.us/test/39500/
```