### PR TITLE
Don't apply TT eval correction in singular nodes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "15.2.0";
+constexpr std::string_view version = "15.3.0";
 
 void PrintVersion()
 {

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -667,7 +667,9 @@ std::tuple<Score, Score> get_search_eval(const GameState& position, SearchStackS
         ss->adjusted_eval = adjusted_eval;
 
         // Use the tt_score to improve the static eval if possible. Avoid returning unproved mate scores in q-search
-        if (tt_score != SCORE_UNDEFINED && (!is_qsearch || !tt_score.is_decisive())
+        // Don't apply tt eval correction if we are in a singular search
+        if (ss->singular_exclusion == Move::Uninitialized && tt_score != SCORE_UNDEFINED
+            && (!is_qsearch || !tt_score.is_decisive())
             && (tt_cutoff == SearchResultType::EXACT
                 || (tt_cutoff == SearchResultType::LOWER_BOUND && tt_score >= adjusted_eval)
                 || (tt_cutoff == SearchResultType::UPPER_BOUND && tt_score <= adjusted_eval)))


### PR DESCRIPTION
```
Elo   | 2.89 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 29290 W: 7161 L: 6917 D: 15212
Penta | [122, 3356, 7432, 3626, 109]
http://chess.grantnet.us/test/40136/
```