### PR TITLE
SPSA LTC tune

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.9.1";
+constexpr std::string_view version = "14.10.0";
 
 void PrintVersion()
 {

--- a/src/search/history.h
+++ b/src/search/history.h
@@ -43,7 +43,7 @@ struct HistoryTable
 
 struct PawnHistory : HistoryTable<PawnHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 7392;
+    static TUNEABLE_CONSTANT int max_value = 7200;
     static TUNEABLE_CONSTANT int scale = 38;
     static constexpr size_t pawn_states = 512;
     int16_t table[N_SIDES][pawn_states][N_PIECE_TYPES][N_SQUARES] = {};
@@ -52,24 +52,24 @@ struct PawnHistory : HistoryTable<PawnHistory>
 
 struct ThreatHistory : HistoryTable<ThreatHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 5440;
-    static TUNEABLE_CONSTANT int scale = 40;
+    static TUNEABLE_CONSTANT int max_value = 4768;
+    static TUNEABLE_CONSTANT int scale = 41;
     int16_t table[N_SIDES][2][2][N_SQUARES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct CaptureHistory : HistoryTable<CaptureHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 18829;
-    static TUNEABLE_CONSTANT int scale = 41;
+    static TUNEABLE_CONSTANT int max_value = 17843;
+    static TUNEABLE_CONSTANT int scale = 44;
     int16_t table[N_SIDES][N_PIECE_TYPES][N_SQUARES][N_PIECE_TYPES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
 
 struct PieceMoveHistory : HistoryTable<PieceMoveHistory>
 {
-    static TUNEABLE_CONSTANT int max_value = 9770;
-    static TUNEABLE_CONSTANT int scale = 34;
+    static TUNEABLE_CONSTANT int max_value = 10409;
+    static TUNEABLE_CONSTANT int scale = 35;
     int16_t table[N_SIDES][N_PIECE_TYPES][N_SQUARES] = {};
     int16_t* get(const GameState& position, const SearchStackState* ss, Move move);
 };
@@ -90,7 +90,7 @@ struct ContinuationHistory
     }
 };
 
-TUNEABLE_CONSTANT int corr_hist_scale = 133;
+TUNEABLE_CONSTANT int corr_hist_scale = 129;
 
 struct PawnCorrHistory
 {
@@ -122,7 +122,7 @@ struct NonPawnCorrHistory
 {
     // must be a power of 2, for fast hash lookup
     static constexpr size_t hash_table_size = 16384;
-    static TUNEABLE_CONSTANT int correction_max = 77;
+    static TUNEABLE_CONSTANT int correction_max = 81;
 
     int16_t table[N_SIDES][hash_table_size] = {};
 

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -12,10 +12,10 @@
 
 constexpr inline int LMR_SCALE = 1024;
 
-TUNEABLE_CONSTANT float LMR_constant = -1.551;
-TUNEABLE_CONSTANT float LMR_depth_coeff = 1.388;
-TUNEABLE_CONSTANT float LMR_move_coeff = 2.564;
-TUNEABLE_CONSTANT float LMR_depth_move_coeff = -0.8151;
+TUNEABLE_CONSTANT float LMR_constant = -1.583;
+TUNEABLE_CONSTANT float LMR_depth_coeff = 1.428;
+TUNEABLE_CONSTANT float LMR_move_coeff = 2.522;
+TUNEABLE_CONSTANT float LMR_depth_move_coeff = -0.8144;
 
 inline auto Initialise_LMR_reduction()
 {
@@ -41,7 +41,7 @@ TUNEABLE_CONSTANT int aspiration_window_size = 9;
 
 TUNEABLE_CONSTANT int nmp_const = 6;
 TUNEABLE_CONSTANT int nmp_d = 7;
-TUNEABLE_CONSTANT int nmp_s = 244;
+TUNEABLE_CONSTANT int nmp_s = 243;
 TUNEABLE_CONSTANT int nmp_sd = 5;
 
 TUNEABLE_CONSTANT int iid_depth = 3;
@@ -49,64 +49,64 @@ TUNEABLE_CONSTANT int iid_depth = 3;
 TUNEABLE_CONSTANT int se_sbeta_depth = 45;
 TUNEABLE_CONSTANT int se_double = 7;
 TUNEABLE_CONSTANT int se_double_pv = 489;
-TUNEABLE_CONSTANT int se_double_hd = 300;
+TUNEABLE_CONSTANT int se_double_hd = 315;
 TUNEABLE_CONSTANT int se_double_quiet = 1;
 TUNEABLE_CONSTANT int se_min_depth = 6;
 TUNEABLE_CONSTANT int se_tt_depth = 3;
 
-TUNEABLE_CONSTANT int lmr_pv = 1361;
-TUNEABLE_CONSTANT int lmr_cut = 1335;
-TUNEABLE_CONSTANT int lmr_improving = 1110;
-TUNEABLE_CONSTANT int lmr_loud = 808;
-TUNEABLE_CONSTANT int lmr_h = 2586;
-TUNEABLE_CONSTANT int lmr_offset = 374;
+TUNEABLE_CONSTANT int lmr_pv = 1337;
+TUNEABLE_CONSTANT int lmr_cut = 1379;
+TUNEABLE_CONSTANT int lmr_improving = 1082;
+TUNEABLE_CONSTANT int lmr_loud = 793;
+TUNEABLE_CONSTANT int lmr_h = 2531;
+TUNEABLE_CONSTANT int lmr_offset = 396;
 
-TUNEABLE_CONSTANT int fifty_mr_scale_a = 312;
-TUNEABLE_CONSTANT int fifty_mr_scale_b = 214;
+TUNEABLE_CONSTANT int fifty_mr_scale_a = 308;
+TUNEABLE_CONSTANT int fifty_mr_scale_b = 205;
 
 TUNEABLE_CONSTANT int rfp_max_d = 10;
-TUNEABLE_CONSTANT int rfp_const = -135;
-TUNEABLE_CONSTANT int rfp_depth = 3097;
-TUNEABLE_CONSTANT int rfp_quad = 15;
+TUNEABLE_CONSTANT int rfp_const = -164;
+TUNEABLE_CONSTANT int rfp_depth = 2950;
+TUNEABLE_CONSTANT int rfp_quad = 29;
 
 TUNEABLE_CONSTANT int lmp_max_d = 7;
-TUNEABLE_CONSTANT int lmp_const = 405;
-TUNEABLE_CONSTANT int lmp_depth = 403;
-TUNEABLE_CONSTANT int lmp_quad = 9;
+TUNEABLE_CONSTANT int lmp_const = 396;
+TUNEABLE_CONSTANT int lmp_depth = 392;
+TUNEABLE_CONSTANT int lmp_quad = 15;
 
 TUNEABLE_CONSTANT int fp_max_d = 9;
-TUNEABLE_CONSTANT int fp_const = 2394;
+TUNEABLE_CONSTANT int fp_const = 2443;
 TUNEABLE_CONSTANT int fp_depth = 841;
-TUNEABLE_CONSTANT int fp_quad = 812;
+TUNEABLE_CONSTANT int fp_quad = 751;
 
-TUNEABLE_CONSTANT int see_quiet_depth = 109;
-TUNEABLE_CONSTANT int see_quiet_hist = 146;
-TUNEABLE_CONSTANT int see_loud_depth = 37;
-TUNEABLE_CONSTANT int see_loud_hist = 155;
+TUNEABLE_CONSTANT int see_quiet_depth = 106;
+TUNEABLE_CONSTANT int see_quiet_hist = 153;
+TUNEABLE_CONSTANT int see_loud_depth = 40;
+TUNEABLE_CONSTANT int see_loud_hist = 154;
 TUNEABLE_CONSTANT int see_max_depth = 8;
 
-TUNEABLE_CONSTANT int hist_prune_depth = 2681;
-TUNEABLE_CONSTANT int hist_prune = 253;
+TUNEABLE_CONSTANT int hist_prune_depth = 2256;
+TUNEABLE_CONSTANT int hist_prune = 256;
 
-TUNEABLE_CONSTANT int delta_c = 432;
+TUNEABLE_CONSTANT int delta_c = 448;
 
-TUNEABLE_CONSTANT std::array eval_scale = { 0, 569, 474, 706, 1697 };
-TUNEABLE_CONSTANT int eval_scale_const = 21516;
+TUNEABLE_CONSTANT std::array eval_scale = { 0, 573, 461, 682, 1791 };
+TUNEABLE_CONSTANT int eval_scale_const = 20852;
 
-TUNEABLE_CONSTANT std::array see_values = { 123, 456, 427, 806, 1632, 5000 };
+TUNEABLE_CONSTANT std::array see_values = { 126, 493, 438, 760, 1661, 5000 };
 
-TUNEABLE_CONSTANT float soft_tm = 0.2562;
-TUNEABLE_CONSTANT float node_tm_base = 0.4414;
-TUNEABLE_CONSTANT float node_tm_scale = 2.487;
-TUNEABLE_CONSTANT int blitz_tc_a = 47;
-TUNEABLE_CONSTANT int blitz_tc_b = 401;
+TUNEABLE_CONSTANT float soft_tm = 0.2608;
+TUNEABLE_CONSTANT float node_tm_base = 0.4334;
+TUNEABLE_CONSTANT float node_tm_scale = 2.484;
+TUNEABLE_CONSTANT int blitz_tc_a = 46;
+TUNEABLE_CONSTANT int blitz_tc_b = 337;
 TUNEABLE_CONSTANT int sudden_death_tc = 51;
 TUNEABLE_CONSTANT int repeating_tc = 96;
 
-TUNEABLE_CONSTANT int history_bonus_const = 818;
-TUNEABLE_CONSTANT int history_bonus_depth = 55;
-TUNEABLE_CONSTANT int history_bonus_quad = 78;
+TUNEABLE_CONSTANT int history_bonus_const = 840;
+TUNEABLE_CONSTANT int history_bonus_depth = 51;
+TUNEABLE_CONSTANT int history_bonus_quad = 80;
 
-TUNEABLE_CONSTANT int history_penalty_const = 1144;
-TUNEABLE_CONSTANT int history_penalty_depth = -23;
-TUNEABLE_CONSTANT int history_penalty_quad = 44;
+TUNEABLE_CONSTANT int history_penalty_const = 1232;
+TUNEABLE_CONSTANT int history_penalty_depth = -10;
+TUNEABLE_CONSTANT int history_penalty_quad = 40;


### PR DESCRIPTION
```
Elo   | 2.35 +- 1.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 39370 W: 9545 L: 9279 D: 20546
Penta | [154, 4574, 9936, 4894, 127]
http://chess.grantnet.us/test/39967/
```
```
Elo   | 2.92 +- 2.05 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 26872 W: 6420 L: 6194 D: 14258
Penta | [31, 3031, 7090, 3249, 35]
http://chess.grantnet.us/test/39968/
```