### PR TITLE
Apply double negative extensions to near multi-cut nodes

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -473,7 +473,12 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
     // might decide to reduce the TT move search. The TT move doesn't have LMR applied, to heuristically this
     // reduction can be thought of as evening out the search depth between the moves and not favouring the TT
     // move as heavily.
-    else if (tt_score >= beta || cut_node)
+    else if (tt_score >= beta)
+    {
+        extensions += -2;
+    }
+
+    else if (cut_node)
     {
         extensions += -1;
     }


### PR DESCRIPTION
```
Elo   | 1.95 +- 1.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 52274 W: 12600 L: 12306 D: 27368
Penta | [203, 6063, 13321, 6337, 213]
http://chess.grantnet.us/test/39962/
```