### PR TITLE
Apply double negative extensions for non-singular cut ndoes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.7.0";
+constexpr std::string_view version = "14.8.0";
 
 void PrintVersion()
 {

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -475,12 +475,12 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
     // move as heavily.
     else if (tt_score >= beta)
     {
-        extensions += -2;
+        extensions += -1;
     }
 
     else if (cut_node)
     {
-        extensions += -1;
+        extensions += -2;
     }
 
     return std::nullopt;

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -473,7 +473,12 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
     // might decide to reduce the TT move search. The TT move doesn't have LMR applied, to heuristically this
     // reduction can be thought of as evening out the search depth between the moves and not favouring the TT
     // move as heavily.
-    else if (tt_score >= beta || cut_node)
+    else if (tt_score >= beta)
+    {
+        extensions += -2;
+    }
+
+    else if (cut_node)
     {
         extensions += -1;
     }


### PR DESCRIPTION
```
Elo   | 5.02 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 14466 W: 3595 L: 3386 D: 7485
Penta | [39, 1664, 3632, 1845, 53]
http://chess.grantnet.us/test/39963/
```