### PR TITLE
Speedup cmpgt_i32_mask computation on NEON

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.4.5";
+constexpr std::string_view version = "16.4.6";
 
 int main(int argc, char* argv[])
 {

--- a/src/network/simd/intrinsics.hpp
+++ b/src/network/simd/intrinsics.hpp
@@ -347,12 +347,10 @@ inline uint16_t cmpgt_i32_mask(const vecu8& a)
 #elif defined(USE_NEON)
     uint32x4_t a_u32 = vreinterpretq_u32_u8(a);
     uint32x4_t cmp = vcgtq_u32(a_u32, vdupq_n_u32(0));
-    uint32_t mask = 0;
-    mask |= (vgetq_lane_u32(cmp, 0) & 1) << 0;
-    mask |= (vgetq_lane_u32(cmp, 1) & 1) << 1;
-    mask |= (vgetq_lane_u32(cmp, 2) & 1) << 2;
-    mask |= (vgetq_lane_u32(cmp, 3) & 1) << 3;
-    return mask;
+    static const uint32x4_t weights = { 1u, 2u, 4u, 8u };
+    uint32x4_t bits = vshrq_n_u32(cmp, 31);
+    bits = vmulq_u32(bits, weights);
+    return vaddvq_u32(bits);
 #endif
 }
 

--- a/src/network/simd/intrinsics.hpp
+++ b/src/network/simd/intrinsics.hpp
@@ -335,6 +335,10 @@ inline vecu8 pack_i16_to_u8(const veci16& a, const veci16& b)
 #endif
 }
 
+#if defined(USE_NEON)
+static const uint32x4_t cmpgt_i32_bits = { 1u, 2u, 4u, 8u };
+#endif
+
 inline uint16_t cmpgt_i32_mask(const vecu8& a)
 {
 #if defined(USE_AVX512)
@@ -347,10 +351,7 @@ inline uint16_t cmpgt_i32_mask(const vecu8& a)
 #elif defined(USE_NEON)
     uint32x4_t a_u32 = vreinterpretq_u32_u8(a);
     uint32x4_t cmp = vcgtq_u32(a_u32, vdupq_n_u32(0));
-    static const uint32x4_t weights = { 1u, 2u, 4u, 8u };
-    uint32x4_t bits = vshrq_n_u32(cmp, 31);
-    bits = vmulq_u32(bits, weights);
-    return vaddvq_u32(bits);
+    return vaddvq_u32(vandq_u32(cmp, cmpgt_i32_bits));
 #endif
 }
 


### PR DESCRIPTION
Thanks @sp00ph for measuring the speed:

```
Benchmark 1: ./halogen-base bench > /dev/null
  Time (mean ± σ):     11.789 s ±  0.239 s    [User: 11.723 s, System: 0.017 s]
  Range (min … max):   11.511 s … 12.174 s    10 runs

Benchmark 2: ./halogen-dev bench > /dev/null
  Time (mean ± σ):     11.646 s ±  0.222 s    [User: 11.582 s, System: 0.015 s]
  Range (min … max):   11.412 s … 12.187 s    10 runs

Summary
  ./halogen-dev bench > /dev/null ran
    1.01 ± 0.03 times faster than ./halogen-base bench > /dev/null
```