### PR TITLE
Use dpbusd, mask_compressstoreu, to speedup Zen5 builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -124,9 +124,13 @@ endif
 
 # Detect the highest AVX instruction set supported
 
+# We use some instructions (dpbusd_epi32, mask_compressstoreu_epi16) which are slower on Zen 4, so we disable them for that architecture.
 ifneq ($(findstring __AVX512VNNI__, $(SUPPORTED)),)
-	CFLAGS += -DUSE_AVX512_VNNI
+	ifeq ($(findstring __znver4, $(SUPPORTED)),)
+		CFLAGS += -DUSE_AVX512_VNNI
+	endif
 endif
+
 ifneq ($(findstring __AVX512F__, $(SUPPORTED)),)
 	CFLAGS += -DUSE_AVX512
 endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.14.0";
+constexpr std::string_view version = "14.15.0";
 
 void PrintVersion()
 {

--- a/src/network/inference.hpp
+++ b/src/network/inference.hpp
@@ -133,9 +133,7 @@ void FT_activation(const std::array<int16_t, FT_SIZE>& stm, const std::array<int
 #if defined(USE_AVX512_VNNI)
         auto indicies = SIMD::load_si(nibble_offset_table.data());
         indicies = SIMD::add_epi16(indicies, sparse_nibble_offset);
-        auto compressed = _mm512_maskz_compress_epi16(mask, indicies);
-        assert(sparse_nibbles_size + popcount(mask) <= sparse_nibbles.size());
-        _mm512_storeu_si512(&sparse_nibbles[sparse_nibbles_size], compressed);
+        _mm512_mask_compressstoreu_epi16(&sparse_nibbles[sparse_nibbles_size], mask, indicies);
         sparse_nibbles_size += popcount(mask);
         sparse_nibble_offset = SIMD::add_epi32(sparse_nibble_offset, sparse_nibble_offset_adj);
 #else
@@ -195,9 +193,7 @@ void FT_activation(const std::array<int16_t, FT_SIZE>& stm, const std::array<int
 #if defined(USE_AVX512_VNNI)
         auto indicies = SIMD::load_si(nibble_offset_table.data());
         indicies = SIMD::add_epi16(indicies, sparse_nibble_offset);
-        auto compressed = _mm512_maskz_compress_epi16(mask, indicies);
-        assert(sparse_nibbles_size + popcount(mask) <= sparse_nibbles.size());
-        _mm512_storeu_si512(&sparse_nibbles[sparse_nibbles_size], compressed);
+        _mm512_mask_compressstoreu_epi16(&sparse_nibbles[sparse_nibbles_size], mask, indicies);
         sparse_nibbles_size += popcount(mask);
         sparse_nibble_offset = SIMD::add_epi32(sparse_nibble_offset, sparse_nibble_offset_adj);
 #else

--- a/src/network/simd/definitions.hpp
+++ b/src/network/simd/definitions.hpp
@@ -253,12 +253,8 @@ static const auto madd_helper = SIMD::set1_epi16(1);
 
 inline veci dpbusd_epi32(const veci& source, const veci& a, const veci& b)
 {
-// In my testing, _mm512_dpbusd_epi32 seems to be slower even on Zen5.
 #if defined(USE_AVX512_VNNI)
-    // return _mm512_dpbusd_epi32(source, a, b);
-    auto dot = _mm512_maddubs_epi16(a, b);
-    dot = _mm512_madd_epi16(dot, madd_helper);
-    return _mm512_add_epi32(source, dot);
+    return _mm512_dpbusd_epi32(source, a, b);
 #elif defined(USE_AVX512)
     auto dot = _mm512_maddubs_epi16(a, b);
     dot = _mm512_madd_epi16(dot, madd_helper);


### PR DESCRIPTION
`1.183 %  +/-  0.217 %` speedup

Bench: 7609093