### PR TITLE
Scale good loud SEE margin by move history

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.11.1";
+constexpr std::string_view version = "14.12.0";
 
 void PrintVersion()
 {

--- a/src/search/staged_movegen.cpp
+++ b/src/search/staged_movegen.cpp
@@ -61,7 +61,7 @@ bool StagedMoveGenerator::next(Move& move)
     {
         while (current != loudMoves.end())
         {
-            if (see_ge(position.board(), current->move, -good_loud_see - current->score * 51 / 1024))
+            if (see_ge(position.board(), current->move, -good_loud_see - current->score * good_loud_see_hist / 1024))
             {
                 move = current->move;
                 ++current;

--- a/src/search/staged_movegen.cpp
+++ b/src/search/staged_movegen.cpp
@@ -61,7 +61,7 @@ bool StagedMoveGenerator::next(Move& move)
     {
         while (current != loudMoves.end())
         {
-            if (see_ge(position.board(), current->move, good_loud_see))
+            if (see_ge(position.board(), current->move, -good_loud_see - current->score * 51 / 1024))
             {
                 move = current->move;
                 ++current;

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -112,3 +112,4 @@ TUNEABLE_CONSTANT int history_penalty_depth = -10;
 TUNEABLE_CONSTANT int history_penalty_quad = 40;
 
 TUNEABLE_CONSTANT int good_loud_see = 100;
+TUNEABLE_CONSTANT int good_loud_see_hist = 51;

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -111,4 +111,4 @@ TUNEABLE_CONSTANT int history_penalty_const = 1232;
 TUNEABLE_CONSTANT int history_penalty_depth = -10;
 TUNEABLE_CONSTANT int history_penalty_quad = 40;
 
-TUNEABLE_CONSTANT int good_loud_see = -100;
+TUNEABLE_CONSTANT int good_loud_see = 100;

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -365,7 +365,7 @@ auto Uci::options_handler()
 
         tuneable_int(corr_hist_scale, 64, 256),
 
-        tuneable_int(good_loud_see, -250, 0),
+        tuneable_int(good_loud_see, 0, 200),
 #else
 #endif
     };

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -366,6 +366,7 @@ auto Uci::options_handler()
         tuneable_int(corr_hist_scale, 64, 256),
 
         tuneable_int(good_loud_see, 0, 200),
+        tuneable_int(good_loud_see_hist, 0, 100),
 #else
 #endif
     };


### PR DESCRIPTION
```
Elo   | 4.82 +- 2.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 15206 W: 3746 L: 3535 D: 7925
Penta | [45, 1727, 3871, 1892, 68]
http://chess.grantnet.us/test/39993/
```