### PR TITLE
Prefetch TT entry in null move pruning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.7.0";
+constexpr std::string_view version = "16.7.1";
 
 int main(int argc, char* argv[])
 {

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -497,6 +497,7 @@ std::optional<Score> null_move_pruning(GameState& position, SearchStackState* ss
     ss->cont_hist_subtable = nullptr;
     ss->cont_corr_hist_subtable = nullptr;
     position.apply_null_move();
+    shared.transposition_table.prefetch(Zobrist::get_fifty_move_adj_key(position.board()));
     auto null_move_score
         = -search<SearchType::ZW>(position, ss + 1, acc, local, shared, depth - reduction - 1, -beta, -beta + 1, false);
     position.revert_null_move();


### PR DESCRIPTION
The main move loop, probcut, and qsearch all prefetch the TT entry for the child position immediately after apply_move, but null_move_pruning did not. Add the same prefetch after apply_null_move.

AVX2: +0.12% +/- 0.19% (n=100, marginal)

Bench: 7157470