### PR TITLE
Avoid returning false mate scores from multi-cut

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -519,8 +519,8 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
 
     // Multi-Cut: In this case, we have proven that at least one other move appears to fail high, along with
     // the TT move having a LOWER_BOUND score of significantly above beta. In this case, we can assume the node
-    // will fail high and we return a soft bound.
-    else if (sbeta >= beta)
+    // will fail high and we return a soft bound. Avoid returning false mate scores.
+    else if (sbeta >= beta && std::abs(sbeta) < Score::tb_win_in(MAX_DEPTH))
     {
         return sbeta;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.32.0";
+constexpr std::string_view version = "12.32.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 0.65 +- 1.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 43048 W: 10263 L: 10183 D: 22602
Penta | [222, 4740, 11506, 4848, 208]
http://chess.grantnet.us/test/39547/
```