### PR TITLE
Allow fail high TT cutoffs with insufficient depth when tt score is sufficiently high

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "15.3.0";
+constexpr std::string_view version = "15.4.0";
 
 void PrintVersion()
 {

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -866,11 +866,15 @@ Score search(GameState& position, SearchStackState* ss, NN::Accumulator* acc, Se
         }
     }
 
-    // Idea from Stockfish: in-check probcut
-    const auto in_check_probcut_beta = beta + 400;
-    if (tt_cutoff == SearchResultType::LOWER_BOUND && tt_depth >= depth - 4 && tt_score >= in_check_probcut_beta)
+    // Idea from Stockfish: Generalized TT cutoffs
+    //
+    // If the TT entry has a insufficient depth but a LOWER_BOUND cutoff, but the score is sufficiently above beta, then
+    // we cutoff anyways.
+    const auto generalized_tt_failhigh_beta = beta + generalized_tt_failhigh_margin;
+    if (tt_cutoff == SearchResultType::LOWER_BOUND && tt_depth >= depth - generalized_tt_failhigh_depth
+        && tt_score >= generalized_tt_failhigh_beta)
     {
-        return in_check_probcut_beta;
+        return generalized_tt_failhigh_beta;
     }
 
     // Step 8: Mate distance pruning

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -866,6 +866,13 @@ Score search(GameState& position, SearchStackState* ss, NN::Accumulator* acc, Se
         }
     }
 
+    // Idea from Stockfish: in-check probcut
+    const auto in_check_probcut_beta = beta + 400;
+    if (tt_cutoff == SearchResultType::LOWER_BOUND && tt_depth >= depth - 4 && tt_score >= in_check_probcut_beta)
+    {
+        return in_check_probcut_beta;
+    }
+
     // Step 8: Mate distance pruning
     alpha = std::max(Score::mated_in(distance_from_root), alpha);
     beta = std::min(Score::mate_in(distance_from_root + 1), beta);

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -121,3 +121,6 @@ TUNEABLE_CONSTANT int qsearch_see_hist = 179;
 TUNEABLE_CONSTANT int probcut_beta = 213;
 TUNEABLE_CONSTANT int probcut_min_depth = 3;
 TUNEABLE_CONSTANT int probcut_depth_const = 5;
+
+TUNEABLE_CONSTANT int generalized_tt_failhigh_margin = 400;
+TUNEABLE_CONSTANT int generalized_tt_failhigh_depth = 4;

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -360,6 +360,9 @@ auto Uci::options_handler()
         tuneable_int(probcut_min_depth, 1, 5),
         tuneable_int(probcut_depth_const, 3, 7),
 
+        tuneable_int(generalized_tt_failhigh_margin, 200, 600),
+        tuneable_int(generalized_tt_failhigh_depth, 2, 6),
+
         tuneable_int(PawnHistory::max_value, 1000, 32000),
         tuneable_int(PawnHistory::scale, 20, 50),
         tuneable_int(ThreatHistory::max_value, 1000, 32000),


### PR DESCRIPTION
```
Elo   | 2.26 +- 1.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 41584 W: 10053 L: 9783 D: 21748
Penta | [143, 4838, 10567, 5094, 150]
http://chess.grantnet.us/test/40143/
```