### PR TITLE
Make accumulators even lazier

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.6.1";
+constexpr std::string_view version = "16.6.2";
 
 int main(int argc, char* argv[])
 {

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -68,10 +68,20 @@ bool Network::verify(const BoardState& board, const Accumulator& acc)
     return expected == acc;
 }
 
-void Network::store_lazy_updates(
+void Network::mark_lazy_update(
     const BoardState& prev_move_board, const BoardState& post_move_board, Accumulator& acc, Move move)
 {
     acc.acc_is_valid = false;
+    acc.prev_move_board = &prev_move_board;
+    acc.post_move_board = &post_move_board;
+    acc.move = move;
+}
+
+static void compute_lazy_updates(Accumulator& acc)
+{
+    const BoardState& prev_move_board = *acc.prev_move_board;
+    const BoardState& post_move_board = *acc.post_move_board;
+    const Move move = acc.move;
 
     acc.king_bucket.store_lazy_updates(prev_move_board, post_move_board, move);
 
@@ -111,6 +121,8 @@ void Network::apply_lazy_updates(const Accumulator& prev_acc, Accumulator& next_
     {
         return;
     }
+
+    compute_lazy_updates(next_acc);
 
     next_acc.king_bucket.apply_lazy_updates(prev_acc.king_bucket, table, net);
 

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "movegen/move.h"
 #include "network/accumulator/king_bucket.h"
 #include "network/accumulator/threat.h"
 #include "search/score.h"
 
 class BoardState;
-class Move;
 
 namespace NN
 {
@@ -16,6 +16,11 @@ struct Accumulator
 {
     KingBucket::KingBucketAccumulator king_bucket;
     Threats::ThreatAccumulator threats;
+
+    // lazy updates
+    const BoardState* prev_move_board = nullptr;
+    const BoardState* post_move_board = nullptr;
+    Move move = {};
 
     bool operator==(const Accumulator& rhs) const
     {
@@ -42,7 +47,7 @@ public:
     // does a full from scratch recalculation
     static Score slow_eval(const BoardState& board);
 
-    void store_lazy_updates(
+    void mark_lazy_update(
         const BoardState& prev_move_board, const BoardState& post_move_board, Accumulator& acc, Move move);
 
     void apply_lazy_updates(const Accumulator& prev_acc, Accumulator& next_acc);

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -1028,7 +1028,7 @@ Score search(GameState& position, SearchStackState* ss, NN::Accumulator* acc, Se
                        .table[position.board().stm][enum_to<PieceType>(ss->moved_piece)][move.to()];
             position.apply_move(move);
             shared.transposition_table.prefetch(Zobrist::get_fifty_move_adj_key(position.board()));
-            local.net.store_lazy_updates(position.prev_board(), position.board(), *(acc + 1), move);
+            local.net.mark_lazy_update(position.prev_board(), position.board(), *(acc + 1), move);
 
             // verify the move looks good before doing a probcut search (idea from Ethereal)
             auto value = -qsearch<SearchType::ZW>(
@@ -1146,7 +1146,7 @@ Score search(GameState& position, SearchStackState* ss, NN::Accumulator* acc, Se
         position.apply_move(move);
         shared.transposition_table.prefetch(
             Zobrist::get_fifty_move_adj_key(position.board())); // load the transposition into l1 cache. ~5% speedup
-        local.net.store_lazy_updates(position.prev_board(), position.board(), *(acc + 1), move);
+        local.net.mark_lazy_update(position.prev_board(), position.board(), *(acc + 1), move);
 
         // Step 19: Late move reductions
         int r = late_move_reduction<pv_node>(depth, seen_moves, history, cut_node, improving, is_loud_move);
@@ -1364,7 +1364,7 @@ Score qsearch(GameState& position, SearchStackState* ss, NN::Accumulator* acc, S
                                            .table[position.board().stm][enum_to<PieceType>(ss->moved_piece)][move.to()];
         position.apply_move(move);
         shared.transposition_table.prefetch(Zobrist::get_fifty_move_adj_key(position.board()));
-        local.net.store_lazy_updates(position.prev_board(), position.board(), *(acc + 1), move);
+        local.net.mark_lazy_update(position.prev_board(), position.board(), *(acc + 1), move);
         auto search_score = -qsearch<search_type>(position, ss + 1, acc + 1, local, shared, -beta, -alpha);
         position.revert_move();
 


### PR DESCRIPTION
store_lazy_updates ran eagerly at every make_move, computing king-bucket and threat deltas even for subtrees cut off before any eval. Replace it with mark_lazy_update, which only records the move and the two board states; the deltas are now computed lazily in apply_lazy_updates (via compute_lazy_updates), the first time the accumulator is actually needed. Subtrees cut off before an eval never pay for the delta computation.

AVX2: +0.24%
AVX512VNNI: +0.934 %  +/-  0.269 %

Bench: 5409018