### PR TITLE
Prefetch TT entry before apply_move using precomputed key

### DIFF
--- a/src/chessboard/board_state.cpp
+++ b/src/chessboard/board_state.cpp
@@ -314,6 +314,10 @@ void BoardState::apply_move(Move move)
 {
     // std::cout << *this << std::endl;
 
+#ifndef NDEBUG
+    const auto expected_key_after = Zobrist::get_fifty_move_adj_key_after(*this, move);
+#endif
+
     key ^= Zobrist::stm();
 
     // undo the previous ep square
@@ -644,6 +648,7 @@ void BoardState::apply_move(Move move)
     assert(pawn_key == Zobrist::pawn_key(*this));
     assert(non_pawn_key[WHITE] == Zobrist::non_pawn_key(*this, WHITE));
     assert(non_pawn_key[BLACK] == Zobrist::non_pawn_key(*this, BLACK));
+    assert(expected_key_after == Zobrist::get_fifty_move_adj_key(*this));
     update_lesser_threats();
     update_checkers();
     update_pinned();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.7.0";
+constexpr std::string_view version = "16.7.1";
 
 int main(int argc, char* argv[])
 {

--- a/src/movegen/movegen.cpp
+++ b/src/movegen/movegen.cpp
@@ -1059,7 +1059,12 @@ bool move_puts_self_in_check(const BoardState& board, const Move& move)
 
 bool ep_is_legal(const BoardState& board, const Move& move)
 {
-    if (board.stm == WHITE)
+    return ep_is_legal(board, move, board.stm);
+}
+
+bool ep_is_legal(const BoardState& board, const Move& move, Side capturer)
+{
+    if (capturer == WHITE)
     {
         return ep_is_legal<WHITE>(board, move);
     }

--- a/src/movegen/movegen.h
+++ b/src/movegen/movegen.h
@@ -5,6 +5,7 @@
 #include "bitboard/define.h"
 
 enum PieceType : int8_t;
+enum Side : int8_t;
 enum Square : int8_t;
 
 class BoardState;
@@ -19,6 +20,7 @@ void quiet_moves(const BoardState& board, T& moves);
 
 bool is_legal(const BoardState& board, const Move& move);
 bool ep_is_legal(const BoardState& board, const Move& move);
+bool ep_is_legal(const BoardState& board, const Move& move, Side capturer);
 
 // Returns the attack bitboard for a piece of piecetype on square sq
 template <PieceType pieceType>

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -1019,6 +1019,7 @@ Score search(GameState& position, SearchStackState* ss, NN::Accumulator* acc, Se
                 continue;
             }
 
+            shared.transposition_table.prefetch(Zobrist::get_fifty_move_adj_key_after(position.board(), move));
             ss->move = move;
             ss->moved_piece = position.board().get_square_piece(move.from());
             ss->cont_hist_subtable
@@ -1027,7 +1028,6 @@ Score search(GameState& position, SearchStackState* ss, NN::Accumulator* acc, Se
                 = &local.shared_hist->cont_corr_hist
                        .table[position.board().stm][enum_to<PieceType>(ss->moved_piece)][move.to()];
             position.apply_move(move);
-            shared.transposition_table.prefetch(Zobrist::get_fifty_move_adj_key(position.board()));
             local.net.mark_lazy_update(position.prev_board(), position.board(), *(acc + 1), move);
 
             // verify the move looks good before doing a probcut search (idea from Ethereal)
@@ -1137,6 +1137,8 @@ Score search(GameState& position, SearchStackState* ss, NN::Accumulator* acc, Se
             }
         }
 
+        // Precalculate the next Zobrist key to prefetch TT entry as early as possible
+        shared.transposition_table.prefetch(Zobrist::get_fifty_move_adj_key_after(position.board(), move));
         ss->move = move;
         ss->moved_piece = position.board().get_square_piece(move.from());
         ss->cont_hist_subtable
@@ -1144,8 +1146,6 @@ Score search(GameState& position, SearchStackState* ss, NN::Accumulator* acc, Se
         ss->cont_corr_hist_subtable = &local.shared_hist->cont_corr_hist
                                            .table[position.board().stm][enum_to<PieceType>(ss->moved_piece)][move.to()];
         position.apply_move(move);
-        shared.transposition_table.prefetch(
-            Zobrist::get_fifty_move_adj_key(position.board())); // load the transposition into l1 cache. ~5% speedup
         local.net.mark_lazy_update(position.prev_board(), position.board(), *(acc + 1), move);
 
         // Step 19: Late move reductions
@@ -1356,6 +1356,7 @@ Score qsearch(GameState& position, SearchStackState* ss, NN::Accumulator* acc, S
 
         seen_moves++;
 
+        shared.transposition_table.prefetch(Zobrist::get_fifty_move_adj_key_after(position.board(), move));
         ss->move = move;
         ss->moved_piece = position.board().get_square_piece(move.from());
         ss->cont_hist_subtable
@@ -1363,7 +1364,6 @@ Score qsearch(GameState& position, SearchStackState* ss, NN::Accumulator* acc, S
         ss->cont_corr_hist_subtable = &local.shared_hist->cont_corr_hist
                                            .table[position.board().stm][enum_to<PieceType>(ss->moved_piece)][move.to()];
         position.apply_move(move);
-        shared.transposition_table.prefetch(Zobrist::get_fifty_move_adj_key(position.board()));
         local.net.mark_lazy_update(position.prev_board(), position.board(), *(acc + 1), move);
         auto search_score = -qsearch<search_type>(position, ss + 1, acc + 1, local, shared, -beta, -alpha);
         position.revert_move();

--- a/src/search/zobrist.cpp
+++ b/src/search/zobrist.cpp
@@ -3,6 +3,8 @@
 #include "bitboard/define.h"
 #include "bitboard/enum.h"
 #include "chessboard/board_state.h"
+#include "movegen/move.h"
+#include "movegen/movegen.h"
 #include "utility/splitmix64.h"
 
 #include <array>
@@ -163,6 +165,145 @@ uint64_t get_fifty_move_adj_key(const BoardState& board)
 {
     assert(0 <= board.fifty_move_count && board.fifty_move_count <= 100);
     return board.key ^ fifty_move_hash[board.fifty_move_count];
+}
+
+// This must mirror the incremental key updates in BoardState::apply_move and BoardState::update_castle_rights, and is
+// verified against them by an assert at the end of apply_move.
+uint64_t get_fifty_move_adj_key_after(const BoardState& board, Move move)
+{
+    uint64_t key = board.key ^ stm();
+
+    // undo the previous ep square
+    if (board.en_passant <= SQ_H8)
+    {
+        key ^= en_passant(enum_to<File>(board.en_passant));
+    }
+
+    // castle rights: check for the king or rook moving, or a rook being captured
+    uint64_t castle_squares = board.castle_squares;
+
+    if (move.from() == board.get_king_sq(WHITE))
+    {
+        uint64_t white_castle = castle_squares & RankBB[RANK_1];
+
+        while (white_castle)
+        {
+            key ^= castle(lsbpop(white_castle));
+        }
+
+        castle_squares &= ~(RankBB[RANK_1]);
+    }
+
+    if (move.from() == board.get_king_sq(BLACK))
+    {
+        uint64_t black_castle = castle_squares & RankBB[RANK_8];
+
+        while (black_castle)
+        {
+            key ^= castle(lsbpop(black_castle));
+        }
+
+        castle_squares &= ~(RankBB[RANK_8]);
+    }
+
+    if (SquareBB[move.to()] & castle_squares)
+    {
+        key ^= castle(move.to());
+    }
+
+    if (SquareBB[move.from()] & castle_squares)
+    {
+        key ^= castle(move.from());
+    }
+
+    switch (move.flag())
+    {
+    case QUIET:
+    {
+        const auto piece = board.get_square_piece(move.from());
+        key ^= piece_square(piece, move.from());
+        key ^= piece_square(piece, move.to());
+        break;
+    }
+    case PAWN_DOUBLE_MOVE:
+    {
+        const auto piece = get_piece(PAWN, board.stm);
+        key ^= piece_square(piece, move.from());
+        key ^= piece_square(piece, move.to());
+
+        // the new ep square only enters the key if the opponent has a legal ep capture
+        Square ep_sq = static_cast<Square>((move.to() + move.from()) / 2);
+        uint64_t potential_attackers = PawnAttacks[board.stm][ep_sq] & board.get_pieces_bb(PAWN, !board.stm);
+
+        while (potential_attackers)
+        {
+            if (ep_is_legal(board, Move(lsbpop(potential_attackers), ep_sq, EN_PASSANT), !board.stm))
+            {
+                key ^= en_passant(enum_to<File>(ep_sq));
+                break;
+            }
+        }
+
+        break;
+    }
+    case A_SIDE_CASTLE:
+    {
+        Square king_end = board.stm == WHITE ? SQ_C1 : SQ_C8;
+        Square rook_end = board.stm == WHITE ? SQ_D1 : SQ_D8;
+        key ^= piece_square(get_piece(KING, board.stm), move.from());
+        key ^= piece_square(get_piece(KING, board.stm), king_end);
+        key ^= piece_square(get_piece(ROOK, board.stm), move.to());
+        key ^= piece_square(get_piece(ROOK, board.stm), rook_end);
+        break;
+    }
+    case H_SIDE_CASTLE:
+    {
+        Square king_end = board.stm == WHITE ? SQ_G1 : SQ_G8;
+        Square rook_end = board.stm == WHITE ? SQ_F1 : SQ_F8;
+        key ^= piece_square(get_piece(KING, board.stm), move.from());
+        key ^= piece_square(get_piece(KING, board.stm), king_end);
+        key ^= piece_square(get_piece(ROOK, board.stm), move.to());
+        key ^= piece_square(get_piece(ROOK, board.stm), rook_end);
+        break;
+    }
+    case CAPTURE:
+    {
+        const auto piece = board.get_square_piece(move.from());
+        key ^= piece_square(piece, move.from());
+        key ^= piece_square(piece, move.to());
+        key ^= piece_square(board.get_square_piece(move.to()), move.to());
+        break;
+    }
+    case EN_PASSANT:
+    {
+        const auto ep_cap_sq = get_square(enum_to<File>(move.to()), enum_to<Rank>(move.from()));
+        const auto piece = get_piece(PAWN, board.stm);
+        key ^= piece_square(get_piece(PAWN, !board.stm), ep_cap_sq);
+        key ^= piece_square(piece, move.from());
+        key ^= piece_square(piece, move.to());
+        break;
+    }
+    default:
+    {
+        assert(move.is_promotion());
+        static_assert(BISHOP_PROMOTION - KNIGHT_PROMOTION == BISHOP - KNIGHT);
+        static_assert(QUEEN_PROMOTION_CAPTURE - KNIGHT_PROMOTION_CAPTURE == QUEEN - KNIGHT);
+        const auto promo_type = static_cast<PieceType>(KNIGHT + ((move.flag() - KNIGHT_PROMOTION) & 3));
+        key ^= piece_square(get_piece(PAWN, board.stm), move.from());
+        key ^= piece_square(get_piece(promo_type, board.stm), move.to());
+        if (move.is_capture())
+        {
+            key ^= piece_square(board.get_square_piece(move.to()), move.to());
+        }
+        break;
+    }
+    }
+
+    const bool resets_fifty_move
+        = move.is_capture() || move.is_promotion() || board.get_square_piece(move.from()) == get_piece(PAWN, board.stm);
+    const auto new_fifty_move = resets_fifty_move ? 0 : board.fifty_move_count + 1;
+    assert(0 <= new_fifty_move && new_fifty_move <= 100);
+    return key ^ fifty_move_hash[new_fifty_move];
 }
 
 } // namespace Zobrist

--- a/src/search/zobrist.h
+++ b/src/search/zobrist.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 class BoardState;
+class Move;
 enum File : int8_t;
 enum Piece : int8_t;
 enum Side : int8_t;
@@ -20,4 +21,8 @@ uint64_t pawn_key(const BoardState& board);
 uint64_t non_pawn_key(const BoardState& board, Side side);
 
 uint64_t get_fifty_move_adj_key(const BoardState& board);
+
+// The fifty move adjusted key of the position that will result from playing 'move' on 'board', without applying the
+// move. Used to prefetch the TT entry for a child node before apply_move, giving the prefetch more time to complete.
+uint64_t get_fifty_move_adj_key_after(const BoardState& board, Move move);
 }


### PR DESCRIPTION
Zobrist::get_fifty_move_adj_key_after computes the fifty move adjusted key of the child position directly from (board, move), mirroring the incremental key updates in apply_move. This lets the TT prefetch in the main move loop, probcut, and qsearch issue before apply_move instead of after it, giving the prefetch the full duration of apply_move (copy, key updates, threat/checkers/pinned recompute) to complete before the child node probes the TT. A debug assert at the end of apply_move verifies the precomputed key matches the real one on every move.

AVX2: +2.10% +/- 0.19%
AVX512: +3.826 %  +/-  0.734 %

```
Elo   | 6.41 +- 3.39 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 3.00]
Games | N: 11928 W: 3316 L: 3096 D: 5516
Penta | [100, 1244, 3063, 1450, 107]
https://chess.grantnet.us/test/40668/
```

Bench: 7157470