### PR TITLE
SPSA LTC tune

### DIFF
--- a/src/search/history.h
+++ b/src/search/history.h
@@ -43,7 +43,7 @@ struct HistoryTable
 
 struct PawnHistory : HistoryTable<PawnHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 11059;
+    static TUNEABLE_CONSTANT int max_value = 8888;
     static TUNEABLE_CONSTANT int scale = 37;
     static constexpr size_t pawn_states = 512;
     int16_t table[N_SIDES][pawn_states][N_PIECE_TYPES][N_SQUARES] = {};
@@ -52,7 +52,7 @@ struct PawnHistory : HistoryTable<PawnHistory>
 
 struct ThreatHistory : HistoryTable<ThreatHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 8476;
+    static TUNEABLE_CONSTANT int max_value = 5681;
     static TUNEABLE_CONSTANT int scale = 41;
     int16_t table[N_SIDES][2][N_SQUARES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
@@ -60,16 +60,16 @@ struct ThreatHistory : HistoryTable<ThreatHistory>
 
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 21292;
-    static TUNEABLE_CONSTANT int scale = 38;
+    static TUNEABLE_CONSTANT int max_value = 19714;
+    static TUNEABLE_CONSTANT int scale = 41;
     int16_t table[N_SIDES][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct PieceMoveHistory : HistoryTable<PieceMoveHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 9307;
-    static TUNEABLE_CONSTANT int scale = 36;
+    static TUNEABLE_CONSTANT int max_value = 9343;
+    static TUNEABLE_CONSTANT int scale = 35;
     int16_t table[N_SIDES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
@@ -90,13 +90,13 @@ struct ContinuationHistory
     }
 };
 
-TUNEABLE_CONSTANT int corr_hist_scale = 148;
+TUNEABLE_CONSTANT int corr_hist_scale = 137;
 
 struct PawnCorrHistory
 {
     // must be a power of 2, for fast hash lookup
     static constexpr size_t pawn_hash_table_size = 16384;
-    static TUNEABLE_CONSTANT int correction_max = 64;
+    static TUNEABLE_CONSTANT int correction_max = 62;
 
     int16_t table[N_SIDES][pawn_hash_table_size] = {};
 
@@ -122,7 +122,7 @@ struct NonPawnCorrHistory
 {
     // must be a power of 2, for fast hash lookup
     static constexpr size_t hash_table_size = 16384;
-    static TUNEABLE_CONSTANT int correction_max = 76;
+    static TUNEABLE_CONSTANT int correction_max = 82;
 
     int16_t table[N_SIDES][hash_table_size] = {};
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -521,13 +521,18 @@ void UpdatePV(Move move, SearchStackState* ss)
 
 void AddHistory(const StagedMoveGenerator& gen, const Move& move, int depthRemaining)
 {
+    const auto bonus = history_bonus_const + history_bonus_depth * depthRemaining / 64
+        + history_bonus_quad * depthRemaining * depthRemaining / 64;
+    const auto penalty = -history_penalty_const - history_penalty_depth * depthRemaining / 64
+        - history_penalty_quad * depthRemaining * depthRemaining / 64;
+
     if (move.is_capture() || move.is_promotion())
     {
-        gen.update_loud_history(move, depthRemaining * depthRemaining, -depthRemaining * depthRemaining);
+        gen.update_loud_history(move, bonus, penalty);
     }
     else
     {
-        gen.update_quiet_history(move, depthRemaining * depthRemaining, -depthRemaining * depthRemaining);
+        gen.update_quiet_history(move, bonus, penalty);
     }
 }
 

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <cstddef>
 
+#define TUNE
+
 #ifdef TUNE
 #define TUNEABLE_CONSTANT inline
 #else
@@ -68,8 +70,8 @@ TUNEABLE_CONSTANT int rfp_max_d = 9;
 TUNEABLE_CONSTANT int rfp_d = 51;
 
 TUNEABLE_CONSTANT int lmp_max_d = 7;
-TUNEABLE_CONSTANT int lmp_const = 3;
-TUNEABLE_CONSTANT int lmp_depth = 3;
+TUNEABLE_CONSTANT int lmp_const = 6;
+TUNEABLE_CONSTANT int lmp_depth = 6;
 
 TUNEABLE_CONSTANT int fp_max_d = 9;
 TUNEABLE_CONSTANT int fp_const = 39;
@@ -102,3 +104,11 @@ TUNEABLE_CONSTANT int blitz_tc_a = 49;
 TUNEABLE_CONSTANT int blitz_tc_b = 619;
 TUNEABLE_CONSTANT int sudden_death_tc = 51;
 TUNEABLE_CONSTANT int repeating_tc = 96;
+
+TUNEABLE_CONSTANT int history_bonus_const = 0;
+TUNEABLE_CONSTANT int history_bonus_depth = 0;
+TUNEABLE_CONSTANT int history_bonus_quad = 64;
+
+TUNEABLE_CONSTANT int history_penalty_const = 0;
+TUNEABLE_CONSTANT int history_penalty_depth = 0;
+TUNEABLE_CONSTANT int history_penalty_quad = 64;

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -4,8 +4,6 @@
 #include <cmath>
 #include <cstddef>
 
-#define TUNE
-
 #ifdef TUNE
 #define TUNEABLE_CONSTANT inline
 #else
@@ -14,10 +12,10 @@
 
 constexpr inline int LMR_SCALE = 1024;
 
-TUNEABLE_CONSTANT float LMR_constant = -1.550;
-TUNEABLE_CONSTANT float LMR_depth_coeff = 1.115;
-TUNEABLE_CONSTANT float LMR_move_coeff = 2.798;
-TUNEABLE_CONSTANT float LMR_depth_move_coeff = -0.8258;
+TUNEABLE_CONSTANT float LMR_constant = -1.621;
+TUNEABLE_CONSTANT float LMR_depth_coeff = 1.149;
+TUNEABLE_CONSTANT float LMR_move_coeff = 2.840;
+TUNEABLE_CONSTANT float LMR_depth_move_coeff = -0.7957;
 
 inline auto Initialise_LMR_reduction()
 {
@@ -43,31 +41,31 @@ TUNEABLE_CONSTANT int aspiration_window_size = 9;
 
 TUNEABLE_CONSTANT int nmp_const = 6;
 TUNEABLE_CONSTANT int nmp_d = 7;
-TUNEABLE_CONSTANT int nmp_s = 250;
+TUNEABLE_CONSTANT int nmp_s = 245;
 TUNEABLE_CONSTANT int nmp_sd = 5;
 
 TUNEABLE_CONSTANT int iid_depth = 3;
 
-TUNEABLE_CONSTANT int se_sbeta_depth = 40;
-TUNEABLE_CONSTANT int se_double = 5;
-TUNEABLE_CONSTANT int se_double_pv = 450;
-TUNEABLE_CONSTANT int se_double_hd = 300;
-TUNEABLE_CONSTANT int se_double_quiet = 4;
+TUNEABLE_CONSTANT int se_sbeta_depth = 39;
+TUNEABLE_CONSTANT int se_double = 6;
+TUNEABLE_CONSTANT int se_double_pv = 456;
+TUNEABLE_CONSTANT int se_double_hd = 286;
+TUNEABLE_CONSTANT int se_double_quiet = 3;
 TUNEABLE_CONSTANT int se_min_depth = 6;
 TUNEABLE_CONSTANT int se_tt_depth = 4;
 
-TUNEABLE_CONSTANT int lmr_pv = 1252;
-TUNEABLE_CONSTANT int lmr_cut = 1176;
-TUNEABLE_CONSTANT int lmr_improving = 1192;
-TUNEABLE_CONSTANT int lmr_loud = 755;
-TUNEABLE_CONSTANT int lmr_h = 2668;
-TUNEABLE_CONSTANT int lmr_offset = 369;
+TUNEABLE_CONSTANT int lmr_pv = 1275;
+TUNEABLE_CONSTANT int lmr_cut = 1188;
+TUNEABLE_CONSTANT int lmr_improving = 1186;
+TUNEABLE_CONSTANT int lmr_loud = 756;
+TUNEABLE_CONSTANT int lmr_h = 2642;
+TUNEABLE_CONSTANT int lmr_offset = 424;
 
-TUNEABLE_CONSTANT int fifty_mr_scale_a = 310;
-TUNEABLE_CONSTANT int fifty_mr_scale_b = 248;
+TUNEABLE_CONSTANT int fifty_mr_scale_a = 323;
+TUNEABLE_CONSTANT int fifty_mr_scale_b = 233;
 
 TUNEABLE_CONSTANT int rfp_max_d = 9;
-TUNEABLE_CONSTANT int rfp_d = 51;
+TUNEABLE_CONSTANT int rfp_d = 54;
 
 TUNEABLE_CONSTANT int lmp_max_d = 7;
 TUNEABLE_CONSTANT int lmp_const = 6;
@@ -76,39 +74,39 @@ TUNEABLE_CONSTANT int lmp_depth = 6;
 TUNEABLE_CONSTANT int fp_max_d = 9;
 TUNEABLE_CONSTANT int fp_const = 39;
 TUNEABLE_CONSTANT int fp_depth = 13;
-TUNEABLE_CONSTANT int fp_quad = 13;
+TUNEABLE_CONSTANT int fp_quad = 14;
 
-TUNEABLE_CONSTANT int see_quiet_depth = 106;
-TUNEABLE_CONSTANT int see_quiet_hist = 149;
+TUNEABLE_CONSTANT int see_quiet_depth = 111;
+TUNEABLE_CONSTANT int see_quiet_hist = 161;
 TUNEABLE_CONSTANT int see_loud_depth = 36;
-TUNEABLE_CONSTANT int see_loud_hist = 142;
-TUNEABLE_CONSTANT int see_max_depth = 6;
+TUNEABLE_CONSTANT int see_loud_hist = 153;
+TUNEABLE_CONSTANT int see_max_depth = 7;
 
-TUNEABLE_CONSTANT int hist_prune_depth = 3000;
-TUNEABLE_CONSTANT int hist_prune = 500;
+TUNEABLE_CONSTANT int hist_prune_depth = 3388;
+TUNEABLE_CONSTANT int hist_prune = 404;
 
-TUNEABLE_CONSTANT int delta_c = 346;
+TUNEABLE_CONSTANT int delta_c = 377;
 
-TUNEABLE_CONSTANT int eval_scale_knight = 546;
-TUNEABLE_CONSTANT int eval_scale_bishop = 432;
-TUNEABLE_CONSTANT int eval_scale_rook = 718;
-TUNEABLE_CONSTANT int eval_scale_queen = 1648;
-TUNEABLE_CONSTANT int eval_scale_const = 23978;
+TUNEABLE_CONSTANT int eval_scale_knight = 565;
+TUNEABLE_CONSTANT int eval_scale_bishop = 450;
+TUNEABLE_CONSTANT int eval_scale_rook = 675;
+TUNEABLE_CONSTANT int eval_scale_queen = 1642;
+TUNEABLE_CONSTANT int eval_scale_const = 23278;
 
-TUNEABLE_CONSTANT std::array see_values = { 106, 481, 452, 808, 1399, 5000 };
+TUNEABLE_CONSTANT std::array see_values = { 110, 471, 452, 810, 1489, 5000 };
 
-TUNEABLE_CONSTANT float soft_tm = 0.3463;
-TUNEABLE_CONSTANT float node_tm_base = 0.5324;
-TUNEABLE_CONSTANT float node_tm_scale = 2.223;
-TUNEABLE_CONSTANT int blitz_tc_a = 49;
-TUNEABLE_CONSTANT int blitz_tc_b = 619;
+TUNEABLE_CONSTANT float soft_tm = 0.3484;
+TUNEABLE_CONSTANT float node_tm_base = 0.5283;
+TUNEABLE_CONSTANT float node_tm_scale = 2.352;
+TUNEABLE_CONSTANT int blitz_tc_a = 48;
+TUNEABLE_CONSTANT int blitz_tc_b = 535;
 TUNEABLE_CONSTANT int sudden_death_tc = 51;
 TUNEABLE_CONSTANT int repeating_tc = 96;
 
-TUNEABLE_CONSTANT int history_bonus_const = 0;
-TUNEABLE_CONSTANT int history_bonus_depth = 0;
-TUNEABLE_CONSTANT int history_bonus_quad = 64;
+TUNEABLE_CONSTANT int history_bonus_const = 11;
+TUNEABLE_CONSTANT int history_bonus_depth = 3;
+TUNEABLE_CONSTANT int history_bonus_quad = 72;
 
-TUNEABLE_CONSTANT int history_penalty_const = 0;
-TUNEABLE_CONSTANT int history_penalty_depth = 0;
-TUNEABLE_CONSTANT int history_penalty_quad = 64;
+TUNEABLE_CONSTANT int history_penalty_const = 14;
+TUNEABLE_CONSTANT int history_penalty_depth = 2;
+TUNEABLE_CONSTANT int history_penalty_quad = 56;

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -339,6 +339,13 @@ auto Uci::options_handler()
         tuneable_int(sudden_death_tc, 25, 100),
         tuneable_int(repeating_tc, 50, 200),
 
+        tuneable_int(history_bonus_const, -50, 50),
+        tuneable_int(history_bonus_depth, -50, 50),
+        tuneable_int(history_bonus_quad, 32, 128),
+        tuneable_int(history_penalty_const, -50, 50),
+        tuneable_int(history_penalty_depth, -50, 50),
+        tuneable_int(history_penalty_quad, 32, 128),
+
         tuneable_int(PawnHistory::max_value, 1000, 32000),
         tuneable_int(PawnHistory::scale, 20, 50),
         tuneable_int(ThreatHistory::max_value, 1000, 32000),


### PR DESCRIPTION
A few ideas were included in this tune:
- Initial value for LMP pruning was adjusted to be much less aggressive. This is because https://github.com/KierenP/Halogen/pull/689 it was found to overlap significantly with the newly added quiet history pruning. This allowed each scheme to be tuned to a complementary balance.
- History bonus and penalty formulas were tuned as a quadratic polynomial rather than just `depth^2`
- https://github.com/KierenP/Halogen/pull/690 The SPSA tuning rate for LMR was adjusted down, history up, some min/max values were adjusted for parameters which had reached these limits