### PR TITLE
Fix correction history implementation

### DIFF
--- a/src/search/history.cpp
+++ b/src/search/history.cpp
@@ -60,8 +60,8 @@ void PawnCorrHistory::add(const GameState& position, int depth, int eval_diff)
 {
     auto* entry = get(position);
 
-    int change
-        = std::clamp(eval_diff * depth / 8, -correction_max * eval_scale() / 4, correction_max * eval_scale() / 4);
+    int change = std::clamp(
+        eval_diff * depth * 128 / 64, -correction_max * eval_scale() / 4, correction_max * eval_scale() / 4);
     *entry += change - *entry * abs(change) / (correction_max * eval_scale());
 }
 
@@ -81,8 +81,8 @@ void NonPawnCorrHistory::add(const GameState& position, Side side, int depth, in
 {
     auto* entry = get(position, side);
 
-    int change
-        = std::clamp(eval_diff * depth / 8, -correction_max * eval_scale() / 4, correction_max * eval_scale() / 4);
+    int change = std::clamp(
+        eval_diff * depth * 128 / 64, -correction_max * eval_scale() / 4, correction_max * eval_scale() / 4);
     *entry += change - *entry * abs(change) / (correction_max * eval_scale());
 }
 

--- a/src/search/history.h
+++ b/src/search/history.h
@@ -94,7 +94,7 @@ struct PawnCorrHistory
 {
     // must be a power of 2, for fast hash lookup
     static constexpr size_t pawn_hash_table_size = 16384;
-    static TUNEABLE_CONSTANT int correction_max = 18;
+    static TUNEABLE_CONSTANT int correction_max = 64;
 
     int16_t table[N_SIDES][pawn_hash_table_size] = {};
 
@@ -120,7 +120,7 @@ struct NonPawnCorrHistory
 {
     // must be a power of 2, for fast hash lookup
     static constexpr size_t hash_table_size = 16384;
-    static TUNEABLE_CONSTANT int correction_max = 19;
+    static TUNEABLE_CONSTANT int correction_max = 64;
 
     int16_t table[N_SIDES][hash_table_size] = {};
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -1024,10 +1024,10 @@ Score search(GameState& position, SearchStackState* ss, SearchLocalState& local,
 
     // Step 20: Adjust eval correction history
     if (!InCheck && !(bestMove.is_capture() || bestMove.is_promotion())
-        && !(bound == SearchResultType::LOWER_BOUND && score <= raw_eval)
-        && !(bound == SearchResultType::UPPER_BOUND && score >= raw_eval))
+        && !(bound == SearchResultType::LOWER_BOUND && score <= ss->adjusted_eval)
+        && !(bound == SearchResultType::UPPER_BOUND && score >= ss->adjusted_eval))
     {
-        const auto adj = score.value() - raw_eval.value();
+        const auto adj = score.value() - ss->adjusted_eval.value();
         local.pawn_corr_hist.add(position, depth, adj);
         local.non_pawn_corr[WHITE].add(position, WHITE, depth, adj);
         local.non_pawn_corr[BLACK].add(position, BLACK, depth, adj);


### PR DESCRIPTION
```
Elo   | 23.73 +- 6.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2728 W: 728 L: 542 D: 1458
Penta | [5, 254, 670, 420, 15]
http://chess.grantnet.us/test/39705/
```
```
Elo   | 22.61 +- 6.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 2908 W: 807 L: 618 D: 1483
Penta | [10, 280, 696, 447, 21]
http://chess.grantnet.us/test/39704/
```