### PR TITLE
Use compress_epi16 to process 32 blocks of 4 FT activations at once

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.13.1";
+constexpr std::string_view version = "14.14.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
`3.399 %  +/-  0.733 %` speedup

```
Elo   | 7.04 +- 3.45 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 3.00]
Games | N: 9866 W: 2528 L: 2328 D: 5010
Penta | [39, 980, 2708, 1154, 52]
http://chess.grantnet.us/test/40010/
```