### PR TITLE
Upgrade default network to df9e042a.nn

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ BINARY_DIR := ../bin
 
 # Network configuration
 ifndef EVALFILE
-    NET_HASH := 22f80ada
+    NET_HASH := df9e042a
     EVALFILE := $(BUILD_DIR)/$(NET_HASH).nn
     NO_EVALFILE_SET = true
 endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.5.3";
+constexpr std::string_view version = "16.6.0";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
https://github.com/KierenP/Halogen-Networks/releases/tag/df9e042a
```
Elo   | 12.64 +- 4.86 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 5116 W: 1401 L: 1215 D: 2500
Penta | [14, 517, 1313, 697, 17]
https://chess.grantnet.us/test/40660/
```
```
Elo   | 11.39 +- 4.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 6316 W: 1749 L: 1542 D: 3025
Penta | [38, 693, 1510, 858, 59]
https://chess.grantnet.us/test/40659/
```