### PR TITLE
Update default network to 4ed21ecb.nn

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-network/b425ef8d.nn filter=lfs diff=lfs merge=lfs -text
+network/4ed21ecb.nn filter=lfs diff=lfs merge=lfs -text

--- a/network/4ed21ecb.nn
+++ b/network/4ed21ecb.nn
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ed21ecb0bd53d3fa8713901ec79b52d90211b342a2bbf03df26873fbcc5f713
+size 12617792

--- a/network/b425ef8d.nn
+++ b/network/b425ef8d.nn
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b425ef8d2172703bdffd2973bac8ff4f3a13455022fdd57c3ea8f13f20578c56
-size 12617792

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ LLVM_PROFDATA := llvm-profdata
 BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
-NETWORK = b425ef8d.nn
+NETWORK = 4ed21ecb.nn
 EVALFILE := ../network/$(NETWORK)
 
 SRCS := \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.31.3";
+constexpr std::string_view version = "12.32.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
Trained r70 using 0.4 constant WDL rather than 0.3 constant WDL used by r62. Then trained r71 using 0.5 constant WDL.

----------------------------

The datasets used were as follows:

| File       | Origin                                        | Fens |
|------------|-----------------------------------------------|------|
| datagen3+4 | 11.24.0 + 768-512x2-1_r18_g2771316.nn         | 0.6B |
| datagen5+6 | 11.30.0 + bullet_r10_768-512x2-1-epoch100.bin | 0.7B |
| datagen7..13| 12.0.0                                        | 4.0B |

The combined dataset was converted into viribinpack using [link](https://github.com/KierenP/Halogen/blob/ebd0b3572c524c91234d2629f370eebf833f92a3/src/datagen/convert_to_viribinpack.h), the files were interleaved.

The bullet trainer was used with [config](https://github.com/KierenP/bullet/blob/7d52b20f9efa2c746b5ecdbfa71be5fde82227e9/examples/halogen.rs).

-----------------------------

r70 vs r62
```
Elo   | 2.66 +- 1.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 36066 W: 9106 L: 8830 D: 18130
Penta | [295, 4242, 8672, 4540, 284]
http://chess.grantnet.us/test/39508/
```
r70 vs r62
```
Elo   | 9.15 +- 4.08 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 7292 W: 1830 L: 1638 D: 3824
Penta | [21, 773, 1870, 957, 25]
http://chess.grantnet.us/test/39511/
```

r71 vs r70
```
Elo   | 0.79 +- 2.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -0.04 (-2.94, 2.94) [0.00, 3.00]
Games | N: 22524 W: 5674 L: 5623 D: 11227
Penta | [179, 2713, 5424, 2770, 176]
http://chess.grantnet.us/test/39512/
```
```
Elo   | 4.01 +- 2.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 18986 W: 4637 L: 4418 D: 9931
Penta | [63, 2150, 4838, 2389, 53]
http://chess.grantnet.us/test/39513/
```