### PR TITLE
Refactor 'threats' logic into BoardState

### DIFF
--- a/src/chessboard/board_state.cpp
+++ b/src/chessboard/board_state.cpp
@@ -130,6 +130,7 @@ bool BoardState::init_from_fen(const std::array<std::string_view, 6>& fen)
     non_pawn_key[BLACK] = Zobrist::non_pawn_key(*this, BLACK);
     // minor_key = Zobrist::minor_key(*this);
     // major_key = Zobrist::major_key(*this);
+    update_lesser_threats();
     return true;
 }
 
@@ -709,6 +710,7 @@ void BoardState::apply_move(Move move)
     assert(non_pawn_key[BLACK] == Zobrist::non_pawn_key(*this, BLACK));
     // assert(minor_key == Zobrist::minor_key(*this));
     // assert(major_key == Zobrist::major_key(*this));
+    update_lesser_threats();
 }
 
 void BoardState::apply_null_move()
@@ -732,6 +734,7 @@ void BoardState::apply_null_move()
     assert(non_pawn_key[BLACK] == Zobrist::non_pawn_key(*this, BLACK));
     // assert(minor_key == Zobrist::minor_key(*this));
     // assert(major_key == Zobrist::major_key(*this));
+    update_lesser_threats();
 }
 
 MoveFlag BoardState::infer_move_flag(Square from, Square to) const
@@ -782,4 +785,58 @@ MoveFlag BoardState::infer_move_flag(Square from, Square to) const
     }
 
     return QUIET;
+}
+
+uint64_t BoardState::active_lesser_threats() const
+{
+    return (lesser_threats[KNIGHT] & get_pieces_bb(KNIGHT, stm)) | (lesser_threats[BISHOP] & get_pieces_bb(BISHOP, stm))
+        | (lesser_threats[ROOK] & get_pieces_bb(ROOK, stm)) | (lesser_threats[QUEEN] & get_pieces_bb(QUEEN, stm))
+        | (lesser_threats[KING] & get_pieces_bb(KING, stm));
+}
+
+void BoardState::update_lesser_threats()
+{
+    const uint64_t occ = get_pieces_bb();
+
+    uint64_t attacks = EMPTY;
+
+    // pawn threats
+    for (uint64_t pieces = get_pieces_bb(PAWN, !stm); pieces != 0;)
+    {
+        attacks |= PawnAttacks[!stm][lsbpop(pieces)];
+    }
+
+    lesser_threats[KNIGHT] = attacks;
+
+    // knight threats
+    for (uint64_t pieces = get_pieces_bb(KNIGHT, !stm); pieces != 0;)
+    {
+        attacks |= attack_bb<KNIGHT>(lsbpop(pieces), occ);
+    }
+
+    lesser_threats[BISHOP] = attacks;
+
+    // bishop threats
+    for (uint64_t pieces = get_pieces_bb(BISHOP, !stm); pieces != 0;)
+    {
+        attacks |= attack_bb<BISHOP>(lsbpop(pieces), occ);
+    }
+
+    lesser_threats[ROOK] = attacks;
+
+    // rook threats
+    for (uint64_t pieces = get_pieces_bb(ROOK, !stm); pieces != 0;)
+    {
+        attacks |= attack_bb<ROOK>(lsbpop(pieces), occ);
+    }
+
+    lesser_threats[QUEEN] = attacks;
+
+    // queen threats
+    for (uint64_t pieces = get_pieces_bb(QUEEN, !stm); pieces != 0;)
+    {
+        attacks |= attack_bb<QUEEN>(lsbpop(pieces), occ);
+    }
+
+    lesser_threats[KING] = attacks;
 }

--- a/src/chessboard/board_state.cpp
+++ b/src/chessboard/board_state.cpp
@@ -803,10 +803,9 @@ void BoardState::update_lesser_threats()
     uint64_t attacks = EMPTY;
 
     // pawn threats
-    for (uint64_t pieces = get_pieces_bb(PAWN, !stm); pieces != 0;)
-    {
-        attacks |= PawnAttacks[!stm][lsbpop(pieces)];
-    }
+    uint64_t opp_pawns = get_pieces_bb(PAWN, !stm);
+    attacks |= (stm == WHITE ? shift_bb<Shift::SE>(opp_pawns) : shift_bb<Shift::NE>(opp_pawns));
+    attacks |= (stm == WHITE ? shift_bb<Shift::SW>(opp_pawns) : shift_bb<Shift::NW>(opp_pawns));
 
     lesser_threats[KNIGHT] = attacks;
 

--- a/src/chessboard/board_state.cpp
+++ b/src/chessboard/board_state.cpp
@@ -796,7 +796,9 @@ uint64_t BoardState::active_lesser_threats() const
 
 void BoardState::update_lesser_threats()
 {
-    const uint64_t occ = get_pieces_bb();
+    // x-ray through own king: this has no effect on search, but makes lesser threats useful for king evasion movegen.
+    uint64_t occ = get_pieces_bb();
+    occ ^= get_pieces_bb(KING, stm);
 
     uint64_t attacks = EMPTY;
 

--- a/src/chessboard/board_state.h
+++ b/src/chessboard/board_state.h
@@ -62,9 +62,13 @@ public:
 
     friend std::ostream& operator<<(std::ostream& os, const BoardState& b);
 
+    uint64_t active_lesser_threats() const;
+
 private:
     void recalculate_side_bb();
     void update_castle_rights(Move move);
+
+    void update_lesser_threats();
 
 public:
     uint64_t key = 0;
@@ -72,6 +76,11 @@ public:
     std::array<uint64_t, 2> non_pawn_key {};
     // uint64_t minor_key = 0;
     // uint64_t major_key = 0;
+
+    // mask of squares threatened by a lesser piece e.g lesser_threats[BISHOP] contains all squares attacked by enemy
+    // pawns and knights
+    std::array<uint64_t, N_PIECE_TYPES> lesser_threats {};
+
 private:
     std::array<uint64_t, N_PIECES> board = {};
     std::array<uint64_t, 2> side_bb = {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.12.3";
+constexpr std::string_view version = "14.12.4";
 
 void PrintVersion()
 {

--- a/src/movegen/movegen.h
+++ b/src/movegen/movegen.h
@@ -20,9 +20,6 @@ bool is_in_check(const BoardState& board);
 bool is_legal(const BoardState& board, const Move& move);
 bool ep_is_legal(const BoardState& board, const Move& move);
 
-// Returns a threat mask that only contains winning captures (RxQ, B/NxR/Q, Px!P)
-std::array<uint64_t, N_PIECE_TYPES> capture_threat_mask(const BoardState& board, Side colour);
-
 // Returns the attack bitboard for a piece of piecetype on square sq
 template <PieceType pieceType>
 uint64_t attack_bb(Square sq, uint64_t occupied = EMPTY);

--- a/src/search/data.h
+++ b/src/search/data.h
@@ -51,7 +51,6 @@ struct SearchStackState
 
     Move move = Move::Uninitialized;
     Piece moved_piece = N_PIECES;
-    std::array<uint64_t, N_PIECE_TYPES> threat_mask = {};
 
     Move singular_exclusion = Move::Uninitialized;
 

--- a/src/search/history.cpp
+++ b/src/search/history.cpp
@@ -15,11 +15,11 @@ int16_t* PawnHistory::get(const GameState& position, const SearchStackState*, Mo
     return &table[stm][pawn_hash][piece][move.to()];
 }
 
-int16_t* ThreatHistory::get(const GameState& position, const SearchStackState* ss, Move move)
+int16_t* ThreatHistory::get(const GameState& position, const SearchStackState*, Move move)
 {
     const auto& stm = position.board().stm;
-    const bool from_square_threat = (ss->threat_mask[KING] & SquareBB[move.from()]);
-    const bool to_square_threat = (ss->threat_mask[KING] & SquareBB[move.to()]);
+    const bool from_square_threat = (position.board().lesser_threats[KING] & SquareBB[move.from()]);
+    const bool to_square_threat = (position.board().lesser_threats[KING] & SquareBB[move.to()]);
 
     return &table[stm][from_square_threat][to_square_threat][move.from()][move.to()];
 }

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -788,16 +788,11 @@ Score search(GameState& position, SearchStackState* ss, SearchLocalState& local,
     const auto [raw_eval, eval] = get_search_eval<false>(
         position, ss, shared, local, tt_entry, tt_eval, tt_score, tt_cutoff, depth, distance_from_root, InCheck);
     const bool improving = ss->adjusted_eval > (ss - 2)->adjusted_eval;
-    ss->threat_mask = capture_threat_mask(position.board(), !position.board().stm);
 
     // Step 6: Static null move pruning (a.k.a reverse futility pruning)
     //
     // If the static score is far above beta we fail high.
-    const bool has_active_threat
-        = (ss->threat_mask[KNIGHT] & position.board().get_pieces_bb(KNIGHT, position.board().stm))
-        | (ss->threat_mask[BISHOP] & position.board().get_pieces_bb(BISHOP, position.board().stm))
-        | (ss->threat_mask[ROOK] & position.board().get_pieces_bb(ROOK, position.board().stm))
-        | (ss->threat_mask[QUEEN] & position.board().get_pieces_bb(QUEEN, position.board().stm));
+    const bool has_active_threat = position.board().active_lesser_threats();
     const auto rfp_margin
         = (rfp_const + rfp_depth * (depth - improving) + rfp_quad * (depth - improving) * (depth - improving)) / 64;
     if (!pv_node && !InCheck && ss->singular_exclusion == Move::Uninitialized && depth < rfp_max_d


### PR DESCRIPTION
```
Elo   | 0.53 +- 1.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 44904 W: 10837 L: 10769 D: 23298
Penta | [114, 4237, 13699, 4271, 131]
http://chess.grantnet.us/test/40006/
```