### PR TITLE
SPSA LTC tune

### DIFF
--- a/src/evaluation/evaluate.cpp
+++ b/src/evaluation/evaluate.cpp
@@ -30,10 +30,10 @@ Score evaluate(const BoardState& board, SearchStackState* ss, NN::Network& net)
     Score eval = NN::Network::eval(board, ss->acc);
 
     // Apply material scaling factor
-    const auto npMaterial = eval_scale_knight * popcount(board.get_pieces_bb(KNIGHT))
-        + eval_scale_bishop * popcount(board.get_pieces_bb(BISHOP))
-        + eval_scale_rook * popcount(board.get_pieces_bb(ROOK))
-        + eval_scale_queen * popcount(board.get_pieces_bb(QUEEN));
+    const auto npMaterial = eval_scale[KNIGHT] * popcount(board.get_pieces_bb(KNIGHT))
+        + eval_scale[BISHOP] * popcount(board.get_pieces_bb(BISHOP))
+        + eval_scale[ROOK] * popcount(board.get_pieces_bb(ROOK))
+        + eval_scale[QUEEN] * popcount(board.get_pieces_bb(QUEEN));
     eval = eval.value() * (eval_scale_const + npMaterial) / 32768;
 
     return std::clamp<Score>(eval, Score::Limits::EVAL_MIN, Score::Limits::EVAL_MAX);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.2.0";
+constexpr std::string_view version = "14.3.0";
 
 void PrintVersion()
 {

--- a/src/search/history.h
+++ b/src/search/history.h
@@ -43,8 +43,8 @@ struct HistoryTable
 
 struct PawnHistory : HistoryTable<PawnHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 8335;
-    static TUNEABLE_CONSTANT int scale = 37;
+    static TUNEABLE_CONSTANT int max_value = 7392;
+    static TUNEABLE_CONSTANT int scale = 38;
     static constexpr size_t pawn_states = 512;
     int16_t table[N_SIDES][pawn_states][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
@@ -52,24 +52,24 @@ struct PawnHistory : HistoryTable<PawnHistory>
 
 struct ThreatHistory : HistoryTable<ThreatHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 5113;
-    static TUNEABLE_CONSTANT int scale = 41;
+    static TUNEABLE_CONSTANT int max_value = 5440;
+    static TUNEABLE_CONSTANT int scale = 40;
     int16_t table[N_SIDES][2][N_SQUARES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 19616;
-    static TUNEABLE_CONSTANT int scale = 40;
+    static TUNEABLE_CONSTANT int max_value = 18829;
+    static TUNEABLE_CONSTANT int scale = 41;
     int16_t table[N_SIDES][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct PieceMoveHistory : HistoryTable<PieceMoveHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 9270;
-    static TUNEABLE_CONSTANT int scale = 35;
+    static TUNEABLE_CONSTANT int max_value = 9770;
+    static TUNEABLE_CONSTANT int scale = 34;
     int16_t table[N_SIDES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
@@ -90,13 +90,13 @@ struct ContinuationHistory
     }
 };
 
-TUNEABLE_CONSTANT int corr_hist_scale = 134;
+TUNEABLE_CONSTANT int corr_hist_scale = 133;
 
 struct PawnCorrHistory
 {
     // must be a power of 2, for fast hash lookup
     static constexpr size_t pawn_hash_table_size = 16384;
-    static TUNEABLE_CONSTANT int correction_max = 59;
+    static TUNEABLE_CONSTANT int correction_max = 61;
 
     int16_t table[N_SIDES][pawn_hash_table_size] = {};
 
@@ -122,7 +122,7 @@ struct NonPawnCorrHistory
 {
     // must be a power of 2, for fast hash lookup
     static constexpr size_t hash_table_size = 16384;
-    static TUNEABLE_CONSTANT int correction_max = 82;
+    static TUNEABLE_CONSTANT int correction_max = 77;
 
     int16_t table[N_SIDES][hash_table_size] = {};
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -521,10 +521,12 @@ void UpdatePV(Move move, SearchStackState* ss)
 
 void AddHistory(const StagedMoveGenerator& gen, const Move& move, int depthRemaining)
 {
-    const auto bonus = history_bonus_const + history_bonus_depth * depthRemaining / 64
-        + history_bonus_quad * depthRemaining * depthRemaining / 64;
-    const auto penalty = -history_penalty_const - history_penalty_depth * depthRemaining / 64
-        - history_penalty_quad * depthRemaining * depthRemaining / 64;
+    const auto bonus = (history_bonus_const + history_bonus_depth * depthRemaining
+                           + history_bonus_quad * depthRemaining * depthRemaining)
+        / 64;
+    const auto penalty = -(history_penalty_const + history_penalty_depth * depthRemaining
+                             + history_penalty_quad * depthRemaining * depthRemaining)
+        / 64;
 
     if (move.is_capture() || move.is_promotion())
     {
@@ -774,8 +776,10 @@ Score search(GameState& position, SearchStackState* ss, SearchLocalState& local,
     // Step 6: Static null move pruning (a.k.a reverse futility pruning)
     //
     // If the static score is far above beta we fail high.
+    const auto rfp_margin
+        = (rfp_const + rfp_depth * (depth - improving) + rfp_quad * (depth - improving) * (depth - improving)) / 64;
     if (!pv_node && !InCheck && ss->singular_exclusion == Move::Uninitialized && depth < rfp_max_d
-        && eval - rfp_d * (depth - improving) - 50 * (ss->threat_mask != 0) >= beta)
+        && eval - rfp_margin - 50 * (ss->threat_mask != 0) >= beta)
     {
         return (beta.value() + eval.value()) / 2;
     }
@@ -836,8 +840,9 @@ Score search(GameState& position, SearchStackState* ss, SearchLocalState& local,
         //
         // At low depths, we limit the number of candidate quiet moves. This is a more aggressive form of futility
         // pruning
-        if (depth < lmp_max_d && seen_moves >= lmp_const + lmp_depth * depth * (1 + improving)
-            && score > Score::tb_loss_in(MAX_DEPTH))
+        const auto lmp_margin
+            = (lmp_const + lmp_depth * depth * (1 + improving) + lmp_quad * depth * depth * (1 + improving)) / 64;
+        if (depth < lmp_max_d && seen_moves >= lmp_margin && score > Score::tb_loss_in(MAX_DEPTH))
         {
             gen.skip_quiets();
         }
@@ -846,7 +851,7 @@ Score search(GameState& position, SearchStackState* ss, SearchLocalState& local,
         //
         // Prune quiet moves if we are significantly below alpha. TODO: this implementation is a little strange
         if (!pv_node && !InCheck && depth < fp_max_d
-            && eval + fp_const + fp_depth * depth + fp_quad * depth * depth < alpha
+            && eval + (fp_const + fp_depth * depth + fp_quad * depth * depth) / 64 < alpha
             && score > Score::tb_loss_in(MAX_DEPTH))
         {
             gen.skip_quiets();

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -4,8 +4,6 @@
 #include <cmath>
 #include <cstddef>
 
-#define TUNE
-
 #ifdef TUNE
 #define TUNEABLE_CONSTANT inline
 #else
@@ -14,10 +12,10 @@
 
 constexpr inline int LMR_SCALE = 1024;
 
-TUNEABLE_CONSTANT float LMR_constant = -1.548;
-TUNEABLE_CONSTANT float LMR_depth_coeff = 1.150;
-TUNEABLE_CONSTANT float LMR_move_coeff = 2.691;
-TUNEABLE_CONSTANT float LMR_depth_move_coeff = -0.7976;
+TUNEABLE_CONSTANT float LMR_constant = -1.551;
+TUNEABLE_CONSTANT float LMR_depth_coeff = 1.388;
+TUNEABLE_CONSTANT float LMR_move_coeff = 2.564;
+TUNEABLE_CONSTANT float LMR_depth_move_coeff = -0.8151;
 
 inline auto Initialise_LMR_reduction()
 {
@@ -43,72 +41,72 @@ TUNEABLE_CONSTANT int aspiration_window_size = 9;
 
 TUNEABLE_CONSTANT int nmp_const = 6;
 TUNEABLE_CONSTANT int nmp_d = 7;
-TUNEABLE_CONSTANT int nmp_s = 243;
+TUNEABLE_CONSTANT int nmp_s = 244;
 TUNEABLE_CONSTANT int nmp_sd = 5;
 
 TUNEABLE_CONSTANT int iid_depth = 3;
 
-TUNEABLE_CONSTANT int se_sbeta_depth = 41;
+TUNEABLE_CONSTANT int se_sbeta_depth = 45;
 TUNEABLE_CONSTANT int se_double = 7;
-TUNEABLE_CONSTANT int se_double_pv = 462;
-TUNEABLE_CONSTANT int se_double_hd = 276;
-TUNEABLE_CONSTANT int se_double_quiet = 2;
+TUNEABLE_CONSTANT int se_double_pv = 489;
+TUNEABLE_CONSTANT int se_double_hd = 300;
+TUNEABLE_CONSTANT int se_double_quiet = 1;
 TUNEABLE_CONSTANT int se_min_depth = 6;
-TUNEABLE_CONSTANT int se_tt_depth = 4;
+TUNEABLE_CONSTANT int se_tt_depth = 3;
 
-TUNEABLE_CONSTANT int lmr_pv = 1319;
-TUNEABLE_CONSTANT int lmr_cut = 1238;
-TUNEABLE_CONSTANT int lmr_improving = 1176;
-TUNEABLE_CONSTANT int lmr_loud = 755;
-TUNEABLE_CONSTANT int lmr_h = 2638;
-TUNEABLE_CONSTANT int lmr_offset = 456;
+TUNEABLE_CONSTANT int lmr_pv = 1361;
+TUNEABLE_CONSTANT int lmr_cut = 1335;
+TUNEABLE_CONSTANT int lmr_improving = 1110;
+TUNEABLE_CONSTANT int lmr_loud = 808;
+TUNEABLE_CONSTANT int lmr_h = 2586;
+TUNEABLE_CONSTANT int lmr_offset = 374;
 
-TUNEABLE_CONSTANT int fifty_mr_scale_a = 325;
-TUNEABLE_CONSTANT int fifty_mr_scale_b = 234;
+TUNEABLE_CONSTANT int fifty_mr_scale_a = 312;
+TUNEABLE_CONSTANT int fifty_mr_scale_b = 214;
 
-TUNEABLE_CONSTANT int rfp_max_d = 9;
-TUNEABLE_CONSTANT int rfp_const = 0;
-TUNEABLE_CONSTANT int rfp_depth = 3392;
-TUNEABLE_CONSTANT int rfp_quad = 0;
+TUNEABLE_CONSTANT int rfp_max_d = 10;
+TUNEABLE_CONSTANT int rfp_const = -135;
+TUNEABLE_CONSTANT int rfp_depth = 3097;
+TUNEABLE_CONSTANT int rfp_quad = 15;
 
 TUNEABLE_CONSTANT int lmp_max_d = 7;
-TUNEABLE_CONSTANT int lmp_const = 384;
-TUNEABLE_CONSTANT int lmp_depth = 384;
-TUNEABLE_CONSTANT int lmp_quad = 0;
+TUNEABLE_CONSTANT int lmp_const = 405;
+TUNEABLE_CONSTANT int lmp_depth = 403;
+TUNEABLE_CONSTANT int lmp_quad = 9;
 
 TUNEABLE_CONSTANT int fp_max_d = 9;
-TUNEABLE_CONSTANT int fp_const = 2432;
-TUNEABLE_CONSTANT int fp_depth = 896;
-TUNEABLE_CONSTANT int fp_quad = 896;
+TUNEABLE_CONSTANT int fp_const = 2394;
+TUNEABLE_CONSTANT int fp_depth = 841;
+TUNEABLE_CONSTANT int fp_quad = 812;
 
 TUNEABLE_CONSTANT int see_quiet_depth = 109;
-TUNEABLE_CONSTANT int see_quiet_hist = 155;
+TUNEABLE_CONSTANT int see_quiet_hist = 146;
 TUNEABLE_CONSTANT int see_loud_depth = 37;
-TUNEABLE_CONSTANT int see_loud_hist = 158;
-TUNEABLE_CONSTANT int see_max_depth = 7;
+TUNEABLE_CONSTANT int see_loud_hist = 155;
+TUNEABLE_CONSTANT int see_max_depth = 8;
 
-TUNEABLE_CONSTANT int hist_prune_depth = 3324;
-TUNEABLE_CONSTANT int hist_prune = 344;
+TUNEABLE_CONSTANT int hist_prune_depth = 2681;
+TUNEABLE_CONSTANT int hist_prune = 253;
 
-TUNEABLE_CONSTANT int delta_c = 367;
+TUNEABLE_CONSTANT int delta_c = 432;
 
-TUNEABLE_CONSTANT std::array eval_scale = { 0, 564, 460, 681, 1645 };
-TUNEABLE_CONSTANT int eval_scale_const = 23008;
+TUNEABLE_CONSTANT std::array eval_scale = { 0, 569, 474, 706, 1697 };
+TUNEABLE_CONSTANT int eval_scale_const = 21516;
 
-TUNEABLE_CONSTANT std::array see_values = { 112, 452, 452, 817, 1553, 5000 };
+TUNEABLE_CONSTANT std::array see_values = { 123, 456, 427, 806, 1632, 5000 };
 
-TUNEABLE_CONSTANT float soft_tm = 0.2957;
-TUNEABLE_CONSTANT float node_tm_base = 0.5052;
-TUNEABLE_CONSTANT float node_tm_scale = 2.329;
-TUNEABLE_CONSTANT int blitz_tc_a = 49;
-TUNEABLE_CONSTANT int blitz_tc_b = 500;
+TUNEABLE_CONSTANT float soft_tm = 0.2562;
+TUNEABLE_CONSTANT float node_tm_base = 0.4414;
+TUNEABLE_CONSTANT float node_tm_scale = 2.487;
+TUNEABLE_CONSTANT int blitz_tc_a = 47;
+TUNEABLE_CONSTANT int blitz_tc_b = 401;
 TUNEABLE_CONSTANT int sudden_death_tc = 51;
 TUNEABLE_CONSTANT int repeating_tc = 96;
 
-TUNEABLE_CONSTANT int history_bonus_const = 896;
-TUNEABLE_CONSTANT int history_bonus_depth = 2;
-TUNEABLE_CONSTANT int history_bonus_quad = 76;
+TUNEABLE_CONSTANT int history_bonus_const = 818;
+TUNEABLE_CONSTANT int history_bonus_depth = 55;
+TUNEABLE_CONSTANT int history_bonus_quad = 78;
 
-TUNEABLE_CONSTANT int history_penalty_const = 1024;
-TUNEABLE_CONSTANT int history_penalty_depth = 3;
-TUNEABLE_CONSTANT int history_penalty_quad = 54;
+TUNEABLE_CONSTANT int history_penalty_const = 1144;
+TUNEABLE_CONSTANT int history_penalty_depth = -23;
+TUNEABLE_CONSTANT int history_penalty_quad = 44;

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <cstddef>
 
+#define TUNE
+
 #ifdef TUNE
 #define TUNEABLE_CONSTANT inline
 #else
@@ -65,16 +67,19 @@ TUNEABLE_CONSTANT int fifty_mr_scale_a = 325;
 TUNEABLE_CONSTANT int fifty_mr_scale_b = 234;
 
 TUNEABLE_CONSTANT int rfp_max_d = 9;
-TUNEABLE_CONSTANT int rfp_d = 53;
+TUNEABLE_CONSTANT int rfp_const = 0;
+TUNEABLE_CONSTANT int rfp_depth = 3392;
+TUNEABLE_CONSTANT int rfp_quad = 0;
 
 TUNEABLE_CONSTANT int lmp_max_d = 7;
-TUNEABLE_CONSTANT int lmp_const = 6;
-TUNEABLE_CONSTANT int lmp_depth = 6;
+TUNEABLE_CONSTANT int lmp_const = 384;
+TUNEABLE_CONSTANT int lmp_depth = 384;
+TUNEABLE_CONSTANT int lmp_quad = 0;
 
 TUNEABLE_CONSTANT int fp_max_d = 9;
-TUNEABLE_CONSTANT int fp_const = 38;
-TUNEABLE_CONSTANT int fp_depth = 14;
-TUNEABLE_CONSTANT int fp_quad = 14;
+TUNEABLE_CONSTANT int fp_const = 2432;
+TUNEABLE_CONSTANT int fp_depth = 896;
+TUNEABLE_CONSTANT int fp_quad = 896;
 
 TUNEABLE_CONSTANT int see_quiet_depth = 109;
 TUNEABLE_CONSTANT int see_quiet_hist = 155;
@@ -87,10 +92,7 @@ TUNEABLE_CONSTANT int hist_prune = 344;
 
 TUNEABLE_CONSTANT int delta_c = 367;
 
-TUNEABLE_CONSTANT int eval_scale_knight = 564;
-TUNEABLE_CONSTANT int eval_scale_bishop = 460;
-TUNEABLE_CONSTANT int eval_scale_rook = 681;
-TUNEABLE_CONSTANT int eval_scale_queen = 1645;
+TUNEABLE_CONSTANT std::array eval_scale = { 0, 564, 460, 681, 1645 };
 TUNEABLE_CONSTANT int eval_scale_const = 23008;
 
 TUNEABLE_CONSTANT std::array see_values = { 112, 452, 452, 817, 1553, 5000 };
@@ -103,10 +105,10 @@ TUNEABLE_CONSTANT int blitz_tc_b = 500;
 TUNEABLE_CONSTANT int sudden_death_tc = 51;
 TUNEABLE_CONSTANT int repeating_tc = 96;
 
-TUNEABLE_CONSTANT int history_bonus_const = 14;
+TUNEABLE_CONSTANT int history_bonus_const = 896;
 TUNEABLE_CONSTANT int history_bonus_depth = 2;
 TUNEABLE_CONSTANT int history_bonus_quad = 76;
 
-TUNEABLE_CONSTANT int history_penalty_const = 16;
+TUNEABLE_CONSTANT int history_penalty_const = 1024;
 TUNEABLE_CONSTANT int history_penalty_depth = 3;
 TUNEABLE_CONSTANT int history_penalty_quad = 54;

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -297,16 +297,19 @@ auto Uci::options_handler()
         tuneable_int(fifty_mr_scale_b, 100, 350),
 
         tuneable_int(rfp_max_d, 5, 15),
-        tuneable_int(rfp_d, 50, 150),
+        tuneable_int(rfp_const, -1000, 1000),
+        tuneable_int(rfp_depth, 1500, 6000),
+        tuneable_int(rfp_quad, 0, 500),
 
         tuneable_int(lmp_max_d, 3, 9),
-        tuneable_int(lmp_const, 1, 10),
-        tuneable_int(lmp_depth, 1, 10),
+        tuneable_int(lmp_const, 64, 640),
+        tuneable_int(lmp_depth, 64, 640),
+        tuneable_int(lmp_quad, 0, 500),
 
         tuneable_int(fp_max_d, 5, 15),
-        tuneable_int(fp_const, 10, 50),
-        tuneable_int(fp_depth, 5, 15),
-        tuneable_int(fp_quad, 5, 25),
+        tuneable_int(fp_const, 1200, 2800),
+        tuneable_int(fp_depth, 450, 1800),
+        tuneable_int(fp_quad, 450, 1800),
 
         tuneable_int(see_quiet_depth, 50, 150),
         tuneable_int(see_quiet_hist, 50, 250),
@@ -319,10 +322,10 @@ auto Uci::options_handler()
 
         tuneable_int(delta_c, 0, 500),
 
-        tuneable_int(eval_scale_knight, 200, 800),
-        tuneable_int(eval_scale_bishop, 200, 800),
-        tuneable_int(eval_scale_rook, 400, 1200),
-        tuneable_int(eval_scale_queen, 600, 2400),
+        tuneable_int(eval_scale[KNIGHT], 200, 800),
+        tuneable_int(eval_scale[BISHOP], 200, 800),
+        tuneable_int(eval_scale[ROOK], 400, 1200),
+        tuneable_int(eval_scale[QUEEN], 600, 2400),
         tuneable_int(eval_scale_const, 15000, 40000),
 
         tuneable_int(see_values[PAWN], 50, 200),
@@ -339,11 +342,11 @@ auto Uci::options_handler()
         tuneable_int(sudden_death_tc, 25, 100),
         tuneable_int(repeating_tc, 50, 200),
 
-        tuneable_int(history_bonus_const, -50, 50),
-        tuneable_int(history_bonus_depth, -50, 50),
+        tuneable_int(history_bonus_const, 450, 1800),
+        tuneable_int(history_bonus_depth, -500, 500),
         tuneable_int(history_bonus_quad, 32, 128),
-        tuneable_int(history_penalty_const, -50, 50),
-        tuneable_int(history_penalty_depth, -50, 50),
+        tuneable_int(history_penalty_const, 500, 2000),
+        tuneable_int(history_penalty_depth, -500, 500),
         tuneable_int(history_penalty_quad, 32, 128),
 
         tuneable_int(PawnHistory::max_value, 1000, 32000),


### PR DESCRIPTION
```
Elo   | 7.37 +- 5.44 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3958 W: 969 L: 885 D: 2104
Penta | [9, 424, 1027, 512, 7]
http://chess.grantnet.us/test/39920/
```
```
Elo   | 7.13 +- 4.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6726 W: 1735 L: 1597 D: 3394
Penta | [28, 771, 1635, 893, 36]
http://chess.grantnet.us/test/39919/
```