### PR TITLE
Use git lfs to host network files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+network/b425ef8d.nn filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/fastchess.yml
+++ b/.github/workflows/fastchess.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           path: Halogen
+          lfs: true
 
       - name: Build
         working-directory: Halogen/src

--- a/.github/workflows/matetrack.yml
+++ b/.github/workflows/matetrack.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           path: Halogen
+          lfs: true
 
       - name: Build Halogen
         working-directory: Halogen/src

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,6 +28,7 @@ jobs:
         # This ensures we can extract the expected bench from the commit message.
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          lfs: true
 
       - name: Install
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,6 +24,7 @@ jobs:
         # This ensures we can extract the expected bench from the commit message.
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          lfs: true
 
       - uses: msys2/setup-msys2@v2.22.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 build/*
 bin/*
-*.nn

--- a/network/b425ef8d.nn
+++ b/network/b425ef8d.nn
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b425ef8d2172703bdffd2973bac8ff4f3a13455022fdd57c3ea8f13f20578c56
+size 12617792

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,8 +3,7 @@ LLVM_PROFDATA := llvm-profdata
 BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
-EVALURL = https://github.com/KierenP/Halogen-Networks/blob/f9832830c55ee68cf0c4a0663b9af58ef668ea4f/b425ef8d.nn?raw=true
-EVALFILE = $(BUILD_DIR)/b425ef8d.nn
+EVALFILE := ../network/b425ef8d.nn
 
 SRCS := \
 	BoardState.cpp \
@@ -248,16 +247,10 @@ release:
 $(EVALFILE):
 	@ mkdir -p $(dir $@)
 	@echo "net: $(EVALFILE)"
-	$(eval curl_or_wget := $(shell if hash curl 2>/dev/null; then echo "curl -skL"; elif hash wget 2>/dev/null; then echo "wget -qO-"; fi))
 	@if test -f "$(EVALFILE)"; then \
         echo "Already available."; \
 	else \
-		if [ "x$(curl_or_wget)" = "x" ]; then \
-			echo "Automatic download failed: neither curl nor wget is installed. Install one of these tools or download the net manually"; exit 1; \
-		else \
-			echo "Downloading... $(EVALURL)"; $(curl_or_wget) $(EVALURL) > $(EVALFILE);\
-			echo "Download complete."; \
-		fi; \
+		git lfs pull --include "$(EVALFILE)"; \
 	fi;
 
 #----------------------------------------------------------------------------------------------------------------------

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,8 @@ LLVM_PROFDATA := llvm-profdata
 BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
-EVALFILE := ../network/b425ef8d.nn
+NETWORK = b425ef8d.nn
+EVALFILE := ../network/$(NETWORK)
 
 SRCS := \
 	BoardState.cpp \
@@ -250,7 +251,7 @@ $(EVALFILE):
 	@if test -f "$(EVALFILE)"; then \
         echo "Already available."; \
 	else \
-		git lfs pull --include "$(EVALFILE)"; \
+		git lfs pull --include "$(NETWORK)"; \
 	fi;
 
 #----------------------------------------------------------------------------------------------------------------------

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.31.1";
+constexpr std::string_view version = "12.31.2";
 
 void PrintVersion()
 {


### PR DESCRIPTION
https://github.com/KierenP/Halogen-Networks will continue to exist in order to support building older versions of Halogen, but newer versions will leverage git-lfs