### PR TITLE
Generalised double extensions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "13.14.0";
+constexpr std::string_view version = "13.15.0";
 
 void PrintVersion()
 {

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -450,7 +450,7 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
     // If the TT move is singular, we extend the search by one or more plies depending on how singular it appears
     if (se_score < sbeta)
     {
-        auto double_margin = se_de + 400 * pv_node + 400 * (ss->distance_from_root < local.curr_depth);
+        auto double_margin = se_de + 400 * pv_node + 400 * (ss->distance_from_root >= local.curr_depth);
         extensions += 1 + (se_score < sbeta - double_margin);
     }
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -448,13 +448,10 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
     ss->singular_exclusion = Move::Uninitialized;
 
     // If the TT move is singular, we extend the search by one or more plies depending on how singular it appears
-    if (!pv_node && se_score < sbeta - se_de && ss->distance_from_root < local.curr_depth)
+    if (se_score < sbeta)
     {
-        extensions += 2;
-    }
-    else if (se_score < sbeta)
-    {
-        extensions += 1;
+        auto double_margin = se_de + 400 * pv_node + 400 * (ss->distance_from_root < local.curr_depth);
+        extensions += 1 + (se_score < sbeta - double_margin);
     }
 
     // Multi-Cut: In this case, we have proven that at least one other move appears to fail high, along with

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -450,7 +450,8 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
     // If the TT move is singular, we extend the search by one or more plies depending on how singular it appears
     if (se_score < sbeta)
     {
-        auto double_margin = se_de + 400 * pv_node + 400 * (ss->distance_from_root >= local.curr_depth);
+        auto double_margin = se_de + 450 * pv_node + 300 * (ss->distance_from_root >= local.curr_depth)
+            - 4 * !(tt_move.is_capture() || tt_move.is_promotion());
         extensions += 1 + (se_score < sbeta - double_margin);
     }
 


### PR DESCRIPTION
```
Elo   | 0.49 +- 1.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -0.89 (-2.94, 2.94) [0.00, 3.00]
Games | N: 70286 W: 16457 L: 16357 D: 37472
Penta | [110, 8265, 18269, 8413, 86]
http://chess.grantnet.us/test/39789/
```
```
Elo   | 1.07 +- 1.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 1.21 (-2.94, 2.94) [0.00, 3.00]
Games | N: 92484 W: 22059 L: 21773 D: 48652
Penta | [445, 11083, 22898, 11373, 443]
http://chess.grantnet.us/test/39784/
```