### PR TITLE
Variable fused add/sub operations for threat accumulators

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.5.2";
+constexpr std::string_view version = "16.5.3";
 
 int main(int argc, char* argv[])
 {

--- a/src/network/accumulator/threat.cpp
+++ b/src/network/accumulator/threat.cpp
@@ -437,8 +437,6 @@ void ThreatAccumulator::recalculate_side_from_scratch(const BoardState& board, c
 void ThreatAccumulator::apply_lazy_updates(
     const ThreatAccumulator& prev, const BoardState& board, const NN::network& net)
 {
-    // ~3% speedup from prefetching
-
     std::array<uint32_t, MAX_THREAT_DELTAS> w_add_delta_indicies;
     std::array<uint32_t, MAX_THREAT_DELTAS> w_sub_delta_indicies;
     std::array<uint32_t, MAX_THREAT_DELTAS> b_add_delta_indicies;
@@ -503,66 +501,45 @@ void ThreatAccumulator::apply_lazy_updates(
         }
     }
 
+    // Gather weight pointers, prefetch them, then fold into a single fused add/sub operation
+    auto apply_side = [&net](std::array<int16_t, FT_SIZE>& out, const std::array<int16_t, FT_SIZE>& in,
+                          const uint32_t* add_indicies, size_t n_add, const uint32_t* sub_indicies, size_t n_sub)
+    {
+        std::array<const int8_t*, MAX_THREAT_DELTAS> add_ptrs;
+        std::array<const int8_t*, MAX_THREAT_DELTAS> sub_ptrs;
+        for (size_t i = 0; i < n_add; i++)
+        {
+            add_ptrs[i] = net.ft_threat_weight[add_indicies[i]].data();
+            __builtin_prefetch(add_ptrs[i]);
+        }
+        for (size_t i = 0; i < n_sub; i++)
+        {
+            sub_ptrs[i] = net.ft_threat_weight[sub_indicies[i]].data();
+            __builtin_prefetch(sub_ptrs[i]);
+        }
+        NN::add_n_sub_n(out, in, add_ptrs.data(), n_add, sub_ptrs.data(), n_sub);
+    };
+
     if (white_threats_requires_recalculation)
     {
         recalculate_side_from_scratch(board, net, WHITE);
-        side[BLACK] = prev.side[BLACK];
         assert(w_sub_delta_indicies_size == 0 && w_add_delta_indicies_size == 0);
+        apply_side(side[BLACK], prev.side[BLACK], b_add_delta_indicies.data(), b_add_delta_indicies_size,
+            b_sub_delta_indicies.data(), b_sub_delta_indicies_size);
     }
     else if (black_threats_requires_recalculation)
     {
         recalculate_side_from_scratch(board, net, BLACK);
-        side[WHITE] = prev.side[WHITE];
         assert(b_sub_delta_indicies_size == 0 && b_add_delta_indicies_size == 0);
+        apply_side(side[WHITE], prev.side[WHITE], w_add_delta_indicies.data(), w_add_delta_indicies_size,
+            w_sub_delta_indicies.data(), w_sub_delta_indicies_size);
     }
     else
     {
-        side = prev.side;
-    }
-
-    size_t w_add_idx = 0;
-    size_t w_sub_idx = 0;
-    size_t b_add_idx = 0;
-    size_t b_sub_idx = 0;
-
-    while (w_sub_idx < w_sub_delta_indicies_size && w_add_idx < w_add_delta_indicies_size)
-    {
-        __builtin_prefetch(&net.ft_threat_weight[w_add_delta_indicies[w_add_idx]]);
-        __builtin_prefetch(&net.ft_threat_weight[w_sub_delta_indicies[w_sub_idx]]);
-        NN::add1sub1(side[WHITE], side[WHITE], net.ft_threat_weight[w_add_delta_indicies[w_add_idx++]],
-            net.ft_threat_weight[w_sub_delta_indicies[w_sub_idx++]]);
-    }
-
-    while (w_sub_idx < w_sub_delta_indicies_size)
-    {
-        __builtin_prefetch(&net.ft_threat_weight[w_sub_delta_indicies[w_sub_idx]]);
-        NN::sub1(side[WHITE], net.ft_threat_weight[w_sub_delta_indicies[w_sub_idx++]]);
-    }
-
-    while (w_add_idx < w_add_delta_indicies_size)
-    {
-        __builtin_prefetch(&net.ft_threat_weight[w_add_delta_indicies[w_add_idx]]);
-        NN::add1(side[WHITE], net.ft_threat_weight[w_add_delta_indicies[w_add_idx++]]);
-    }
-
-    while (b_sub_idx < b_sub_delta_indicies_size && b_add_idx < b_add_delta_indicies_size)
-    {
-        __builtin_prefetch(&net.ft_threat_weight[b_add_delta_indicies[b_add_idx]]);
-        __builtin_prefetch(&net.ft_threat_weight[b_sub_delta_indicies[b_sub_idx]]);
-        NN::add1sub1(side[BLACK], side[BLACK], net.ft_threat_weight[b_add_delta_indicies[b_add_idx++]],
-            net.ft_threat_weight[b_sub_delta_indicies[b_sub_idx++]]);
-    }
-
-    while (b_sub_idx < b_sub_delta_indicies_size)
-    {
-        __builtin_prefetch(&net.ft_threat_weight[b_sub_delta_indicies[b_sub_idx]]);
-        NN::sub1(side[BLACK], net.ft_threat_weight[b_sub_delta_indicies[b_sub_idx++]]);
-    }
-
-    while (b_add_idx < b_add_delta_indicies_size)
-    {
-        __builtin_prefetch(&net.ft_threat_weight[b_add_delta_indicies[b_add_idx]]);
-        NN::add1(side[BLACK], net.ft_threat_weight[b_add_delta_indicies[b_add_idx++]]);
+        apply_side(side[WHITE], prev.side[WHITE], w_add_delta_indicies.data(), w_add_delta_indicies_size,
+            w_sub_delta_indicies.data(), w_sub_delta_indicies_size);
+        apply_side(side[BLACK], prev.side[BLACK], b_add_delta_indicies.data(), b_add_delta_indicies_size,
+            b_sub_delta_indicies.data(), b_sub_delta_indicies_size);
     }
 
     acc_is_valid = true;

--- a/src/network/simd/accumulator.hpp
+++ b/src/network/simd/accumulator.hpp
@@ -176,6 +176,58 @@ void add1sub1(std::array<int16_t, SIZE>& a, const std::array<int16_t, SIZE>& b, 
 }
 
 template <size_t SIZE>
+void add_n_sub_n(std::array<int16_t, SIZE>& out, const std::array<int16_t, SIZE>& in, const int8_t* const* adds,
+    size_t n_add, const int8_t* const* subs, size_t n_sub)
+{
+#if defined(SIMD_ENABLED)
+    // Manually unrolled and interleaved x4
+    constexpr auto stride = SIMD::vec_size / sizeof(int16_t);
+    static_assert(SIZE % (stride * 4) == 0);
+    for (size_t i = 0; i < SIZE; i += stride * 4)
+    {
+        auto acc1 = SIMD::load(&in[i]);
+        auto acc2 = SIMD::load(&in[i + stride]);
+        auto acc3 = SIMD::load(&in[i + stride * 2]);
+        auto acc4 = SIMD::load(&in[i + stride * 3]);
+        for (size_t j = 0; j < n_add; j++)
+        {
+            const int8_t* w = adds[j];
+            acc1 = SIMD::add_i16(acc1, SIMD::load_i8_to_i16(&w[i]));
+            acc2 = SIMD::add_i16(acc2, SIMD::load_i8_to_i16(&w[i + stride]));
+            acc3 = SIMD::add_i16(acc3, SIMD::load_i8_to_i16(&w[i + stride * 2]));
+            acc4 = SIMD::add_i16(acc4, SIMD::load_i8_to_i16(&w[i + stride * 3]));
+        }
+        for (size_t j = 0; j < n_sub; j++)
+        {
+            const int8_t* w = subs[j];
+            acc1 = SIMD::sub_i16(acc1, SIMD::load_i8_to_i16(&w[i]));
+            acc2 = SIMD::sub_i16(acc2, SIMD::load_i8_to_i16(&w[i + stride]));
+            acc3 = SIMD::sub_i16(acc3, SIMD::load_i8_to_i16(&w[i + stride * 2]));
+            acc4 = SIMD::sub_i16(acc4, SIMD::load_i8_to_i16(&w[i + stride * 3]));
+        }
+        SIMD::store(&out[i], acc1);
+        SIMD::store(&out[i + stride], acc2);
+        SIMD::store(&out[i + stride * 2], acc3);
+        SIMD::store(&out[i + stride * 3], acc4);
+    }
+#else
+    for (size_t i = 0; i < SIZE; i++)
+    {
+        int16_t v = in[i];
+        for (size_t j = 0; j < n_add; j++)
+        {
+            v += static_cast<int16_t>(adds[j][i]);
+        }
+        for (size_t j = 0; j < n_sub; j++)
+        {
+            v -= static_cast<int16_t>(subs[j][i]);
+        }
+        out[i] = v;
+    }
+#endif
+}
+
+template <size_t SIZE>
 void add1sub2(std::array<int16_t, SIZE>& a, const std::array<int16_t, SIZE>& b, const std::array<int16_t, SIZE>& c,
     const std::array<int16_t, SIZE>& d, const std::array<int16_t, SIZE>& e)
 {


### PR DESCRIPTION
Apply all of a side's threat deltas in one register-blocked read-modify-write pass (NN::add_n_sub_n) instead of a chain of add1/sub1/add1sub1 calls, each of which streamed the whole accumulator through a separate pass. Reading directly from prev.side also removes the separate copy of the unchanged side. int16 add/sub is modular, so the result is order-independent and the bench is unchanged.

AVX2: +2%
AVX512: +3.693 %  +/-  0.876 %

Bench: 6353247