### PR TITLE
Drop dead accumulator resets in king-bucket store_lazy_updates

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.6.3";
+constexpr std::string_view version = "16.6.4";
 
 int main(int argc, char* argv[])
 {

--- a/src/network/accumulator/king_bucket.cpp
+++ b/src/network/accumulator/king_bucket.cpp
@@ -135,7 +135,7 @@ void KingBucketAccumulator::store_lazy_updates(
     black_requires_recalculation = false;
     // n_adds/n_subs and the adds/subs entries they index are fully written by the branches below on
     // every path, and `board` is read only on a recalculation (where it is set to post_move_board), so
-    // none of them need clearing here. Clearing `board` in particular was a 256-byte memset every move.
+    // none of them need clearing here.
 
     auto stm = prev_move_board.stm;
     auto from_sq = move.from();

--- a/src/network/accumulator/king_bucket.cpp
+++ b/src/network/accumulator/king_bucket.cpp
@@ -133,11 +133,9 @@ void KingBucketAccumulator::store_lazy_updates(
     acc_is_valid = false;
     white_requires_recalculation = false;
     black_requires_recalculation = false;
-    adds = {};
-    n_adds = 0;
-    subs = {};
-    n_subs = 0;
-    board = {};
+    // n_adds/n_subs and the adds/subs entries they index are fully written by the branches below on
+    // every path, and `board` is read only on a recalculation (where it is set to post_move_board), so
+    // none of them need clearing here. Clearing `board` in particular was a 256-byte memset every move.
 
     auto stm = prev_move_board.stm;
     auto from_sq = move.from();


### PR DESCRIPTION
store_lazy_updates cleared adds/subs/n_adds/n_subs/board at entry before recomputing the deltas. Every one of those was a dead store:

- The exhaustive move-kind branch chain (castle/promo/capture/quiet) fully writes n_adds, n_subs, and every adds/subs entry it uses on all paths, and apply_lazy_updates only ever reads adds/subs up to n_adds/ n_subs, so the array and counter resets were never observed.
- board is read only on a recalculation (KingBucketAccumulator:: apply_lazy_updates, and threats via Network::apply_lazy_updates), and every recalc path assigns board = post_move_board a few lines below. The threat-recalc condition (king crosses the FILE_D mirror) is a strict subset of the king-bucket recalc condition, so board is always valid when read. board = {} in particular was a 256-byte memset on every move that the compiler can't eliminate, since the accumulator persists across the search stack and board escapes by reference.

Remove the reset block. Bit-exact (same deltas, same order), no eval or search behaviour change, not specific to any uarch.

AVX2: +1.47% +/- 0.23%
AVX512: +0.581 %  +/-  0.253 %

Bench: 5409018