### PR TITLE
Adjust good loud move margin to -100

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.10.2";
+constexpr std::string_view version = "14.11.0";
 
 void PrintVersion()
 {

--- a/src/search/staged_movegen.cpp
+++ b/src/search/staged_movegen.cpp
@@ -61,7 +61,7 @@ bool StagedMoveGenerator::next(Move& move)
     {
         while (current != loudMoves.end())
         {
-            if (see_ge(position.board(), current->move, -50))
+            if (see_ge(position.board(), current->move, -100))
             {
                 move = current->move;
                 ++current;

--- a/src/search/staged_movegen.cpp
+++ b/src/search/staged_movegen.cpp
@@ -61,7 +61,7 @@ bool StagedMoveGenerator::next(Move& move)
     {
         while (current != loudMoves.end())
         {
-            if (see_ge(position.board(), current->move, 0))
+            if (see_ge(position.board(), current->move, 50))
             {
                 move = current->move;
                 ++current;

--- a/src/search/staged_movegen.cpp
+++ b/src/search/staged_movegen.cpp
@@ -61,7 +61,7 @@ bool StagedMoveGenerator::next(Move& move)
     {
         while (current != loudMoves.end())
         {
-            if (see_ge(position.board(), current->move, 50))
+            if (see_ge(position.board(), current->move, 100))
             {
                 move = current->move;
                 ++current;

--- a/src/search/staged_movegen.cpp
+++ b/src/search/staged_movegen.cpp
@@ -61,7 +61,7 @@ bool StagedMoveGenerator::next(Move& move)
     {
         while (current != loudMoves.end())
         {
-            if (see_ge(position.board(), current->move, 100))
+            if (see_ge(position.board(), current->move, -50))
             {
                 move = current->move;
                 ++current;


### PR DESCRIPTION
```
Elo   | 4.37 +- 2.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 17400 W: 4206 L: 3987 D: 9207
Penta | [71, 1958, 4415, 2193, 63]
http://chess.grantnet.us/test/39985/
```