### PR TITLE
Simplify double extensions to only non-pv nodes

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -453,12 +453,13 @@ std::optional<Score> singular_extensions(GameState& position, SearchStackState* 
     ss->singular_exclusion = Move::Uninitialized;
 
     // If the TT move is singular, we extend the search by one or more plies depending on how singular it appears
-    if (se_score < sbeta)
+    if (se_score < sbeta - se_double && !pv_node && ss->distance_from_root < local.curr_depth)
     {
-        auto double_margin = se_double + se_double_pv * pv_node
-            + se_double_hd * (ss->distance_from_root >= local.curr_depth)
-            - se_double_quiet * !(tt_move.is_capture() || tt_move.is_promotion());
-        extensions += 1 + (se_score < sbeta - double_margin);
+        extensions += 2;
+    }
+    else if (se_score < sbeta)
+    {
+        extensions += 1;
     }
 
     // Multi-Cut: In this case, we have proven that at least one other move appears to fail high, along with


### PR DESCRIPTION
```
Elo   | 0.94 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 36268 W: 8591 L: 8493 D: 19184
Penta | [137, 4303, 9172, 4369, 153]
http://chess.grantnet.us/test/39974/
```
```
Elo   | -0.59 +- 2.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.09 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 12848 W: 3015 L: 3037 D: 6796
Penta | [13, 1499, 3414, 1493, 5]
http://chess.grantnet.us/test/39975/
```