### PR TITLE
Correctly handle promotions in static exchange evaluation

### DIFF
--- a/src/search/static_exchange_evaluation.cpp
+++ b/src/search/static_exchange_evaluation.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdint>
+#include <iostream>
 
 #include "bitboard/define.h"
 #include "bitboard/enum.h"
@@ -37,52 +38,6 @@ uint64_t least_valuable_attacker(const BoardState& board, uint64_t attackers, Pi
     return 0;
 }
 
-int see(const BoardState& board, Move move)
-{
-    Square from = move.from();
-    Square to = move.to();
-
-    int scores[32] { 0 };
-    int index = 0;
-
-    auto capturing = board.get_square_piece(from);
-    auto attacker = enum_to<Side>(capturing);
-    auto captured = move.flag() == EN_PASSANT ? get_piece(PAWN, !attacker) : board.get_square_piece(to);
-
-    uint64_t from_set = (1ull << from);
-    uint64_t occ = board.get_pieces_bb(), bishops = 0, rooks = 0;
-
-    bishops = rooks = board.get_pieces_bb(QUEEN);
-    bishops |= board.get_pieces_bb(BISHOP);
-    rooks |= board.get_pieces_bb(ROOK);
-
-    if (move.flag() == EN_PASSANT)
-    {
-        occ ^= SquareBB[get_square(enum_to<File>(move.to()), enum_to<Rank>(move.from()))];
-    }
-
-    uint64_t attack_def = attackers_to_sq(board, to, occ);
-    scores[index] = captured == N_PIECES ? 0 : see_values[enum_to<PieceType>(captured)];
-
-    do
-    {
-        index++;
-        attacker = !attacker;
-        scores[index] = see_values[enum_to<PieceType>(capturing)] - scores[index - 1];
-
-        attack_def ^= from_set;
-        occ ^= from_set;
-
-        attack_def |= occ & ((bishops & attack_bb<BISHOP>(to, occ)) | (rooks & attack_bb<ROOK>(to, occ)));
-        from_set = least_valuable_attacker(board, attack_def, capturing, Side(attacker));
-    } while (from_set);
-    while (--index)
-    {
-        scores[index - 1] = -(-scores[index - 1] > scores[index] ? -scores[index - 1] : scores[index]);
-    }
-    return scores[0];
-}
-
 bool see_ge(const BoardState& board, Move move, Score threshold)
 {
     // TODO: the handling of castle moves is bugged
@@ -94,10 +49,36 @@ bool see_ge(const BoardState& board, Move move, Score threshold)
     auto capturing = board.get_square_piece(from);
     auto attacker = enum_to<Side>(capturing);
     auto captured = move.flag() == EN_PASSANT ? get_piece(PAWN, !attacker) : board.get_square_piece(to);
+    auto promo_value = [&]()
+    {
+        switch (move.flag())
+        {
+        case KNIGHT_PROMOTION:
+        case KNIGHT_PROMOTION_CAPTURE:
+            capturing = get_piece(KNIGHT, board.stm);
+            return see_values[KNIGHT] - see_values[PAWN];
+        case BISHOP_PROMOTION:
+        case BISHOP_PROMOTION_CAPTURE:
+            capturing = get_piece(BISHOP, board.stm);
+            return see_values[BISHOP] - see_values[PAWN];
+        case ROOK_PROMOTION:
+        case ROOK_PROMOTION_CAPTURE:
+            capturing = get_piece(ROOK, board.stm);
+            return see_values[ROOK] - see_values[PAWN];
+        case QUEEN_PROMOTION:
+        case QUEEN_PROMOTION_CAPTURE:
+            capturing = get_piece(QUEEN, board.stm);
+            return see_values[QUEEN] - see_values[PAWN];
+        default:
+            return 0;
+        }
+    }();
 
-    // The value of 'swap' is the net exchanged material less the threshold, relative to the perspective to move. If the
-    // value of the captured piece does not beat the threshold, the opponent can do nothing and we lose
-    Score swap = (captured == N_PIECES ? 0 : see_values[enum_to<PieceType>(captured)]) - threshold + 1;
+    auto value = promo_value + (captured == N_PIECES ? 0 : see_values[enum_to<PieceType>(captured)]);
+
+    // The value of 'swap' is the net exchanged material less the threshold, relative to the perspective to move. If
+    // the value of the captured piece does not beat the threshold, the opponent can do nothing and we lose
+    Score swap = value - threshold + 1;
     if (swap <= 0)
     {
         return false;

--- a/src/test/static_exchange_evaluation_test.cpp
+++ b/src/test/static_exchange_evaluation_test.cpp
@@ -5,11 +5,11 @@
 #include "movegen/move.h"
 #include "search/score.h"
 #include "search/static_exchange_evaluation.h"
+#include "spsa/tuneable.h"
 
 const auto test_see
     = []([[maybe_unused]] const GameState& position, [[maybe_unused]] Move move, [[maybe_unused]] Score expected_value)
 {
-    assert(see(position.board(), move) == expected_value.value());
     assert(see_ge(position.board(), move, expected_value));
     assert(!see_ge(position.board(), move, expected_value + 1));
 };
@@ -99,5 +99,50 @@ void static_exchange_evaluation_test()
     {
         auto position = GameState::from_fen("3k4/8/1B6/5n2/8/8/5P2/3K4 w - - 0 1");
         test_see(position, Move(SQ_B6, SQ_E3, QUIET), -see_values[BISHOP] + see_values[KNIGHT]);
+    }
+
+    // promotion tests
+
+    {
+        auto position = GameState::from_fen("8/7P/8/8/8/k7/8/K7 w - - 0 1");
+        test_see(position, Move(SQ_H7, SQ_H8, QUEEN_PROMOTION), see_values[QUEEN] - see_values[PAWN]);
+    }
+
+    {
+        auto position = GameState::from_fen("3r4/7P/8/8/8/k7/8/K7 w - - 0 1");
+        test_see(position, Move(SQ_H7, SQ_H8, QUEEN_PROMOTION), -see_values[PAWN]);
+    }
+
+    {
+        auto position = GameState::from_fen("3r4/7P/8/7R/8/k7/8/K7 w - - 0 1");
+        test_see(position, Move(SQ_H7, SQ_H8, KNIGHT_PROMOTION), see_values[KNIGHT] - see_values[PAWN]);
+    }
+
+    {
+        auto position = GameState::from_fen("3r4/7P/8/7R/8/k7/8/K7 w - - 0 1");
+        test_see(position, Move(SQ_H7, SQ_H8, QUEEN_PROMOTION), see_values[ROOK] - see_values[PAWN]);
+    }
+
+    {
+        auto position = GameState::from_fen("6n1/7P/8/8/8/k7/8/K7 w - - 0 1");
+        test_see(position, Move(SQ_H7, SQ_G8, ROOK_PROMOTION_CAPTURE),
+            see_values[ROOK] - see_values[PAWN] + see_values[KNIGHT]);
+    }
+
+    {
+        auto position = GameState::from_fen("3r2n1/7P/8/8/8/k7/8/K7 w - - 0 1");
+        test_see(position, Move(SQ_H7, SQ_G8, KNIGHT_PROMOTION_CAPTURE), see_values[KNIGHT] - see_values[PAWN]);
+    }
+
+    {
+        auto position = GameState::from_fen("3r2n1/7P/8/8/6R1/k7/8/K7 w - - 0 1");
+        test_see(position, Move(SQ_H7, SQ_G8, BISHOP_PROMOTION_CAPTURE),
+            see_values[KNIGHT] + see_values[BISHOP] - see_values[PAWN]);
+    }
+
+    {
+        auto position = GameState::from_fen("3r2n1/7P/8/8/6R1/k7/8/K7 w - - 0 1");
+        test_see(position, Move(SQ_H7, SQ_G8, QUEEN_PROMOTION_CAPTURE),
+            see_values[KNIGHT] - see_values[PAWN] + see_values[ROOK]);
     }
 }


### PR DESCRIPTION
```
Elo   | -0.00 +- 0.00 (95%)
SPRT  | N=40000 Threads=1 Hash=8MB
LLR   | 0.75 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 3664 W: 1036 L: 1036 D: 1592
Penta | [0, 0, 1832, 0, 0]
http://chess.grantnet.us/test/39755/
```
non-functional