### PR TITLE
Add hindsight extensions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "test/static_exchange_evaluation_test.h"
 #include "uci/uci.h"
 
-constexpr std::string_view version = "15.5.3";
+constexpr std::string_view version = "15.6.0";
 
 void PrintVersion()
 {

--- a/src/search/data.h
+++ b/src/search/data.h
@@ -63,6 +63,7 @@ struct SearchStackState
     PieceMoveCorrHistory* cont_corr_hist_subtable = nullptr;
 
     Score adjusted_eval = 0;
+    int reduction = 0;
 };
 
 class SearchStack

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -796,7 +796,12 @@ Score search(GameState& position, SearchStackState* ss, NN::Accumulator* acc, Se
         position, ss, acc, shared, local, tt_entry, tt_eval, tt_score, tt_cutoff, depth, distance_from_root, InCheck);
     const bool improving = ss->adjusted_eval > (ss - 2)->adjusted_eval;
 
-    if ((ss - 1)->reduction >= 3 && ss->adjusted_eval + (ss - 1)->adjusted_eval < 0)
+    // Hindsight adjustments
+    //
+    // First added to Stockfish, we use the current nodes eval to adjust the LMR reduction applied with the benefit of
+    // hindsight if the static eval turned out to be better or worse than expected.
+    if ((ss - 1)->reduction >= lmr_hindsight_ext_depth
+        && ss->adjusted_eval + (ss - 1)->adjusted_eval < lmr_hindsight_ext_margin)
     {
         depth++;
     }

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -586,8 +586,10 @@ Score search_move(GameState& position, SearchStackState* ss, NN::Accumulator* ac
 
     if (reductions > 0)
     {
+        ss->reduction = reductions;
         search_score = -search<SearchType::ZW>(
             position, ss + 1, acc + 1, local, shared, new_depth - reductions, -(alpha + 1), -alpha, true);
+        ss->reduction = 0;
 
         if (search_score > alpha)
         {
@@ -793,6 +795,11 @@ Score search(GameState& position, SearchStackState* ss, NN::Accumulator* acc, Se
     const auto [raw_eval, eval] = get_search_eval<false>(
         position, ss, acc, shared, local, tt_entry, tt_eval, tt_score, tt_cutoff, depth, distance_from_root, InCheck);
     const bool improving = ss->adjusted_eval > (ss - 2)->adjusted_eval;
+
+    if ((ss - 1)->reduction >= 3 && ss->adjusted_eval + (ss - 1)->adjusted_eval < 0)
+    {
+        depth++;
+    }
 
     // Step 6: Static null move pruning (a.k.a reverse futility pruning)
     //

--- a/src/spsa/tuneable.h
+++ b/src/spsa/tuneable.h
@@ -59,6 +59,9 @@ TUNEABLE_CONSTANT int lmr_h = 2284;
 TUNEABLE_CONSTANT int lmr_offset = 484;
 TUNEABLE_CONSTANT int lmr_shallower = 10;
 
+TUNEABLE_CONSTANT int lmr_hindsight_ext_depth = 3;
+TUNEABLE_CONSTANT int lmr_hindsight_ext_margin = 0;
+
 TUNEABLE_CONSTANT int fifty_mr_scale_a = 291;
 TUNEABLE_CONSTANT int fifty_mr_scale_b = 209;
 

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -290,6 +290,9 @@ auto Uci::options_handler()
         tuneable_int(lmr_offset, 0, 1000),
         tuneable_int(lmr_shallower, 0, 30),
 
+        tuneable_int(lmr_hindsight_ext_depth, 0, 6),
+        tuneable_int(lmr_hindsight_ext_margin, -200, 200),
+
         tuneable_int(fifty_mr_scale_a, 100, 350),
         tuneable_int(fifty_mr_scale_b, 100, 350),
 


### PR DESCRIPTION
```
Elo   | 1.33 +- 1.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.48 (-2.94, 2.94) [0.00, 3.00]
Games | N: 96530 W: 22951 L: 22582 D: 50997
Penta | [415, 11396, 24290, 11733, 431]
http://chess.grantnet.us/test/40181/
```