### PR TITLE
Apply trailing moves when parsing bench positions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.7.3";
+constexpr std::string_view version = "16.7.4";
 
 int main(int argc, char* argv[])
 {

--- a/src/misc/benchmark.h
+++ b/src/misc/benchmark.h
@@ -61,8 +61,8 @@ const std::array benchMarkPositions = {
     // Mate and stalemate positions
     "6k1/3b3r/1p1p4/p1n2p2/1PPNpP1q/P3Q1p1/1R1RB1P1/5K2 b - - 0 1",
     "r2r1n2/pp2bk2/2p1p2p/3q4/3PN1QP/2P3R1/P4PP1/5RK1 w - - 0 1",
-    //"8/8/8/8/8/6k1/6p1/6K1 w - -", // Halogen doesn't accept positions where the root is a stalemate
-    //"7k/7P/6K1/8/3B4/8/8/8 b - -", // Halogen doesn't accept positions where the root is a checkmate
+    "8/8/8/8/8/6k1/6p1/6K1 w - -",
+    "7k/7P/6K1/8/3B4/8/8/8 b - -",
 
     // Chess 960
     "bbqnnrkr/pppppppp/8/8/8/8/PPPPPPPP/BBQNNRKR w HFhf - 0 1 moves g2g3 d7d5 d2d4 c8h3 c1g5 e8d6 g5e7 f7f6",

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -209,15 +209,33 @@ uint64_t PerftDivide(int depth, GameState& position, bool check_legality)
     return nodeCount;
 }
 
+auto Uci::position_command_handler()
+{
+    // clang-format off
+    return OneOf {
+        Consume { "fen", Sequence {
+            TokensUntil {"moves", [this](auto fen){ return handle_position_fen(fen); } },
+            Repeat { NextToken { [this](auto move){ handle_moves(move); } } } } },
+        Consume { "startpos", Sequence {
+            Invoke { [this] { handle_position_startpos(); } },
+            OneOf {
+                Consume { "moves", Repeat { NextToken { [this](auto move){ handle_moves(move); } } } },
+                EndCommand{} } } } };
+    // clang-format on
+}
+
 void Uci::handle_bench(const SearchLimits& limits)
 {
     Timer timer;
 
     uint64_t nodeCount = 0;
+    auto parse_position = position_command_handler();
 
     for (size_t i = 0; i < benchMarkPositions.size(); i++)
     {
-        if (!position.init_from_fen(benchMarkPositions[i]))
+        std::string command = std::string("fen ") + benchMarkPositions[i];
+        std::string_view command_view = command;
+        if (!parse_position(command_view))
         {
             std::lock_guard io { output_mutex };
             std::cout << "BAD FEN!" << std::endl;
@@ -589,15 +607,7 @@ void Uci::process_input(std::string_view command)
         Consume { "uci", Invoke { [this]{ handle_uci(); } } },
         Consume { "ucinewgame", Invoke { [this]{ handle_ucinewgame(); } } },
         Consume { "isready", Invoke { [this]{ handle_isready(); } } },
-        Consume { "position", OneOf {
-            Consume { "fen", Sequence {
-                TokensUntil {"moves", [this](auto fen){ return handle_position_fen(fen); } },
-                Repeat { NextToken { [this](auto move){ handle_moves(move); } } } } },
-            Consume { "startpos", Sequence {
-                Invoke { [this] { handle_position_startpos(); } },
-                OneOf {
-                    Consume { "moves", Repeat { NextToken { [this](auto move){ handle_moves(move); } } } },
-                    EndCommand{} } } } } },
+        Consume { "position", position_command_handler() },
         Consume { "go", Sequence {
             WithContext { go_ctx{}, Sequence {
                 search_limits_handler_factory(),

--- a/src/uci/uci.h
+++ b/src/uci/uci.h
@@ -103,6 +103,7 @@ private:
     bool finished_startup = false;
 
     auto options_handler();
+    auto position_command_handler();
 };
 
 // A handler that gets passed to the search for it to print info including bestmove


### PR DESCRIPTION
The bench suite fed each position straight to GameState::init_from_fen, which ignores any trailing "moves ..." section, so positions 12/13/26 and the chess960 line were searched before their moves were applied. Route bench positions through the same position-command parser the UCI 'position' command uses. Also re-enable the stalemate and checkmate bench positions now that terminal roots are handled.

Bench: 6926560