### PR TITLE
Update default network to b5e00695.nn

### DIFF
--- a/.github/workflows/fastchess.yml
+++ b/.github/workflows/fastchess.yml
@@ -113,9 +113,6 @@ jobs:
         run: |
           export TSAN_OPTIONS="suppressions=../Halogen/src/test/tsan.supp"
           ./bin/Halogen "setoption name MultiPV value 8" "setoption name Threads value 4" "position fen 1r4k1/8/5PP1/K7/6NR/7B/1r6/7R w - - 0 1" "go movetime 10000" 2>&1 | tee out.log
-          ./bin/Halogen "setoption name MultiPV value 8" "setoption name Threads value 4" "position fen 1r4k1/8/5PP1/K7/6NR/7B/1r6/7R w - - 0 1" "go mate 3" 2>&1 | tee out.log
-          ./bin/Halogen "setoption name MultiPV value 8" "setoption name Threads value 4" "position fen 1r4k1/8/5PP1/K7/6NR/7B/1r6/7R w - - 0 1" "go nodes 100000" 2>&1 | tee out.log
-          ./bin/Halogen "setoption name MultiPV value 8" "setoption name Threads value 4" "position fen 1r4k1/8/5PP1/K7/6NR/7B/1r6/7R w - - 0 1" "go depth 8" 2>&1 | tee out.log
           if grep -q "ThreadSanitizer" out.log; then
             echo "ERROR: ThreadSanitizer found"
             exit 1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,8 +12,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        # removed legacy and sse4 due to floats causing non-deterministic benches
-        arch: [ avx, avx2, avx2-pext, avx512, avx512vnni ]
+        arch: [ legacy, sse4, avx, avx2, avx2-pext, avx512, avx512vnni ]
         os: [ ubuntu-latest, windows-latest ]
         include:
           - os: windows-latest
@@ -73,7 +72,8 @@ jobs:
         mv ${{ github.workspace }}/build/Halogen${{ matrix.extension }} ${{ github.workspace }}/Halogen-${{ env.VERSION }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.extension }}
 
     # only avx2 and below supported on github runners
-    - if: matrix.os == 'ubuntu-latest' && matrix.arch != 'avx512vnni' && matrix.arch != 'avx512'
+    # legacy and sse4 skipped due to non-deterministic bench due to floats
+    - if: matrix.os == 'ubuntu-latest' && matrix.arch != 'avx512vnni' && matrix.arch != 'avx512' && matrix.arch != 'legacy' && matrix.arch != 'sse4'
       name: Verify (Linux)
       run: |
         commit_bench=$(git show --summary | grep -o "Bench: [0-9]*" | awk '{ print $NF }')
@@ -84,7 +84,7 @@ jobs:
           echo "Got correct bench $actual_bench"
         fi
 
-    - if: matrix.os == 'windows-latest' && matrix.arch != 'avx512vnni' && matrix.arch != 'avx512'
+    - if: matrix.os == 'windows-latest' && matrix.arch != 'avx512vnni' && matrix.arch != 'avx512' && matrix.arch != 'legacy' && matrix.arch != 'sse4'
       name: Verify (Windows)
       shell: pwsh
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,7 +12,8 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        arch: [ legacy, sse4, avx, avx2, avx2-pext, avx512, avx512vnni ]
+        # removed legacy and sse4 due to floats causing non-deterministic benches
+        arch: [ avx, avx2, avx2-pext, avx512, avx512vnni ]
         os: [ ubuntu-latest, windows-latest ]
         include:
           - os: windows-latest

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ BUILD_DIR := ../build
 BINARY_DIR := ../bin
 
 ifndef EVALFILE
-    NET_HASH := 2a2c41df
+    NET_HASH := b5e00695
     EVALFILE := $(BUILD_DIR)/$(NET_HASH).nn
     NO_EVALFILE_SET = true
 endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.16.3";
+constexpr std::string_view version = "14.17.0";
 
 void PrintVersion()
 {


### PR DESCRIPTION
Increased WDL from 0.5 to 0.7

The datasets used were as follows:

| File       | Origin                                        | Fens |
|------------|-----------------------------------------------|------|
| datagen3+4 | 11.24.0 + 768-512x2-1_r18_g2771316.nn         | 0.6B |
| datagen5+6 | 11.30.0 + bullet_r10_768-512x2-1-epoch100.bin | 0.7B |
| datagen7..15| 12.0.0                                        | 8.2B |

The bullet trainer was used with [config](https://github.com/KierenP/bullet/blob/c9df285d560dbf7aaefbfa0d8cf22adbcdd6e1f6/examples/halogen.rs).

-----------------------------

failed STC
```
Elo   | -7.52 +- 4.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -3.01 (-2.94, 2.94) [0.00, 3.00]
Games | N: 7814 W: 1857 L: 2026 D: 3931
Penta | [48, 1028, 1914, 879, 38]
http://chess.grantnet.us/test/40027/
```
neutral LTC
```
Elo   | 0.41 +- 1.74 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -0.65 (-2.94, 2.94) [0.00, 3.00]
Games | N: 38346 W: 9196 L: 9151 D: 19999
Penta | [93, 4467, 9950, 4628, 35]
http://chess.grantnet.us/test/40028/
``` 
passed VLTC 
```
Elo   | 2.71 +- 2.17 (95%)
SPRT  | 120.0+1.20s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 23164 W: 5616 L: 5435 D: 12113
Penta | [19, 2577, 6198, 2780, 8]
http://chess.grantnet.us/test/40029/
```