### PR TITLE
Calculate pinned and checker masks in board state

### DIFF
--- a/src/chessboard/board_state.cpp
+++ b/src/chessboard/board_state.cpp
@@ -793,7 +793,7 @@ void BoardState::update_checkers()
     checkers |= (attack_bb<BISHOP>(king, occ) & (bishops | queens));
     checkers |= (attack_bb<ROOK>(king, occ) & (rooks | queens));
 
-    assert(popcount(checkers) <= 2); // triple or more check is impossible
+    assert(std::popcount(checkers) <= 2); // triple or more check is impossible
 }
 
 void BoardState::update_pinned()
@@ -813,7 +813,7 @@ void BoardState::update_pinned()
             const uint64_t possible_pins = BetweenBB[king][threat_sq] & all_pieces;
 
             // if there is just one piece and it's ours it's pinned
-            if (popcount(possible_pins) == 1 && (possible_pins & our_pieces) != EMPTY)
+            if (std::popcount(possible_pins) == 1 && (possible_pins & our_pieces) != EMPTY)
             {
                 pinned |= possible_pins;
             }

--- a/src/chessboard/board_state.cpp
+++ b/src/chessboard/board_state.cpp
@@ -129,6 +129,8 @@ bool BoardState::init_from_fen(const std::array<std::string_view, 6>& fen)
     non_pawn_key[WHITE] = Zobrist::non_pawn_key(*this, WHITE);
     non_pawn_key[BLACK] = Zobrist::non_pawn_key(*this, BLACK);
     update_lesser_threats();
+    update_checkers();
+    update_pinned();
     return true;
 }
 
@@ -641,6 +643,8 @@ void BoardState::apply_move(Move move)
     assert(non_pawn_key[WHITE] == Zobrist::non_pawn_key(*this, WHITE));
     assert(non_pawn_key[BLACK] == Zobrist::non_pawn_key(*this, BLACK));
     update_lesser_threats();
+    update_checkers();
+    update_pinned();
 }
 
 void BoardState::apply_null_move()
@@ -663,6 +667,8 @@ void BoardState::apply_null_move()
     assert(non_pawn_key[WHITE] == Zobrist::non_pawn_key(*this, WHITE));
     assert(non_pawn_key[BLACK] == Zobrist::non_pawn_key(*this, BLACK));
     update_lesser_threats();
+    update_checkers();
+    update_pinned();
 }
 
 MoveFlag BoardState::infer_move_flag(Square from, Square to) const
@@ -768,4 +774,57 @@ void BoardState::update_lesser_threats()
     }
 
     lesser_threats[KING] = attacks;
+}
+
+void BoardState::update_checkers()
+{
+    checkers = EMPTY;
+
+    const auto king = get_king_sq(stm);
+
+    const uint64_t queens = get_pieces_bb(QUEEN, !stm);
+    const uint64_t bishops = get_pieces_bb(BISHOP, !stm);
+    const uint64_t rooks = get_pieces_bb(ROOK, !stm);
+    const uint64_t occ = get_pieces_bb();
+
+    checkers |= (attack_bb<KNIGHT>(king) & get_pieces_bb(KNIGHT, !stm));
+    checkers |= (PawnAttacks[stm][king] & get_pieces_bb(PAWN, !stm));
+    checkers |= (attack_bb<KING>(king) & get_pieces_bb(KING, !stm));
+    checkers |= (attack_bb<BISHOP>(king, occ) & (bishops | queens));
+    checkers |= (attack_bb<ROOK>(king, occ) & (rooks | queens));
+
+    assert(popcount(checkers) <= 2); // triple or more check is impossible
+}
+
+void BoardState::update_pinned()
+{
+    const Square king = get_king_sq(stm);
+    const uint64_t all_pieces = get_pieces_bb();
+    const uint64_t our_pieces = get_pieces_bb(stm);
+    pinned = EMPTY;
+
+    auto check_for_pins = [&](uint64_t threats)
+    {
+        while (threats)
+        {
+            const Square threat_sq = lsbpop(threats);
+
+            // get the pieces standing in between the king and the threat
+            const uint64_t possible_pins = BetweenBB[king][threat_sq] & all_pieces;
+
+            // if there is just one piece and it's ours it's pinned
+            if (popcount(possible_pins) == 1 && (possible_pins & our_pieces) != EMPTY)
+            {
+                pinned |= possible_pins;
+            }
+        }
+    };
+
+    // get the enemy bishops and queens on the kings diagonal
+    const auto bishops_and_queens = get_pieces_bb(BISHOP, !stm) | get_pieces_bb(QUEEN, !stm);
+    const auto rooks_and_queens = get_pieces_bb(ROOK, !stm) | get_pieces_bb(QUEEN, !stm);
+    check_for_pins(DiagonalBB[enum_to<Diagonal>(king)] & bishops_and_queens);
+    check_for_pins(AntiDiagonalBB[enum_to<AntiDiagonal>(king)] & bishops_and_queens);
+    check_for_pins(RankBB[enum_to<Rank>(king)] & rooks_and_queens);
+    check_for_pins(FileBB[enum_to<File>(king)] & rooks_and_queens);
 }

--- a/src/chessboard/board_state.h
+++ b/src/chessboard/board_state.h
@@ -69,6 +69,8 @@ private:
     void update_castle_rights(Move move);
 
     void update_lesser_threats();
+    void update_checkers();
+    void update_pinned();
 
 public:
     uint64_t key = 0;
@@ -78,6 +80,9 @@ public:
     // mask of squares threatened by a lesser piece e.g lesser_threats[BISHOP] contains all squares attacked by enemy
     // pawns and knights
     std::array<uint64_t, N_PIECE_TYPES> lesser_threats {};
+
+    uint64_t checkers {};
+    uint64_t pinned {};
 
 private:
     std::array<uint64_t, N_PIECES> board = {};

--- a/src/datagen/datagen.cpp
+++ b/src/datagen/datagen.cpp
@@ -186,7 +186,7 @@ void self_play_game(GameState& position, SearchThreadPool& pool, const SearchLim
         legal_moves(position.board(), moves);
         if (moves.size() == 0)
         {
-            if (is_in_check(position.board()))
+            if (position.board().checkers)
             {
                 if (position.board().stm == WHITE)
                 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.17.2";
+constexpr std::string_view version = "14.17.3";
 
 void PrintVersion()
 {

--- a/src/movegen/movegen.h
+++ b/src/movegen/movegen.h
@@ -14,9 +14,6 @@ void loud_moves(const BoardState& board, T& moves);
 template <typename T>
 void quiet_moves(const BoardState& board, T& moves);
 
-bool is_in_check(const BoardState& board, Side colour);
-bool is_in_check(const BoardState& board);
-
 bool is_legal(const BoardState& board, const Move& move);
 bool ep_is_legal(const BoardState& board, const Move& move);
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -239,7 +239,7 @@ std::optional<Score> init_search_node(const GameState& position, const int dista
 
     if (position.board().fifty_move_count >= 100)
     {
-        if (is_in_check(position.board()))
+        if (position.board().checkers)
         {
             BasicMoveList moves;
             legal_moves(position.board(), moves);
@@ -727,7 +727,7 @@ Score search(GameState& position, SearchStackState* ss, SearchLocalState& local,
     assert(!(pv_node && cut_node));
     [[maybe_unused]] const bool allNode = !(pv_node || cut_node);
     const auto distance_from_root = ss->distance_from_root;
-    const bool InCheck = is_in_check(position.board());
+    const bool InCheck = position.board().checkers;
 
     // Step 1: Drop into q-search
     if (depth <= 0)
@@ -931,7 +931,7 @@ Score search(GameState& position, SearchStackState* ss, SearchLocalState& local,
         local.net.store_lazy_updates(position.prev_board(), position.board(), (ss + 1)->acc, move);
 
         // Step 15: Check extensions
-        if (is_in_check(position.board()))
+        if (position.board().checkers)
         {
             extensions += 1;
         }
@@ -1053,7 +1053,7 @@ Score qsearch(GameState& position, SearchStackState* ss, SearchLocalState& local
         }
     }
 
-    const bool in_check = is_in_check(position.board());
+    const bool in_check = position.board().checkers;
     const auto [raw_eval, eval] = get_search_eval<true>(
         position, ss, shared, local, tt_entry, tt_eval, tt_score, tt_cutoff, depth, distance_from_root, in_check);
     auto score = in_check ? std::numeric_limits<Score>::min() : eval;


### PR DESCRIPTION
```
Elo   | -1.27 +- 1.25 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | -1.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 69640 W: 16958 L: 17213 D: 35469
Penta | [365, 6883, 20523, 6740, 309]
http://chess.grantnet.us/test/40043/
```