### PR TITLE
Fix Syzygy WDL probe during search

### DIFF
--- a/src/EGTB.cpp
+++ b/src/EGTB.cpp
@@ -76,7 +76,7 @@ std::optional<Score> Syzygy::probe_wdl_search(const BoardState& board, int dista
         board.stm == WHITE);
     // clang-format on
 
-    if (probe == TB_RESULT_FAILED || probe == TB_RESULT_STALEMATE || probe == TB_RESULT_CHECKMATE)
+    if (probe == TB_RESULT_FAILED)
     {
         return std::nullopt;
     }

--- a/src/EGTB.cpp
+++ b/src/EGTB.cpp
@@ -137,13 +137,13 @@ std::optional<RootProbeResult> Syzygy::probe_dtz_root(const BoardState& board)
         return std::nullopt;
     }
 
-    std::ranges::stable_sort(root_moves.moves, std::greater<> {}, &TbRootMove::tbRank);
+    auto probe_moves = std::ranges::subrange { root_moves.moves, root_moves.moves + root_moves.size };
+    std::ranges::stable_sort(probe_moves, std::greater<> {}, &TbRootMove::tbRank);
     RootProbeResult result;
 
-    for (unsigned int i = 0; i < root_moves.size; i++)
+    for (const auto& move : probe_moves)
     {
-        result.root_moves.emplace_back(
-            extract_pyrrhic_move(board, root_moves.moves[i].move), root_moves.moves[i].tbRank);
+        result.root_moves.emplace_back(extract_pyrrhic_move(board, move.move), move.tbRank);
     }
 
     return result;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.31.2";
+constexpr std::string_view version = "12.31.3";
 
 void PrintVersion()
 {


### PR DESCRIPTION
`TB_RESULT_STALEMATE` and `TB_RESULT_CHECKMATE` don't get returned by `tb_probe_wdl` and conflict with legitimate draw and win scores that are returned.

This also fixes an additional bug with `tb_probe_root_dtz`, where the results were being incorrectly sorted invoking undefined behaviour.

```
Elo   | -1.11 +- 4.93 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=8MB
Games | N: 5012 W: 1154 L: 1170 D: 2688
Penta | [20, 581, 1324, 557, 24]
http://chess.grantnet.us/test/39518/
```