### PR TITLE
CI: verify clang + libc++ build path

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,6 +21,7 @@ jobs:
           # x86_64 builds
           - { os: ubuntu-22.04, config: { compiler: g++-11, packages: g++-11, profdata: NA } }
           - { os: ubuntu-24.04, config: { compiler: clang++-16, packages: "clang-16 llvm-16", profdata: llvm-profdata-16 } }
+          - { os: ubuntu-24.04, config: { compiler: clang++-17, packages: "clang-17 llvm-17 libc++-17-dev libc++abi-17-dev", profdata: llvm-profdata-17, extra_flags: "-stdlib=libc++" } }
           # arm64 builds
           - { os: ubuntu-22.04-arm, config: { compiler: g++-11, packages: g++-11, profdata: NA } }
 
@@ -38,7 +39,7 @@ jobs:
 
       - name: Create build
         working-directory: src
-        run: make pgo CXX=${{ matrix.config.compiler }} LLVM_PROFDATA=${{ matrix.config.profdata }} EXE=../bin/Halogen -j
+        run: make pgo CXX=${{ matrix.config.compiler }} LLVM_PROFDATA=${{ matrix.config.profdata }} EXTRA_CXXFLAGS="${{ matrix.config.extra_flags }}" EXTRA_LDFLAGS="${{ matrix.config.extra_flags }}" EXE=../bin/Halogen -j
 
       - name: Check bench matches commit message
         run: |

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.7.4";
+constexpr std::string_view version = "16.7.5";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Add a clang-17 + libc++-17 job to ubuntu.yml to explicitly support users of libc++

Bench: 6926560