### PR TITLE
Simplify condition for limiting singular extensions

### DIFF
--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -508,7 +508,7 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
     ss->singular_exclusion = Move::Uninitialized;
 
     // If the TT move is singular, we extend the search by one or more plies depending on how singular it appears
-    if (!pv_node && se_score < sbeta - 11)
+    if (!pv_node && se_score < sbeta - 11 && ss->distance_from_root < local.curr_depth)
     {
         extensions += 2;
     }

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -310,8 +310,6 @@ std::optional<Score> init_search_node(const GameState& position, const int dista
         return 8 - (local.nodes & 0b1111);
     }
 
-    ss->multiple_extensions = (ss - 1)->multiple_extensions;
-
     if (!ss->nmp_verification_root)
     {
         ss->nmp_verification_depth = (ss - 1)->nmp_verification_depth;
@@ -509,14 +507,10 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
 
     ss->singular_exclusion = Move::Uninitialized;
 
-    // Extending the SE idea, if the score is far below sbeta we extend by two. To avoid extending too much down
-    // forced lines we limit the number of multiple_extensions down one line. We focus on non_pv nodes becuase
-    // in particular we want to verify cut nodes which rest on a single good move and ensure we haven't
-    // overlooked a potential non-pv line.
-    if (!pv_node && se_score < sbeta - 11 && ss->multiple_extensions < 7)
+    // If the TT move is singular, we extend the search by one or more plies depending on how singular it appears
+    if (!pv_node && se_score < sbeta - 11)
     {
         extensions += 2;
-        ss->multiple_extensions++;
     }
     else if (se_score < sbeta)
     {

--- a/src/SearchData.h
+++ b/src/SearchData.h
@@ -47,7 +47,6 @@ struct SearchStackState
     uint64_t threat_mask = EMPTY;
 
     Move singular_exclusion = Move::Uninitialized;
-    int multiple_extensions = 0;
 
     int nmp_verification_depth = 0;
     bool nmp_verification_root = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "Cuckoo.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "12.35.1";
+constexpr std::string_view version = "12.35.2";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | -0.63 +- 1.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.29 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 49326 W: 11169 L: 11258 D: 26899
Penta | [83, 5747, 13095, 5652, 86]
http://chess.grantnet.us/test/39580/
```