### PR TITLE
Don't track depth in qsearch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.18.1";
+constexpr std::string_view version = "14.18.2";
 
 void PrintVersion()
 {


### PR DESCRIPTION
```
Elo   | 3.99 +- 3.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 12964 W: 3191 L: 3042 D: 6731
Penta | [52, 1460, 3308, 1611, 51]
http://chess.grantnet.us/test/40061/
```