### PR TITLE
Fix StaticVector reverse iterators

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "uci/uci.h"
 #include "utility/arch.h"
 
-constexpr std::string_view version = "16.7.9";
+constexpr std::string_view version = "16.7.10";
 
 int main(int argc, char* argv[])
 {

--- a/src/utility/static_vector.h
+++ b/src/utility/static_vector.h
@@ -105,32 +105,32 @@ public:
 
     constexpr reverse_iterator rbegin()
     {
-        return end();
+        return reverse_iterator(end());
     }
 
     constexpr const_reverse_iterator rbegin() const
     {
-        return end();
+        return const_reverse_iterator(end());
     }
 
     constexpr const_reverse_iterator crbegin() const
     {
-        return end();
+        return const_reverse_iterator(cend());
     }
 
     constexpr reverse_iterator rend()
     {
-        return begin();
+        return reverse_iterator(begin());
     }
 
     constexpr const_reverse_iterator rend() const
     {
-        return begin();
+        return const_reverse_iterator(begin());
     }
 
     constexpr const_reverse_iterator crend() const
     {
-        return begin();
+        return const_reverse_iterator(cbegin());
     }
 
     // capacity


### PR DESCRIPTION
rbegin/rend/crbegin/crend returned raw iterators where reverse_iterator was expected; std::reverse_iterator's converting constructor is explicit, so any use was a compile error.

Bench: 6926560