### PR TITLE
Hoist pinned checks in movegen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "14.19.0";
+constexpr std::string_view version = "14.19.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
2.5% perft speedup

```
Before: Nodes searched: 3195901860 in 12.5357 seconds (254944192 nps)
After: Nodes searched: 3195901860 in 12.2229 seconds (261468296 nps)
```

Changes bench. Likely should test as nonregr.

Bench: 6888592