### PR TITLE
Research alpha raising nodes that fail high above beta

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -648,7 +648,7 @@ Score search_move(GameState& position, SearchStackState* ss, SearchLocalState& l
     }
 
     // If the ZW search was skipped or failed high, we do a full depth full width search
-    if (pv_node && (seen_moves == 1 || (search_score > alpha && search_score < beta)))
+    if (pv_node && (seen_moves == 1 || search_score > alpha))
     {
         search_score = -search<SearchType::PV>(position, ss + 1, local, shared, new_depth, -beta, -alpha, false);
     }


### PR DESCRIPTION
```
Elo   | 0.27 +- 1.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 119504 W: 28431 L: 28339 D: 62734
Penta | [652, 14262, 29835, 14348, 655]
http://chess.grantnet.us/test/39655/
```