### PR TITLE
Improve the UCI parsing library

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.7.6";
+constexpr std::string_view version = "16.7.7";
 
 int main(int argc, char* argv[])
 {

--- a/src/uci/parse.h
+++ b/src/uci/parse.h
@@ -3,8 +3,10 @@
 #include "uci/validate_callback.h"
 
 #include <charconv>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <utility>
 
 namespace UCI
@@ -12,45 +14,63 @@ namespace UCI
 
 constexpr inline char uci_delimiter = ' ';
 
-// Returns true if we are at the end of the command
+// A parser consumes some prefix of the command and returns the unconsumed remainder on success, or
+// std::nullopt on failure. Because the input is taken by value, a failed alternative leaves the
+// caller's view untouched, so OneOf can backtrack simply by retrying with the original command.
+//
+// Leaf handlers (the user-supplied lambdas, and the ToInt/ToFloat/ToBool token converters) instead
+// return void or bool via invoke_with_optional_validation; the combinator that owns them adapts
+// that into the parser contract.
+
+// Succeeds only if the whole command has been consumed
 struct EndCommand
 {
     template <typename... Ctx>
-    bool operator()(std::string_view& command, Ctx&&...)
+    constexpr std::optional<std::string_view> operator()(std::string_view command, Ctx&...) const
     {
-        return command.size() == 0;
+        if (command.empty())
+        {
+            return command;
+        }
+
+        return std::nullopt;
     }
 };
 
-// Invokes a callback. Does nothing with the command
+// Invokes a callback. Consumes nothing from the command
 template <typename T>
 struct Invoke
 {
-    Invoke(T&& callback)
+    constexpr Invoke(T&& callback)
         : callback_(std::move(callback))
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view&, Ctx&&... ctx)
+    constexpr std::optional<std::string_view> operator()(std::string_view command, Ctx&... ctx) const
     {
-        return invoke_with_optional_validation(callback_, std::forward<Ctx>(ctx)...);
+        if (!invoke_with_optional_validation(callback_, ctx...))
+        {
+            return std::nullopt;
+        }
+
+        return command;
     }
 
     T callback_;
 };
 
-// Invokes a callback, converting the token to a int
+// Converts a token to an int and passes it to the callback. Used as the leaf of a NextToken
 template <typename T>
 struct ToInt
 {
-    ToInt(T&& callback)
+    constexpr ToInt(T&& callback)
         : callback_(std::move(callback))
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view& token, Ctx&&... ctx)
+    bool operator()(std::string_view token, Ctx&... ctx) const
     {
         int result {};
         auto [ptr, _] = std::from_chars(token.data(), token.end(), result);
@@ -60,51 +80,51 @@ struct ToInt
             return false;
         }
 
-        return invoke_with_optional_validation(callback_, result, std::forward<Ctx>(ctx)...);
+        return invoke_with_optional_validation(callback_, result, ctx...);
     }
 
     T callback_;
 };
 
-// Invokes a callback, converting the token to a float
+// Converts a token to a float and passes it to the callback. Used as the leaf of a NextToken
 template <typename T>
 struct ToFloat
 {
-    ToFloat(T&& callback)
+    constexpr ToFloat(T&& callback)
         : callback_(std::move(callback))
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view& token, Ctx&&... ctx)
+    bool operator()(std::string_view token, Ctx&... ctx) const
     {
         // from_chars(float) only supported in GCC 11+
         float result = std::stof(std::string(token));
-        return invoke_with_optional_validation(callback_, result, std::forward<Ctx>(ctx)...);
+        return invoke_with_optional_validation(callback_, result, ctx...);
     }
 
     T callback_;
 };
 
-// Invokes a callback, converting the token to a boolean
+// Converts a token to a boolean and passes it to the callback. Used as the leaf of a NextToken
 template <typename T>
 struct ToBool
 {
-    ToBool(T&& callback)
+    constexpr ToBool(T&& callback)
         : callback_(std::move(callback))
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view& token, Ctx&&... ctx)
+    bool operator()(std::string_view token, Ctx&... ctx) const
     {
         if (token == "true")
         {
-            return invoke_with_optional_validation(callback_, true, std::forward<Ctx>(ctx)...);
+            return invoke_with_optional_validation(callback_, true, ctx...);
         }
         else if (token == "false")
         {
-            return invoke_with_optional_validation(callback_, false, std::forward<Ctx>(ctx)...);
+            return invoke_with_optional_validation(callback_, false, ctx...);
         }
         else
         {
@@ -115,216 +135,217 @@ struct ToBool
     T callback_;
 };
 
-// Reads the next token and passes to the callback
+// Reads the next token and passes it to the callback, consuming that token
 template <typename T>
 struct NextToken
 {
-    NextToken(T&& callback)
+    constexpr NextToken(T&& callback)
         : callback_(std::move(callback))
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view& command, Ctx&&... ctx)
+    constexpr std::optional<std::string_view> operator()(std::string_view command, Ctx&... ctx) const
     {
         auto pos = command.find(uci_delimiter);
+        auto token = (pos == command.npos) ? command : command.substr(0, pos);
+        auto rest = (pos == command.npos) ? std::string_view {} : command.substr(pos + 1);
 
-        if (pos == command.npos)
+        if (!invoke_with_optional_validation(callback_, token, ctx...))
         {
-            // process all remaining
-            auto token = command;
-            command = "";
-            return invoke_with_optional_validation(callback_, token, std::forward<Ctx>(ctx)...);
+            return std::nullopt;
         }
-        else
-        {
-            // process up to the delimiter, and then update command to be the remaining tokens
-            auto token = command.substr(0, pos);
-            command = command.substr(std::min(command.size(), pos + 1));
-            return invoke_with_optional_validation(callback_, token, std::forward<Ctx>(ctx)...);
-        }
+
+        return rest;
     }
 
     T callback_;
 };
 
-// Reads until the first occurance of the token and passes the substr to the callback
+// Reads until the first occurance of the delimiter and passes the preceding substr to the callback,
+// consuming the substr and the delimiter
 template <typename T>
 struct TokensUntil
 {
-    TokensUntil(std::string_view delimiter, T&& callback)
+    constexpr TokensUntil(std::string_view delimiter, T&& callback)
         : delimiter_(delimiter)
         , callback_(std::move(callback))
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view& command, Ctx&&... ctx)
+    constexpr std::optional<std::string_view> operator()(std::string_view command, Ctx&... ctx) const
     {
         // for a command like 'position fen A B C moves X Y Z' we are trying to consume 'A B C' for example
         auto pos = command.find(delimiter_);
+        auto token = (pos == command.npos) ? command : command.substr(0, std::max(0, (int)pos - 1));
+        auto rest = (pos == command.npos) ? std::string_view {}
+                                          : command.substr(std::min(command.size(), pos + 1 + delimiter_.size()));
 
-        if (pos == command.npos)
+        if (!invoke_with_optional_validation(callback_, token, ctx...))
         {
-            // process all remaining
-            auto token = command;
-            command = "";
-            return invoke_with_optional_validation(callback_, token, std::forward<Ctx>(ctx)...);
+            return std::nullopt;
         }
-        else
-        {
-            auto token = command.substr(0, std::max(0, (int)pos - 1));
-            command = command.substr(std::min(command.size(), pos + 1 + delimiter_.size()));
-            return invoke_with_optional_validation(callback_, token, std::forward<Ctx>(ctx)...);
-        }
+
+        return rest;
     }
 
     std::string_view delimiter_;
     T callback_;
 };
 
-// Consumes a token and passes the remaining command to the handler
+// Consumes a leading token and passes the remaining command to the nested parser
 template <typename T>
 struct Consume
 {
-    Consume(std::string_view token, T&& handler)
+    constexpr Consume(std::string_view token, T&& handler)
         : handler_(std::move(handler))
         , token_(token)
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view& command, Ctx&&... ctx)
+    constexpr std::optional<std::string_view> operator()(std::string_view command, Ctx&... ctx) const
     {
         // try to match the token as the prefix to command. To avoid matching 'uci' when the token is actually
         // 'ucinewgame', we also need to either follow with the delimiter or consume the whole token
         if (command.substr(0, token_.size()) == token_
             && (command.size() == token_.size() || command[token_.size()] == uci_delimiter))
         {
-            command = command.substr(std::min(command.size(), token_.size() + 1));
-            return invoke_with_optional_validation(handler_, command, std::forward<Ctx>(ctx)...);
+            return handler_(command.substr(std::min(command.size(), token_.size() + 1)), ctx...);
         }
-        else
-        {
-            return false;
-        }
+
+        return std::nullopt;
     }
 
     T handler_;
     std::string_view token_;
 };
 
-// Executes a series of handlers in order
+// Executes a series of parsers in order, threading the remainder of each into the next
 template <typename... T>
 struct Sequence
 {
-    Sequence(T&&... handlers)
+    constexpr Sequence(T&&... handlers)
         : handlers_(std::move(handlers)...)
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view& command, Ctx&&... ctx)
+    constexpr std::optional<std::string_view> operator()(std::string_view command, Ctx&... ctx) const
     {
-        return handle<0>(command, std::forward<Ctx>(ctx)...);
+        return handle<0>(command, ctx...);
     }
 
     template <size_t I, typename... Ctx>
-    bool handle(std::string_view& command, Ctx&&... ctx)
+    constexpr std::optional<std::string_view> handle(std::string_view command, Ctx&... ctx) const
     {
         if constexpr (I >= sizeof...(T))
         {
-            return true;
+            return command;
         }
-        else if (!invoke_with_optional_validation(std::get<I>(handlers_), command, std::forward<Ctx>(ctx)...))
+        else if (auto rest = std::get<I>(handlers_)(command, ctx...))
         {
-            return false;
+            return handle<I + 1>(*rest, ctx...);
         }
         else
         {
-            return handle<I + 1>(command, std::forward<Ctx>(ctx)...);
+            return std::nullopt;
         }
     }
 
     std::tuple<T...> handlers_;
 };
 
-// Tries each handler until one returns true
+// Tries each parser against the (unconsumed) command until one succeeds
 template <typename... T>
 struct OneOf
 {
-    OneOf(T&&... handlers)
+    constexpr OneOf(T&&... handlers)
         : handlers_(std::move(handlers)...)
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view& command, Ctx&&... ctx)
+    constexpr std::optional<std::string_view> operator()(std::string_view command, Ctx&... ctx) const
     {
-        return handle<0>(command, std::forward<Ctx>(ctx)...);
+        return handle<0>(command, ctx...);
     }
 
     template <size_t I, typename... Ctx>
-    bool handle(std::string_view& command, Ctx&&... ctx)
+    constexpr std::optional<std::string_view> handle(std::string_view command, Ctx&... ctx) const
     {
         if constexpr (I >= sizeof...(T))
         {
-            return false;
+            return std::nullopt;
         }
-        else if (invoke_with_optional_validation(std::get<I>(handlers_), command, std::forward<Ctx>(ctx)...))
+        // each alternative gets the original command, so a failed branch backtracks for free
+        else if (auto rest = std::get<I>(handlers_)(command, ctx...))
         {
-            return true;
+            return rest;
         }
         else
         {
-            return handle<I + 1>(command, std::forward<Ctx>(ctx)...);
+            return handle<I + 1>(command, ctx...);
         }
     }
 
     std::tuple<T...> handlers_;
 };
 
-// Repeatedly calls the handler until the command is empty
+// Repeatedly applies the parser until the command is empty
 template <typename T>
 struct Repeat
 {
-    Repeat(T&& handler)
+    constexpr Repeat(T&& handler)
         : handler_(std::move(handler))
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view& command, Ctx&&... ctx)
+    constexpr std::optional<std::string_view> operator()(std::string_view command, Ctx&... ctx) const
     {
         while (!command.empty())
         {
-            if (!invoke_with_optional_validation(handler_, command, std::forward<Ctx>(ctx)...))
+            auto rest = handler_(command, ctx...);
+
+            if (!rest)
             {
-                return false;
+                return std::nullopt;
             }
+
+            // Guard against a handler that succeeds without consuming anything, which would loop forever
+            if (rest->size() >= command.size())
+            {
+                return std::nullopt;
+            }
+
+            command = *rest;
         }
 
-        return true;
+        return command;
     }
 
     T handler_;
 };
 
-// Wraps the nested handler in a context, useful for storing state between handlers. with_context can be used recursivly
-// to wrap multiple contexts
+// Wraps the nested parser in a context, useful for storing state between handlers. A fresh copy of
+// the context is made per invocation so the parser can be reused. WithContext can be nested to wrap
+// multiple contexts.
 template <typename new_Ctx, typename T>
 struct WithContext
 {
-    WithContext(new_Ctx&& ctx, T&& handler)
+    constexpr WithContext(new_Ctx&& ctx, T&& handler)
         : context_(std::move(ctx))
         , handler_(std::move(handler))
     {
     }
 
     template <typename... Ctx>
-    bool operator()(std::string_view& command, Ctx&&... ctx)
+    constexpr std::optional<std::string_view> operator()(std::string_view command, Ctx&... ctx) const
     {
-        return invoke_with_optional_validation(handler_, command, std::forward<Ctx>(ctx)..., context_);
+        new_Ctx local = context_;
+        return handler_(command, ctx..., local);
     }
 
     new_Ctx context_;

--- a/src/uci/parse.h
+++ b/src/uci/parse.h
@@ -3,6 +3,7 @@
 #include "uci/validate_callback.h"
 
 #include <charconv>
+#include <cstdlib>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -98,8 +99,17 @@ struct ToFloat
     template <typename... Ctx>
     bool operator()(std::string_view token, Ctx&... ctx) const
     {
-        // from_chars(float) only supported in GCC 11+
-        float result = std::stof(std::string(token));
+        // Not std::stof (throws -> std::terminate under -fno-exceptions) nor std::from_chars (float
+        // needs libc++ 20, too new a floor given macOS ships libc++). strtof is portable and non-throwing.
+        std::string str(token);
+        char* end = nullptr;
+        const float result = std::strtof(str.c_str(), &end);
+
+        if (str.empty() || end != str.c_str() + str.size())
+        {
+            return false;
+        }
+
         return invoke_with_optional_validation(callback_, result, ctx...);
     }
 


### PR DESCRIPTION
Parsers now take the command by value and return std::optional of the unconsumed remainder instead of mutating a string_view& and returning bool. This makes OneOf backtrack for free (each alternative retries the original command), makes EndCommand a simple emptiness check on the returned remainder, and lets Repeat guard against a non-consuming handler looping forever. WithContext now uses a fresh per-invocation context copy. Constructors and operator() are marked const/constexpr as groundwork for a future static constexpr parser (blocked only by the handlers' [this] captures). No functional change.

Bench: 6926560