### PR TITLE
Vectorize move-order scan across all SIMD architectures

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.7.2";
+constexpr std::string_view version = "16.7.3";
 
 int main(int argc, char* argv[])
 {

--- a/src/search/staged_movegen.cpp
+++ b/src/search/staged_movegen.cpp
@@ -7,6 +7,7 @@
 #include "search/data.h"
 #include "search/score.h"
 #include "search/static_exchange_evaluation.h"
+#include "simd/define.hpp"
 #include "spsa/tuneable.h"
 
 #include "simd/intrinsics.hpp"

--- a/src/search/staged_movegen.cpp
+++ b/src/search/staged_movegen.cpp
@@ -9,8 +9,14 @@
 #include "search/static_exchange_evaluation.h"
 #include "spsa/tuneable.h"
 
+#include "simd/intrinsics.hpp"
+#include "simd/utility.hpp"
+
 #include <algorithm>
+#include <array>
+#include <bit>
 #include <cstddef>
+#include <cstdint>
 
 StagedMoveGenerator::StagedMoveGenerator(
     const GameState& Position, const SearchStackState* SS, SearchLocalState& Local, Move tt_move, bool good_loud_only_)
@@ -32,12 +38,86 @@ StagedMoveGenerator StagedMoveGenerator::probcut(const GameState& position, cons
     return gen;
 }
 
+// Equivalent to std::max_element: returns an iterator to the first element with the maximum score. The scan loop in
+// selection_sort dominates move ordering cost, so we vectorize it: pass 1 finds the maximum score, pass 2 finds the
+// first element equal to it. Ties resolve to the first occurrence, so the result is identical to std::max_element.
+#if defined(SIMD_ENABLED)
+ExtendedMoveList::iterator first_max_element(ExtendedMoveList::iterator begin, ExtendedMoveList::iterator end)
+{
+    static_assert(sizeof(ExtendedMove) == 8);
+    static_assert(offsetof(ExtendedMove, score) == 4);
+
+    constexpr size_t lanes = SIMD::vec_size / sizeof(int32_t); // int32 lanes per vector
+    constexpr size_t entries = SIMD::vec_size / sizeof(ExtendedMove); // ExtendedMove entries per vector
+    constexpr uint32_t score_lane_mask = 0xAAAAAAAAu >> (32 - lanes); // odd int32 lanes hold the scores
+
+    const auto n = static_cast<size_t>(end - begin);
+    if (n < entries)
+    {
+        return std::max_element(begin, end);
+    }
+
+    // Each vector load covers `entries` ExtendedMoves; scores sit in the odd int32 lanes. Blending INT32_MIN over the
+    // even (move + padding) lanes stops them ever winning a max, so we can reduce over whole loads.
+    alignas(64) static constexpr auto score_lanes = []
+    {
+        std::array<int32_t, lanes> p {};
+        for (size_t i = 0; i < lanes; i++)
+        {
+            p[i] = (i % 2 == 1) ? -1 : 0;
+        }
+        return p;
+    }();
+
+    const auto floor = SIMD::set_i32(INT32_MIN);
+    const auto score_mask = SIMD::load(score_lanes.data());
+
+    auto vmax = floor;
+    size_t i = 0;
+    for (; i + entries <= n; i += entries)
+    {
+        const auto v = SIMD::loadu(reinterpret_cast<const int32_t*>(&*(begin + i)));
+        vmax = SIMD::max_i32(vmax, SIMD::blendv_i32(floor, v, score_mask));
+    }
+
+    int32_t max_score = SIMD::hmax_i32(vmax);
+    for (auto it = begin + i; it != end; ++it)
+    {
+        max_score = std::max(max_score, it->score);
+    }
+
+    const auto target = SIMD::set_i32(max_score);
+    for (i = 0; i + entries <= n; i += entries)
+    {
+        const auto v = SIMD::loadu(reinterpret_cast<const int32_t*>(&*(begin + i)));
+        const uint32_t mask = SIMD::cmpeq_i32_mask(v, target) & score_lane_mask;
+        if (mask != 0)
+        {
+            return begin + i + (std::countr_zero(mask) >> 1);
+        }
+    }
+
+    for (auto it = begin + i;; ++it)
+    {
+        if (it->score == max_score)
+        {
+            return it;
+        }
+    }
+}
+#else
+ExtendedMoveList::iterator first_max_element(ExtendedMoveList::iterator begin, ExtendedMoveList::iterator end)
+{
+    return std::max_element(begin, end);
+}
+#endif
+
 void selection_sort(
     ExtendedMoveList::iterator begin, ExtendedMoveList::iterator sort_end, ExtendedMoveList::iterator end)
 {
     for (auto it = begin; it != sort_end; ++it)
     {
-        std::iter_swap(it, std::max_element(it, end));
+        std::iter_swap(it, first_max_element(it, end));
     }
 }
 

--- a/src/simd/intrinsics.hpp
+++ b/src/simd/intrinsics.hpp
@@ -55,6 +55,46 @@ inline vec_type_t<T> load(const T* ptr)
 }
 
 template <typename T>
+inline vec_type_t<T> loadu(const T* ptr)
+{
+    if constexpr (std::is_integral_v<T>)
+    {
+#if defined(USE_AVX512)
+        return _mm512_loadu_si512(ptr);
+#elif defined(USE_AVX2)
+        return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
+#elif defined(USE_SSE4)
+        return _mm_loadu_si128(reinterpret_cast<const __m128i*>(ptr));
+#elif defined(USE_NEON)
+        if constexpr (std::is_same_v<T, int8_t>)
+            return vld1q_s8(ptr);
+        else if constexpr (std::is_same_v<T, uint8_t>)
+            return vld1q_u8(ptr);
+        else if constexpr (std::is_same_v<T, int16_t>)
+            return vld1q_s16(ptr);
+        else if constexpr (std::is_same_v<T, int32_t>)
+            return vld1q_s32(ptr);
+#endif
+    }
+    else if constexpr (std::is_same_v<T, float>)
+    {
+#if defined(USE_AVX512)
+        return _mm512_loadu_ps(ptr);
+#elif defined(USE_AVX2)
+        return _mm256_loadu_ps(ptr);
+#elif defined(USE_SSE4)
+        return _mm_loadu_ps(ptr);
+#elif defined(USE_NEON)
+        return vld1q_f32(ptr);
+#endif
+    }
+    else
+    {
+        static_assert(dependent_false<T>, "Unsupported type for SIMD::loadu");
+    }
+}
+
+template <typename T>
 inline void store(T* ptr, const vec_type_t<T>& v)
 {
     if constexpr (std::is_integral_v<T>)
@@ -351,6 +391,34 @@ inline uint16_t cmpgt_i32_mask(const vecu8& a)
     uint32x4_t a_u32 = vreinterpretq_u32_u8(a);
     uint32x4_t cmp = vcgtq_u32(a_u32, vdupq_n_u32(0));
     return vaddvq_u32(vandq_u32(cmp, cmpgt_i32_bits));
+#endif
+}
+
+// One bit per i32 lane, set where a == b.
+inline uint16_t cmpeq_i32_mask(const veci32& a, const veci32& b)
+{
+#if defined(USE_AVX512)
+    return _mm512_cmpeq_epi32_mask(a, b);
+#elif defined(USE_AVX2)
+    return _mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpeq_epi32(a, b)));
+#elif defined(USE_SSE4)
+    return _mm_movemask_ps(_mm_castsi128_ps(_mm_cmpeq_epi32(a, b)));
+#elif defined(USE_NEON)
+    return vaddvq_u32(vandq_u32(vceqq_s32(a, b), cmpgt_i32_bits));
+#endif
+}
+
+// Per i32 lane, select b where mask has its bits set, else a. mask lanes must be all-ones or all-zero.
+inline veci32 blendv_i32(const veci32& a, const veci32& b, const veci32& mask)
+{
+#if defined(USE_AVX512)
+    return _mm512_ternarylogic_epi32(mask, b, a, 0xCA);
+#elif defined(USE_AVX2)
+    return _mm256_blendv_epi8(a, b, mask);
+#elif defined(USE_SSE4)
+    return _mm_blendv_epi8(a, b, mask);
+#elif defined(USE_NEON)
+    return vbslq_s32(vreinterpretq_u32_s32(mask), b, a);
 #endif
 }
 

--- a/src/simd/utility.hpp
+++ b/src/simd/utility.hpp
@@ -35,6 +35,14 @@ inline float hsum_f32(__m128 x)
     __m128 sum32 = _mm_add_ps(sum64, hi32);
     return _mm_cvtss_f32(sum32);
 }
+inline int32_t hmax_i32(__m128i x)
+{
+    auto hi64 = _mm_shuffle_epi32(x, _MM_SHUFFLE(1, 0, 3, 2));
+    auto max64 = _mm_max_epi32(x, hi64);
+    auto hi32 = _mm_shuffle_epi32(max64, _MM_SHUFFLE(2, 3, 0, 1));
+    auto max32 = _mm_max_epi32(max64, hi32);
+    return _mm_cvtsi128_si32(max32);
+}
 #endif
 
 #if defined(USE_AVX2)
@@ -42,6 +50,11 @@ inline int32_t hsum_i32(__m256i v)
 {
     auto sum128 = _mm_add_epi32(_mm256_castsi256_si128(v), _mm256_extracti128_si256(v, 1));
     return hsum_i32(sum128);
+}
+inline int32_t hmax_i32(__m256i v)
+{
+    auto max128 = _mm_max_epi32(_mm256_castsi256_si128(v), _mm256_extracti128_si256(v, 1));
+    return hmax_i32(max128);
 }
 inline float hsum_f32(__m256 v)
 {
@@ -55,6 +68,11 @@ inline int32_t hsum_i32(__m512i v)
 {
     __m256i sum256 = _mm256_add_epi32(_mm512_castsi512_si256(v), _mm512_extracti64x4_epi64(v, 1));
     return hsum_i32(sum256);
+}
+inline int32_t hmax_i32(__m512i v)
+{
+    __m256i max256 = _mm256_max_epi32(_mm512_castsi512_si256(v), _mm512_extracti64x4_epi64(v, 1));
+    return hmax_i32(max256);
 }
 
 inline float hsum_f32(__m512 v)
@@ -72,6 +90,10 @@ inline float hsum_f32(float32x4_t v)
     float32x2_t lo64 = vget_low_f32(v);
     float32x2_t sum64 = vadd_f32(lo64, hi64);
     return vget_lane_f32(sum64, 0) + vget_lane_f32(sum64, 1);
+}
+inline int32_t hmax_i32(int32x4_t v)
+{
+    return vmaxvq_s32(v);
 }
 #endif
 


### PR DESCRIPTION
AVX2: +1.98% +/- 0.14% (n=75, native)
AVX512: -2.834 %  +/-  1.581 %

Bench: 7157470