### PR TITLE
Use AVX512_VBMI2 instructions to speed up movegen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.12.4";
+constexpr std::string_view version = "14.13.0";
 
 void PrintVersion()
 {

--- a/src/movegen/list.h
+++ b/src/movegen/list.h
@@ -9,14 +9,9 @@
 struct ExtendedMove
 {
     ExtendedMove() = default;
-    ExtendedMove(const Move _move)
+    ExtendedMove(const Move _move, int _score)
         : move(_move)
-        , score(0)
-    {
-    }
-    ExtendedMove(Square from, Square to, MoveFlag flag)
-        : move(from, to, flag)
-        , score(0)
+        , score(_score)
     {
     }
 

--- a/src/movegen/movegen.cpp
+++ b/src/movegen/movegen.cpp
@@ -948,11 +948,8 @@ uint64_t attack_bb<KING>(Square sq, uint64_t)
 }
 
 // Explicit template instantiation
-template void legal_moves<ExtendedMoveList>(const BoardState& board, ExtendedMoveList& moves);
 template void legal_moves<BasicMoveList>(const BoardState& board, BasicMoveList& moves);
 
-template void loud_moves<ExtendedMoveList>(const BoardState& board, ExtendedMoveList& moves);
 template void loud_moves<BasicMoveList>(const BoardState& board, BasicMoveList& moves);
 
-template void quiet_moves<ExtendedMoveList>(const BoardState& board, ExtendedMoveList& moves);
 template void quiet_moves<BasicMoveList>(const BoardState& board, BasicMoveList& moves);

--- a/src/movegen/movegen.cpp
+++ b/src/movegen/movegen.cpp
@@ -272,7 +272,7 @@ template <Side STM, typename T>
 void append_legal_moves(uint64_t from, Square to, MoveFlag flag, T& moves)
 {
 #ifdef USE_AVX512_VNNI
-    // Precomputed table of move encodings: move from square -> to square, with a flag
+    // Idea by 87flowers, Using AVX512_VBMI2 instructions, we can splat moves in parallel
     alignas(64) static constexpr std::array<std::array<std::array<int16_t, N_SQUARES>, N_SQUARES>, 16>
         legal_moves_to_sq_template = []
     {

--- a/src/movegen/movegen.cpp
+++ b/src/movegen/movegen.cpp
@@ -229,13 +229,13 @@ void append_legal_moves(Square from, uint64_t to, MoveFlag flag, T& moves)
         legal_moves_from_sq_template = []
     {
         std::array<std::array<std::array<int16_t, N_SQUARES>, N_SQUARES>, 16> cache {};
-        for (int flag = 0; flag < 16; ++flag)
+        for (int flag_ = 0; flag_ < 16; ++flag_)
         {
-            for (Square from = SQ_A1; from < N_SQUARES; ++from)
+            for (Square from_ = SQ_A1; from_ < N_SQUARES; ++from_)
             {
-                for (Square to = SQ_A1; to < N_SQUARES; ++to)
+                for (Square to_ = SQ_A1; to_ < N_SQUARES; ++to_)
                 {
-                    cache[flag][from][to] = (from | (to << 6) | (flag << 12));
+                    cache[flag_][from_][to_] = (from_ | (to_ << 6) | (flag_ << 12));
                 }
             }
         }
@@ -277,13 +277,13 @@ void append_legal_moves(uint64_t from, Square to, MoveFlag flag, T& moves)
         legal_moves_to_sq_template = []
     {
         std::array<std::array<std::array<int16_t, N_SQUARES>, N_SQUARES>, 16> cache {};
-        for (int flag = 0; flag < 16; ++flag)
+        for (int flag_ = 0; flag_ < 16; ++flag_)
         {
-            for (Square from = SQ_A1; from < N_SQUARES; ++from)
+            for (Square from_ = SQ_A1; from_ < N_SQUARES; ++from_)
             {
-                for (Square to = SQ_A1; to < N_SQUARES; ++to)
+                for (Square to_ = SQ_A1; to_ < N_SQUARES; ++to_)
                 {
-                    cache[flag][to][from] = (from | (to << 6) | (flag << 12));
+                    cache[flag_][to_][from_] = (from_ | (to_ << 6) | (flag_ << 12));
                 }
             }
         }

--- a/src/search/staged_movegen.h
+++ b/src/search/staged_movegen.h
@@ -58,8 +58,8 @@ public:
     }
 
 private:
-    void score_quiet_moves(ExtendedMoveList& moves);
-    void score_loud_moves(ExtendedMoveList& moves);
+    void score_quiet_moves(BasicMoveList& moves);
+    void score_loud_moves(BasicMoveList& moves);
 
     // Data needed for use in ordering or generating moves
     const GameState& position;

--- a/src/utility/static_vector.h
+++ b/src/utility/static_vector.h
@@ -255,4 +255,11 @@ public:
         assert(size_ > 0);
         size_--;
     }
+
+    // extensions
+    void unsafe_resize(std::size_t new_size)
+    {
+        assert(new_size <= N);
+        size_ = new_size;
+    }
 };


### PR DESCRIPTION
Need to fix warnings, and segfault in search

------

Baseline: `Nodes searched: 8031647685 in 15.8891 seconds (505480301 nps)`
Dev: `Nodes searched: 8031647685 in 12.3739 seconds (649077260 nps)`

28.4% perft speedup

-----

Elo   | 2.87 +- 1.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 3.00]
Games | N: 25466 W: 6244 L: 6034 D: 13188
Penta | [59, 2302, 7807, 2500, 65]
http://chess.grantnet.us/test/40008/
