### PR TITLE
Emit bestmove (none) for terminal root positions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.7.2";
+constexpr std::string_view version = "16.7.3";
 
 int main(int argc, char* argv[])
 {

--- a/src/search/thread.cpp
+++ b/src/search/thread.cpp
@@ -1,6 +1,7 @@
 #include "thread.h"
 
 #include "chessboard/game_state.h"
+#include "evaluation/evaluate.h"
 #include "movegen/list.h"
 #include "movegen/move.h"
 #include "movegen/movegen.h"
@@ -275,6 +276,23 @@ SearchInfoData SearchThreadPool::launch_search(const SearchLimits& limits)
     BasicMoveList moves;
     legal_moves(position_.board(), moves);
     multi_pv = std::min<int>(multi_pv, moves.size());
+
+    // Detect a root position that is already terminal, so there is nothing to search: either the
+    // side to move has no legal moves (checkmate / stalemate), or the position is an immediate
+    // draw by repetition, the fifty-move rule, or insufficient material.
+    const auto& board = position_.board();
+    const bool no_legal_moves = moves.empty();
+    const bool immediate_draw
+        = position_.is_repetition(0) || board.fifty_move_count >= 100 || insufficient_material(board);
+    if (no_legal_moves || immediate_draw)
+    {
+        const auto score = (no_legal_moves && board.checkers) ? Score::mated_in(0) : Score::draw();
+        const auto search_result = shared_state.build_search_info(0, 0, score, 1, {}, SearchResultType::EXACT);
+        shared_state.uci_handler.print_search_info(search_result, true, shared_state.chess_960);
+        shared_state.uci_handler.print_bestmove(shared_state.chess_960, std::nullopt);
+        set_previous_search_score(score);
+        return search_result;
+    }
 
     // Probe TB at root
     auto probe = Syzygy::probe_dtz_root(position_);

--- a/src/search/thread.cpp
+++ b/src/search/thread.cpp
@@ -1,5 +1,7 @@
 #include "thread.h"
 
+#include "bitboard/enum.h"
+#include "chessboard/board_state.h"
 #include "chessboard/game_state.h"
 #include "evaluation/evaluate.h"
 #include "movegen/list.h"

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -737,19 +737,23 @@ void UciOutput::print_search_info(const SearchInfoData& data, bool final, bool f
     std::cout << std::endl;
 }
 
-void UciOutput::print_bestmove(bool chess960, Move move)
+void UciOutput::print_bestmove(bool chess960, std::optional<Move> move)
 {
     if (output_level > OutputLevel::None)
     {
         std::lock_guard io { output_mutex };
 
-        if (chess960)
+        if (!move.has_value())
         {
-            std::cout << "bestmove " << format_chess960 { move } << std::endl;
+            std::cout << "bestmove (none)" << std::endl;
+        }
+        else if (chess960)
+        {
+            std::cout << "bestmove " << format_chess960 { *move } << std::endl;
         }
         else
         {
-            std::cout << "bestmove " << move << std::endl;
+            std::cout << "bestmove " << *move << std::endl;
         }
     }
 }

--- a/src/uci/uci.h
+++ b/src/uci/uci.h
@@ -112,7 +112,7 @@ public:
     OutputLevel output_level = OutputLevel::Default;
 
     void print_search_info(const SearchInfoData& data, bool final = false, bool format_960 = false);
-    void print_bestmove(bool chess960, Move move);
+    void print_bestmove(bool chess960, std::optional<Move> move);
     void print_error(const std::string& error_str);
 };
 


### PR DESCRIPTION
Checkmate, stalemate, and immediate draws (repetition, fifty-move, insufficient material) at the root left the PV empty and printed the uninitialised move a1a1. Detect these before searching and report the terminal score with bestmove (none).

Bench: 7157470