### PR TITLE
Add quiet history pruning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "13.16.0";
+constexpr std::string_view version = "13.17.0";
 
 void PrintVersion()
 {

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -866,7 +866,8 @@ Score search(GameState& position, SearchStackState* ss, SearchLocalState& local,
 
         if (score > Score::tb_loss_in(MAX_DEPTH) && !is_loud_move && history < -3000 * depth - 500)
         {
-            break;
+            gen.skip_quiets();
+            continue;
         }
 
         int extensions = 0;

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -864,6 +864,11 @@ Score search(GameState& position, SearchStackState* ss, SearchLocalState& local,
             continue;
         }
 
+        if (score > Score::tb_loss_in(MAX_DEPTH) && !is_loud_move && history < -3000 * depth - 500)
+        {
+            break;
+        }
+
         int extensions = 0;
 
         // Step 14: Singular extensions.


### PR DESCRIPTION
```
Elo   | -2.92 +- 5.14 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -1.52 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4402 W: 1022 L: 1059 D: 2321
Penta | [8, 543, 1131, 516, 3]
http://chess.grantnet.us/test/39847/
```
```
Elo   | 1.73 +- 1.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 64584 W: 15386 L: 15064 D: 34134
Penta | [220, 7563, 16434, 7825, 250]
http://chess.grantnet.us/test/39846/
```

The interesting thing about this heuristic, is it overlaps with LMP and will likely allow LMP to become less hyper-aggressive.

Halogen without LMP:
```
Elo   | -28.69 +- 5.02 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=8MB
Games | N: 5000 W: 978 L: 1390 D: 2632
Penta | [34, 797, 1225, 435, 9]
http://chess.grantnet.us/test/39850/
```

Halogen without LMP *with* this patch
```
Elo   | -4.31 +- 5.03 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=8MB
Games | N: 5000 W: 1185 L: 1247 D: 2568
Penta | [26, 612, 1282, 558, 22]
http://chess.grantnet.us/test/39852/
```