### PR TITLE
SPSA LTC tune

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "13.2.0";
+constexpr std::string_view version = "13.3.0";
 
 void PrintVersion()
 {

--- a/src/movegen/list.h
+++ b/src/movegen/list.h
@@ -31,7 +31,7 @@ struct ExtendedMove
     };
 
     Move move;
-    int16_t score;
+    int score;
 };
 
 // TODO: 256?

--- a/src/search/history.cpp
+++ b/src/search/history.cpp
@@ -60,8 +60,8 @@ void PawnCorrHistory::add(const GameState& position, int depth, int eval_diff)
 {
     auto* entry = get(position);
 
-    int change = std::clamp(
-        eval_diff * depth * 128 / 64, -correction_max * eval_scale() / 4, correction_max * eval_scale() / 4);
+    int change = std::clamp(eval_diff * depth * corr_hist_scale / 64, -correction_max * eval_scale() / 4,
+        correction_max * eval_scale() / 4);
     *entry += change - *entry * abs(change) / (correction_max * eval_scale());
 }
 
@@ -81,8 +81,8 @@ void NonPawnCorrHistory::add(const GameState& position, Side side, int depth, in
 {
     auto* entry = get(position, side);
 
-    int change = std::clamp(
-        eval_diff * depth * 128 / 64, -correction_max * eval_scale() / 4, correction_max * eval_scale() / 4);
+    int change = std::clamp(eval_diff * depth * corr_hist_scale / 64, -correction_max * eval_scale() / 4,
+        correction_max * eval_scale() / 4);
     *entry += change - *entry * abs(change) / (correction_max * eval_scale());
 }
 

--- a/src/search/history.h
+++ b/src/search/history.h
@@ -43,7 +43,7 @@ struct HistoryTable
 
 struct PawnHistory : HistoryTable<PawnHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 9929;
+    static TUNEABLE_CONSTANT int max_value = 9864;
     static TUNEABLE_CONSTANT int scale = 35;
     static constexpr size_t pawn_states = 512;
     int16_t table[N_SIDES][pawn_states][N_PIECE_TYPES][N_SQUARES] = {};
@@ -52,15 +52,15 @@ struct PawnHistory : HistoryTable<PawnHistory>
 
 struct ThreatHistory : HistoryTable<ThreatHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 9245;
-    static TUNEABLE_CONSTANT int scale = 45;
+    static TUNEABLE_CONSTANT int max_value = 9338;
+    static TUNEABLE_CONSTANT int scale = 44;
     int16_t table[N_SIDES][2][N_SQUARES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 19732;
+    static TUNEABLE_CONSTANT int max_value = 20005;
     static TUNEABLE_CONSTANT int scale = 43;
     int16_t table[N_SIDES][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
@@ -68,7 +68,7 @@ struct CaptureHistory : HistoryTable<CaptureHistory>
 
 struct PieceMoveHistory : HistoryTable<PieceMoveHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 10537;
+    static TUNEABLE_CONSTANT int max_value = 10495;
     static TUNEABLE_CONSTANT int scale = 35;
     int16_t table[N_SIDES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
@@ -89,6 +89,8 @@ struct ContinuationHistory
         memset(table, 0, sizeof(table));
     }
 };
+
+TUNEABLE_CONSTANT int corr_hist_scale = 128;
 
 struct PawnCorrHistory
 {

--- a/src/search/history.h
+++ b/src/search/history.h
@@ -43,8 +43,8 @@ struct HistoryTable
 
 struct PawnHistory : HistoryTable<PawnHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 9864;
-    static TUNEABLE_CONSTANT int scale = 35;
+    static TUNEABLE_CONSTANT int max_value = 9923;
+    static TUNEABLE_CONSTANT int scale = 37;
     static constexpr size_t pawn_states = 512;
     int16_t table[N_SIDES][pawn_states][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
@@ -52,7 +52,7 @@ struct PawnHistory : HistoryTable<PawnHistory>
 
 struct ThreatHistory : HistoryTable<ThreatHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 9338;
+    static TUNEABLE_CONSTANT int max_value = 9463;
     static TUNEABLE_CONSTANT int scale = 44;
     int16_t table[N_SIDES][2][N_SQUARES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
@@ -60,16 +60,16 @@ struct ThreatHistory : HistoryTable<ThreatHistory>
 
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 20005;
-    static TUNEABLE_CONSTANT int scale = 43;
+    static TUNEABLE_CONSTANT int max_value = 19299;
+    static TUNEABLE_CONSTANT int scale = 41;
     int16_t table[N_SIDES][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct PieceMoveHistory : HistoryTable<PieceMoveHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 10495;
-    static TUNEABLE_CONSTANT int scale = 35;
+    static TUNEABLE_CONSTANT int max_value = 10444;
+    static TUNEABLE_CONSTANT int scale = 37;
     int16_t table[N_SIDES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
@@ -96,7 +96,7 @@ struct PawnCorrHistory
 {
     // must be a power of 2, for fast hash lookup
     static constexpr size_t pawn_hash_table_size = 16384;
-    static TUNEABLE_CONSTANT int correction_max = 64;
+    static TUNEABLE_CONSTANT int correction_max = 62;
 
     int16_t table[N_SIDES][pawn_hash_table_size] = {};
 
@@ -122,7 +122,7 @@ struct NonPawnCorrHistory
 {
     // must be a power of 2, for fast hash lookup
     static constexpr size_t hash_table_size = 16384;
-    static TUNEABLE_CONSTANT int correction_max = 64;
+    static TUNEABLE_CONSTANT int correction_max = 67;
 
     int16_t table[N_SIDES][hash_table_size] = {};
 

--- a/src/search/staged_movegen.cpp
+++ b/src/search/staged_movegen.cpp
@@ -213,9 +213,7 @@ void StagedMoveGenerator::score_quiet_moves(ExtendedMoveList& moves)
         // Quiet
         else
         {
-            int history = local.get_quiet_history(position, ss, moves[i].move);
-            moves[i].score
-                = std::clamp<int>(history, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max());
+            moves[i].score = local.get_quiet_history(position, ss, moves[i].move);
         }
     }
 }
@@ -250,9 +248,7 @@ void StagedMoveGenerator::score_loud_moves(ExtendedMoveList& moves)
         // Captures
         else
         {
-            int history = local.get_loud_history(position, ss, moves[i].move);
-            moves[i].score
-                = std::clamp<int>(history, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max());
+            moves[i].score = local.get_loud_history(position, ss, moves[i].move);
         }
     }
 }

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -4,18 +4,16 @@
 #include <cmath>
 #include <cstddef>
 
-#define TUNE
-
 #ifdef TUNE
 #define TUNEABLE_CONSTANT inline
 #else
 #define TUNEABLE_CONSTANT const inline
 #endif
 
-TUNEABLE_CONSTANT float LMR_constant = 0.5813;
-TUNEABLE_CONSTANT float LMR_depth_coeff = -0.5768;
-TUNEABLE_CONSTANT float LMR_move_coeff = 1.631;
-TUNEABLE_CONSTANT float LMR_depth_move_coeff = 0.01007;
+TUNEABLE_CONSTANT float LMR_constant = 0.3356;
+TUNEABLE_CONSTANT float LMR_depth_coeff = -0.3232;
+TUNEABLE_CONSTANT float LMR_move_coeff = 1.923;
+TUNEABLE_CONSTANT float LMR_depth_move_coeff = -0.2143;
 
 inline auto Initialise_LMR_reduction()
 {
@@ -36,52 +34,52 @@ inline auto Initialise_LMR_reduction()
 // [depth][move number]
 TUNEABLE_CONSTANT std::array<std::array<int, 64>, 64> LMR_reduction = Initialise_LMR_reduction();
 
-TUNEABLE_CONSTANT int aspiration_window_size = 12;
+TUNEABLE_CONSTANT int aspiration_window_size = 11;
 
-TUNEABLE_CONSTANT int nmp_const = 5;
+TUNEABLE_CONSTANT int nmp_const = 6;
 TUNEABLE_CONSTANT int nmp_d = 7;
-TUNEABLE_CONSTANT int nmp_s = 248;
+TUNEABLE_CONSTANT int nmp_s = 250;
 
-TUNEABLE_CONSTANT int se_d = 50;
+TUNEABLE_CONSTANT int se_d = 51;
 TUNEABLE_CONSTANT int se_de = 12;
 
-TUNEABLE_CONSTANT int lmr_h = 6611;
+TUNEABLE_CONSTANT int lmr_h = 6526;
 
-TUNEABLE_CONSTANT int fifty_mr_scale_a = 272;
-TUNEABLE_CONSTANT int fifty_mr_scale_b = 258;
+TUNEABLE_CONSTANT int fifty_mr_scale_a = 278;
+TUNEABLE_CONSTANT int fifty_mr_scale_b = 251;
 
 TUNEABLE_CONSTANT int rfp_max_d = 9;
-TUNEABLE_CONSTANT int rfp_d = 84;
+TUNEABLE_CONSTANT int rfp_d = 78;
 
 TUNEABLE_CONSTANT int lmp_max_d = 6;
-TUNEABLE_CONSTANT int lmp_const = 2;
-TUNEABLE_CONSTANT int lmp_depth = 3;
+TUNEABLE_CONSTANT int lmp_const = 3;
+TUNEABLE_CONSTANT int lmp_depth = 4;
 
 TUNEABLE_CONSTANT int fp_max_d = 10;
-TUNEABLE_CONSTANT int fp_const = 33;
-TUNEABLE_CONSTANT int fp_depth = 13;
+TUNEABLE_CONSTANT int fp_const = 34;
+TUNEABLE_CONSTANT int fp_depth = 12;
 TUNEABLE_CONSTANT int fp_quad = 11;
 
-TUNEABLE_CONSTANT int see_d = 114;
+TUNEABLE_CONSTANT int see_d = 108;
 TUNEABLE_CONSTANT int see_h = 172;
 
 TUNEABLE_CONSTANT int se_max_d = 6;
 TUNEABLE_CONSTANT int see_tt_d = 4;
 
-TUNEABLE_CONSTANT int delta_c = 292;
+TUNEABLE_CONSTANT int delta_c = 296;
 
-TUNEABLE_CONSTANT int eval_scale_knight = 463;
-TUNEABLE_CONSTANT int eval_scale_bishop = 443;
-TUNEABLE_CONSTANT int eval_scale_rook = 724;
-TUNEABLE_CONSTANT int eval_scale_queen = 1198;
-TUNEABLE_CONSTANT int eval_scale_const = 26050;
+TUNEABLE_CONSTANT int eval_scale_knight = 497;
+TUNEABLE_CONSTANT int eval_scale_bishop = 463;
+TUNEABLE_CONSTANT int eval_scale_rook = 736;
+TUNEABLE_CONSTANT int eval_scale_queen = 1265;
+TUNEABLE_CONSTANT int eval_scale_const = 26757;
 
-TUNEABLE_CONSTANT std::array see_values = { 99, 503, 530, 797, 1244, 5000 };
+TUNEABLE_CONSTANT std::array see_values = { 108, 483, 504, 739, 1216, 5000 };
 
-TUNEABLE_CONSTANT float soft_tm = 0.5313;
-TUNEABLE_CONSTANT float node_tm_base = 0.5159;
-TUNEABLE_CONSTANT float node_tm_scale = 2.098;
-TUNEABLE_CONSTANT int blitz_tc_a = 40;
-TUNEABLE_CONSTANT int blitz_tc_b = 1200;
+TUNEABLE_CONSTANT float soft_tm = 0.5414;
+TUNEABLE_CONSTANT float node_tm_base = 0.5420;
+TUNEABLE_CONSTANT float node_tm_scale = 2.283;
+TUNEABLE_CONSTANT int blitz_tc_a = 47;
+TUNEABLE_CONSTANT int blitz_tc_b = 985;
 TUNEABLE_CONSTANT int sudden_death_tc = 51;
 TUNEABLE_CONSTANT int repeating_tc = 96;

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <cstddef>
 
-// TODO: bring all search constants under here, and leverage uci options
+#define TUNE
 
 #ifdef TUNE
 #define TUNEABLE_CONSTANT inline
@@ -12,10 +12,10 @@
 #define TUNEABLE_CONSTANT const inline
 #endif
 
-TUNEABLE_CONSTANT float LMR_constant = 0.5965;
-TUNEABLE_CONSTANT float LMR_depth_coeff = -0.6058;
-TUNEABLE_CONSTANT float LMR_move_coeff = 1.554;
-TUNEABLE_CONSTANT float LMR_depth_move_coeff = 0.03265;
+TUNEABLE_CONSTANT float LMR_constant = 0.5813;
+TUNEABLE_CONSTANT float LMR_depth_coeff = -0.5768;
+TUNEABLE_CONSTANT float LMR_move_coeff = 1.631;
+TUNEABLE_CONSTANT float LMR_depth_move_coeff = 0.01007;
 
 inline auto Initialise_LMR_reduction()
 {
@@ -40,18 +40,18 @@ TUNEABLE_CONSTANT int aspiration_window_size = 12;
 
 TUNEABLE_CONSTANT int nmp_const = 5;
 TUNEABLE_CONSTANT int nmp_d = 7;
-TUNEABLE_CONSTANT int nmp_s = 246;
+TUNEABLE_CONSTANT int nmp_s = 248;
 
-TUNEABLE_CONSTANT int se_d = 52;
+TUNEABLE_CONSTANT int se_d = 50;
 TUNEABLE_CONSTANT int se_de = 12;
 
-TUNEABLE_CONSTANT int lmr_h = 6706;
+TUNEABLE_CONSTANT int lmr_h = 6611;
 
 TUNEABLE_CONSTANT int fifty_mr_scale_a = 272;
-TUNEABLE_CONSTANT int fifty_mr_scale_b = 256;
+TUNEABLE_CONSTANT int fifty_mr_scale_b = 258;
 
 TUNEABLE_CONSTANT int rfp_max_d = 9;
-TUNEABLE_CONSTANT int rfp_d = 85;
+TUNEABLE_CONSTANT int rfp_d = 84;
 
 TUNEABLE_CONSTANT int lmp_max_d = 6;
 TUNEABLE_CONSTANT int lmp_const = 2;
@@ -63,22 +63,25 @@ TUNEABLE_CONSTANT int fp_depth = 13;
 TUNEABLE_CONSTANT int fp_quad = 11;
 
 TUNEABLE_CONSTANT int see_d = 114;
-TUNEABLE_CONSTANT int see_h = 171;
+TUNEABLE_CONSTANT int see_h = 172;
 
-TUNEABLE_CONSTANT int se_max_d = 7;
+TUNEABLE_CONSTANT int se_max_d = 6;
 TUNEABLE_CONSTANT int see_tt_d = 4;
 
-TUNEABLE_CONSTANT int delta_c = 285;
+TUNEABLE_CONSTANT int delta_c = 292;
 
-TUNEABLE_CONSTANT int eval_scale_knight = 474;
-TUNEABLE_CONSTANT int eval_scale_bishop = 446;
-TUNEABLE_CONSTANT int eval_scale_rook = 730;
-TUNEABLE_CONSTANT int eval_scale_queen = 1223;
-TUNEABLE_CONSTANT int eval_scale_const = 25774;
+TUNEABLE_CONSTANT int eval_scale_knight = 463;
+TUNEABLE_CONSTANT int eval_scale_bishop = 443;
+TUNEABLE_CONSTANT int eval_scale_rook = 724;
+TUNEABLE_CONSTANT int eval_scale_queen = 1198;
+TUNEABLE_CONSTANT int eval_scale_const = 26050;
 
-TUNEABLE_CONSTANT std::array see_values = { 97, 501, 529, 802, 1248, 5000 };
+TUNEABLE_CONSTANT std::array see_values = { 99, 503, 530, 797, 1244, 5000 };
 
 TUNEABLE_CONSTANT float soft_tm = 0.5313;
-
-TUNEABLE_CONSTANT float node_tm_base = 0.5118;
-TUNEABLE_CONSTANT float node_tm_scale = 2.041;
+TUNEABLE_CONSTANT float node_tm_base = 0.5159;
+TUNEABLE_CONSTANT float node_tm_scale = 2.098;
+TUNEABLE_CONSTANT int blitz_tc_a = 40;
+TUNEABLE_CONSTANT int blitz_tc_b = 1200;
+TUNEABLE_CONSTANT int sudden_death_tc = 51;
+TUNEABLE_CONSTANT int repeating_tc = 96;


### PR DESCRIPTION
```
Elo   | 10.41 +- 4.43 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.85 (-2.94, 2.94) [0.00, 3.00]
Games | N: 6008 W: 1476 L: 1296 D: 3236
Penta | [11, 632, 1540, 808, 13]
http://chess.grantnet.us/test/39716/
```
```
Elo   | 4.97 +- 2.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 15250 W: 3760 L: 3542 D: 7948
Penta | [79, 1756, 3731, 1986, 73]
http://chess.grantnet.us/test/39715/
```