### PR TITLE
Gate native NEON dotprod on __ARM_FEATURE_DOTPROD

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -144,10 +144,10 @@ ifeq ($(ARCH),native)
     endif
 
     ifneq ($(findstring __ARM_NEON, $(SUPPORTED)),)
-        # Assume if we support NEON, we also support DOTPROD. There's a small range of ARMv8.0-8.1 CPUs without 
-        # DOTPROD, but they are rare. Use ARCH=neon if you need to disable DOTPROD.
         ARCH_DEFINES += -DUSE_NEON
-        ARCH_DEFINES += -DUSE_NEON_DOTPROD
+        ifneq ($(findstring __ARM_FEATURE_DOTPROD, $(SUPPORTED)),)
+            ARCH_DEFINES += -DUSE_NEON_DOTPROD
+        endif
     endif
 endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.7.5";
+constexpr std::string_view version = "16.7.6";
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
On toolchains where -march=native does not enable dotprod (e.g. newer Apple clang), that mismatches codegen and the always_inline vdotq_s32 fails to inline. Only enable the dotprod path when the compiler reports the feature; ARCH=neon-dotprod still forces it.

Bench: 6926560