### PR TITLE
Parse float UCI options with from_chars, not stof

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.7.4";
+constexpr std::string_view version = "16.7.5";
 
 int main(int argc, char* argv[])
 {

--- a/src/uci/parse.h
+++ b/src/uci/parse.h
@@ -3,7 +3,6 @@
 #include "uci/validate_callback.h"
 
 #include <charconv>
-#include <string>
 #include <string_view>
 #include <utility>
 
@@ -78,8 +77,14 @@ struct ToFloat
     template <typename... Ctx>
     bool operator()(std::string_view& token, Ctx&&... ctx)
     {
-        // from_chars(float) only supported in GCC 11+
-        float result = std::stof(std::string(token));
+        float result {};
+        auto [ptr, _] = std::from_chars(token.data(), token.end(), result);
+
+        if (ptr != token.end())
+        {
+            return false;
+        }
+
         return invoke_with_optional_validation(callback_, result, std::forward<Ctx>(ctx)...);
     }
 


### PR DESCRIPTION
std::stof throws on malformed input, which under -fno-exceptions calls std::terminate; a bad float option value crashed the engine. Use std::from_chars like ToInt does, failing the parse gracefully instead. Float from_chars is available on all supported toolchains (libstdc++ since GCC 11, libc++ 20).

Bench: 6926560