### PR TITLE
Fix makefile for network shuffle utility

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -199,7 +199,7 @@ tune: LDFLAGS += -flto
 tune: EXE = $(BINARY_DIR)/Halogen-tune
 tune: verbatim_binary binary
 
-shuffle: VERBATIM_FLAGS=$(CFLAGS)
+shuffle: VERBATIM_FLAGS=$(CFLAGS) -DNETWORK_SHUFFLE
 shuffle: CXXFLAGS += $(CFLAGS) -DNETWORK_SHUFFLE -fopenmp
 shuffle: LDFLAGS += -flto -fopenmp
 shuffle: EXE = $(BINARY_DIR)/Halogen-shuffle

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "15.0.0";
+constexpr std::string_view version = "15.0.1";
 
 void PrintVersion()
 {


### PR DESCRIPTION
Affected tests: r93, r94, r95